### PR TITLE
Removing List Style from Logo Downloads Page

### DIFF
--- a/download-logos.php
+++ b/download-logos.php
@@ -72,7 +72,7 @@ function random_bgcolor($min, $max)
  browser/operating system don't handle transparent PNG images very well.
 </p>
 
-<div class="center">
+<div class="center logo-list">
 <table border="0" width="90%" cellspacing="2" cellpadding="10" id="logos">
  
  <tr>

--- a/styles/theme-base.css
+++ b/styles/theme-base.css
@@ -1920,5 +1920,13 @@ aside.tips div.inner {
 }
 /* }}} */
 
+/* {{{ Logo Downloads */
+
+.logo-list ul{
+  list-style-type: none;
+}
+
+/* }}} */
+
 
 // vim: set ts=2 sw=2 et:


### PR DESCRIPTION
Disc bullet points are displayed on the logo downloads page. I have added a class to the div and some style to remove the bullet points.
