### PR TITLE
Fix for mirror links to link to mirrors instead of 404

### DIFF
--- a/include/site.inc
+++ b/include/site.inc
@@ -241,14 +241,14 @@ function print_mirror_box($countryname, $countrycode, $mirrors, $file = null, $d
             </div>
             <?php foreach($mirrors as $mirror): ?>
 <?php
-    $url = substr($mirror["url"], strpos($mirror["url"], '//') + 2, -1);
+    list($protocol, $url) = explode('://', trim($mirror["url"], '/'), 2);
     if ($file) {
         $what = $direct_download ? "this" : "a";
         $url = $mirror["url"] . "get/$file/from/$what/mirror";
     }
 ?>
             <div class="entry">
-                <div class="url"><a href="<?php echo $url; ?>" title="<?php echo clean($mirror['url']); ?>"><?php echo clean($mirror['url']); ?></a></div>
+                <div class="url"><a href="<?php echo sprintf('%s://%s', $protocol, $url); ?>" title="<?php echo clean($mirror['url']); ?>"><?php echo clean($mirror['url']); ?></a></div>
                 <div class="provider"><a href="<?php echo $mirror['provider_url']; ?>" title="<?php echo clean($mirror['provider_title']); ?>"><?php echo clean($mirror['provider_title']); ?></a></div>
             </div>
             <?php endforeach; ?>


### PR DESCRIPTION
Minor change to keep track of protocol of mirror and reuse when outputting link URL to force external link instead of relative to path.
