### PR TITLE
Fixes GPG Keys and md5 styling overflow on mobile layout

### DIFF
--- a/styles/theme-base.css
+++ b/styles/theme-base.css
@@ -2857,6 +2857,9 @@ section.downloads {
     border-top: 2px solid #e3e3e3;
     margin: 0px;
     padding: 0px;
+    overflow: scroll; 
+    width: 100%;
+    margin-top: 15px;
 }
 .download-box {
     margin: 0.66666666666667em 25px 55px;
@@ -3335,7 +3338,14 @@ div.soft-deprecation-notice blockquote.sidebar {
   }
 
   #intro .download-php { margin: 0 !important; }
-}
+  .md5sum {
+    float: right;
+    padding-left: 0;
+    padding-top: 5px;
+    padding-bottom: 5px;
+    padding-right: 0px;
+    word-break: break-all;
+  }
 
 @media (min-width:768px) {
   #intro .download-php h2 {


### PR DESCRIPTION
Fixes the overflowing of the CSS styling on GPG keys on mobile layout and the md5 keys overflowing. See screenshots below of the GPG keys.

Before: 
![screen shot 2013-11-21 at 23 49 29](https://f.cloud.github.com/assets/5316805/1597192/510b06b0-530a-11e3-8947-2f700d71ad11.png)

After: 
![screen shot 2013-11-22 at 00 07 53](https://f.cloud.github.com/assets/5316805/1597195/636edd36-530a-11e3-9106-2ee37b1ba94e.png)
