### PR TITLE
Update dochowto links

### DIFF
--- a/docs.php
+++ b/docs.php
@@ -106,7 +106,7 @@ foreach ($ACTIVE_ONLINE_LANGUAGES as $langcode => $langname) {
 <ul>
  <li>
   If you are interested in how the documentation is edited and translated,
-  you should read the <a href="http://doc.php.net/php/dochowto/">Documentation HOWTO</a>.
+  you should read the <a href="https://wiki.php.net/doc/howto">Documentation HOWTO</a>.
  </li>
  <li>
   <a href="http://gtk.php.net/docs.php">PHP-GTK related documentation</a>

--- a/error.php
+++ b/error.php
@@ -105,7 +105,7 @@ if (preg_match("!^release_([^\\.]+)(\\.php$|$)!", $URI, $array)) {
 // BC: handle documentation howto moved to the doc.php.net server
 // (redirect to index page)
 if (preg_match("!^manual/howto/!", $URI, $array)) {
-    mirror_redirect("http://doc.php.net/php/dochowto/");
+    mirror_redirect("https://wiki.php.net/doc/howto");
 }
 
 // ============================================================================
@@ -139,8 +139,6 @@ if (preg_match("!^get/([^/]+)$!", $URI, $what)) {
         case "php"           : $URI = "downloads"; break;
         case "docs"          : // intentional
         case "documentation" : $URI = "download-docs"; break;
-        case "dochowto"      : // intentional
-        case "phpdochowto"   : $URI = "getdochowto"; break;
     }
 }
 
@@ -451,8 +449,7 @@ $external_redirects = array(
     "pear"        => "http://pear.php.net/",
     "bugs"        => "http://bugs.php.net/",
     "bugstats"    => "http://bugs.php.net/bugstats.php",
-    "phpdochowto" => "http://doc.php.net/php/dochowto/",
-    "getdochowto" => "http://doc.php.net/php/dochowto/howto.html.tar.gz",
+    "phpdochowto" => "https://wiki.php.net/doc/howto",
     "rev"         => "http://doc.php.net/php/$LANG/revcheck.php",
     "functions.js.txt" => "http://svn.php.net/phpdoc/doc-base/trunk/scripts/quickref",
     "release/5_3_0.php" => "/releases/5_3_0.php", // PHP 5.3.0 release announcement had a typo

--- a/git-php.php
+++ b/git-php.php
@@ -206,11 +206,11 @@ EOT;
  </tr>
  <tr>
   <td class="sub">Reading the PHP source</td>
-  <td><a href="/dochowto">Maintaining the documentation</a></td>
+  <td><a href="https://wiki.php.net/doc/howto">Maintaining the documentation</a></td>
  </tr>
  <tr>
   <td class="sub">Using PHP extensions</td>
-  <td><a href="/dochowto">Translating the documentation</a></td>
+  <td><a href="https://wiki.php.net/doc/howto">Translating the documentation</a></td>
  </tr>
  <tr>
   <td class="sub">Creating experimental PHP extensions</td>
@@ -262,8 +262,8 @@ EOT;
  itself</strong>, not people developing in PHP) subscribe to this list.
  Similarly, if you plan on contributing documentation, you should
  <a href="mailto:phpdoc-subscribe@lists.php.net">subscribe to the
- documentation mailing list</a>, and read the <a href="/dochowto">PHP
- Documentation HOWTO</a>.
+ documentation mailing list</a>, and read the
+ <a href="https://wiki.php.net/doc/howto">PHP Documentation HOWTO</a>.
 </p>
 
 <p>

--- a/license/index.php
+++ b/license/index.php
@@ -65,7 +65,7 @@ For licensing and copyright information on the PHP project materials, please see
     copyright (c) the PHP Documentation Group
    </li>
    <li><a href="http://creativecommons.org/licenses/by/3.0/">Summary</a> in human-readable form</li>
-   <li>Practical Information: <a href="http://doc.php.net/php/dochowto/">Documentation HOWTO</a></li>
+   <li>Practical Information: <a href="https://wiki.php.net/doc/howto">Documentation HOWTO</a></li>
   </ul>
  </li><!-- }}} -->
  <li><!-- {{{ web-lic -->

--- a/manual/help-translate.php
+++ b/manual/help-translate.php
@@ -14,7 +14,7 @@ The PHP Manual has over 30 translations already setup, but due to inactivity man
 
 <h3>How to help translate the PHP Manual</h3>
 <p>
-If you're interested in helping translate a specific language, then please read the translation section of the <a href="http://doc.php.net/php/dochowto/">PHP Documentation HOWTO</a> and contact the appropriate mailing list. Whether or not your language is shown below, you are very welcome to help translate the PHP Manual from English to another language.
+If you're interested in helping translate a specific language, then please read the translation section of the <a href="https://wiki.php.net/doc/howto">PHP Documentation HOWTO</a> and contact the appropriate mailing list. Whether or not your language is shown below, you are very welcome to help translate the PHP Manual from English to another language.
 </p>
 
 <h3>Using outdated translations</h3>


### PR DESCRIPTION
This commit updates dochowto links from doc.php.net to wiki.php.net, as the doc.php.net links are broken (and were becoming dated).
