### PR TITLE
Replaced old link "Documentation HOWTO" on new (doc.php.net/tutorial/)

### DIFF
--- a/docs.php
+++ b/docs.php
@@ -79,7 +79,7 @@ foreach ($ACTIVE_ONLINE_LANGUAGES as $langcode => $langname) {
 <ul class="content-box listed">
  <li>
   If you are interested in how the documentation is edited and translated,
-  you should read the <a href="https://wiki.php.net/doc/howto">Documentation HOWTO</a>.
+  you should read the <a href="http://doc.php.net/tutorial/">Documentation HOWTO</a>.
  </li>
  <li>
   <a href="http://gtk.php.net/docs.php">PHP-GTK related documentation</a>

--- a/error.php
+++ b/error.php
@@ -104,7 +104,7 @@ if (preg_match("!^release_([^\\.]+)(\\.php$|$)!", $URI, $array)) {
 // BC: handle documentation howto moved to the doc.php.net server
 // (redirect to index page)
 if (preg_match("!^manual/howto/!", $URI, $array)) {
-    mirror_redirect("https://wiki.php.net/doc/howto");
+    mirror_redirect("http://doc.php.net/tutorial/");
 }
 
 // ============================================================================

--- a/git-php.php
+++ b/git-php.php
@@ -215,11 +215,11 @@ EOT;
  </tr>
  <tr>
   <td class="sub">Reading the PHP source</td>
-  <td><a href="https://wiki.php.net/doc/howto">Maintaining the documentation</a></td>
+  <td><a href="http://doc.php.net/tutorial/">Maintaining the documentation</a></td>
  </tr>
  <tr>
   <td class="sub">Using PHP extensions</td>
-  <td><a href="https://wiki.php.net/doc/howto">Translating the documentation</a></td>
+  <td><a href="http://doc.php.net/tutorial/">Translating the documentation</a></td>
  </tr>
  <tr>
   <td class="sub">Creating experimental PHP extensions</td>
@@ -273,7 +273,7 @@ EOT;
  Similarly, if you plan on contributing documentation, you should
  <a href="mailto:phpdoc-subscribe@lists.php.net">subscribe to the
  documentation mailing list</a>, and read the
- <a href="https://wiki.php.net/doc/howto">PHP Documentation HOWTO</a>.
+ <a href="http://doc.php.net/tutorial/">PHP Documentation HOWTO</a>.
 </p>
 
 <p>

--- a/license/index.php
+++ b/license/index.php
@@ -65,7 +65,7 @@ site_header("License Information", array("current" => "help"));
   copyright (c) the PHP Documentation Group
  </li>
  <li><a href="http://creativecommons.org/licenses/by/3.0/">Summary</a> in human-readable form</li>
- <li>Practical Information: <a href="https://wiki.php.net/doc/howto">Documentation HOWTO</a></li>
+ <li>Practical Information: <a href="http://doc.php.net/tutorial/">Documentation HOWTO</a></li>
 </ul>
 
 <a name="web-lic"></a>


### PR DESCRIPTION
Although I doubt that you forgot about it, but perhaps
