### PR TITLE
Added section for Stream Service and moved svn

### DIFF
--- a/thanks.php
+++ b/thanks.php
@@ -20,7 +20,7 @@ site_header("Thanks", array("current" => "community"));
 
 <li>
  <a href="http://www.streamservice.nl">Stream Service</a>
- provices svn.php.net, gtk.php.net, people.php.net and europe.rsync.php.net for us.
+ provides svn.php.net, gtk.php.net, people.php.net and europe.rsync.php.net for us.
 </li>
 
 <li>


### PR DESCRIPTION
Moved svn.php.net away from myracloud as it is in reality not hosted by them. Also added section for Stream Service to include what they host (excl. nl1.php.net as it is a normal mirror).
