### PR TITLE
Fix duplicated midwest 2014 conference

### DIFF
--- a/archive/archive.xml
+++ b/archive/archive.xml
@@ -10,7 +10,6 @@
     <email>php-webmaster@lists.php.net</email>
   </author>
   <xi:include href="entries/2014-02-05-3.xml"/>
-  <xi:include href="entries/2014-02-05-3.xml"/>
   <xi:include href="entries/2014-02-05-2.xml"/>
   <xi:include href="entries/2014-02-05-1.xml"/>
   <xi:include href="entries/2014-01-23-1.xml"/>


### PR DESCRIPTION
As it was mentioned in the title. Midwest 2014 is duplicated on php.net/conferences/ and this PR fixes it.
