### PR TITLE
Fixes missing UG-list with unknown country

### DIFF
--- a/ug.php
+++ b/ug.php
@@ -100,8 +100,8 @@ function print_ug_matches($matches) {
 
 $country = isset($_GET["cc"]) ? $_GET["cc"] : $COUNTRY;
 $allcountries = array();
+$matches = get_usergroups_in($country, $allcountries);
 if (isset($COUNTRIES_ALPHA2[$country])) {
-    $matches = get_usergroups_in($country, $allcountries);
     print_cc_header($country);
     print_ug_matches($matches);
 } else {


### PR DESCRIPTION
This change fixes an issue where users without a known IP-address didn't
get to see the list of usergroups
