### PR TITLE
Remove links to snaps.php.net

### DIFF
--- a/downloads.php
+++ b/downloads.php
@@ -25,7 +25,6 @@ $SIDEBAR_DATA = '
 <p class="panel"><a href="download-docs.php">Documentation download</a></p>
 <p class="panel"><a href="download-logos.php">PHP logos</a></p>
 
-<p class="panel"><a href="http://snaps.php.net/">Development Snapshots</a></p>
 <p class="panel"><a href="/git.php">Development sources (git)</a></p>
 <p class="panel"><a href="/releases/">Old archives</a></p>
 ';

--- a/git.php
+++ b/git.php
@@ -21,13 +21,6 @@ $SIDEBAR_DATA = '
  group. You may want <a href="/git-php.php">your own Git account</a>
  to contribute.
 </p>
-
-<h3>Source and binary snapshots</h3>
-<p>
- You may also be interested in a PHP snapshot, see
- <a href="http://snaps.php.net/">snaps.php.net</a>.
- Compiled snapshots for Windows users are also included.
-</p>
 ';
 site_header("Git Access", array("current" => "community"));
 ?>

--- a/sites.php
+++ b/sites.php
@@ -210,14 +210,6 @@ site_header("A Tourist's Guide", array("current" => "help"));
  and the latest news from the project.
 </p>
 
-<h2 id="snaps" class="content-header"><a href="http://snaps.php.net/">snaps.php.net</a>: Daily PHP Snapshots</h2>
-
-<p class="content-box">
- This is your first stop if you're looking for cutting edge development versions
- of PHP which are generated every day from the current stable and current
- development sources.
-</p>
-
 <h2 id="gcov" class="content-header"><a href="http://gcov.php.net/">gcov.php.net</a>: Test and Code Coverage analysis</h2>
 
 <p class="content-box">

--- a/urlhowto.php
+++ b/urlhowto.php
@@ -150,9 +150,6 @@ function a($href) {
 
 <h2>PHP Developer shortcuts</h2>
 <ul>
- <li>Snap downloads: <a href="http://snaps.php.net/?55">http://snaps.php.net/?53</a>
-  (e.g. latest 5.5 snap. Use ?latest for latest master)
- </li>
  <li>Changelog information: <a href="http://php.net/changelog">http://php.net/changelog</a>
   (e.g. latest PHP changelog. php5news = latest PHP 5 NEWS, phptrunknews = latest PHP trunk NEWS)
  </li>


### PR DESCRIPTION
As the development snapshots have been removed in favour of the git sources, this link is no longer required.