### PR TITLE
Add a new /download/filename.ext method that is wget friendly

### DIFF
--- a/error.php
+++ b/error.php
@@ -131,6 +131,26 @@ if (preg_match("!^get/([^/]+)$!", $URI, $what)) {
     }
 }
 
+// Method of downloading files that is wget friendly
+// This method serves requests for /download/filename.ext from THIS mirror
+if (preg_match("|^download/(.+?)$|", $URI, $match)) {
+    $filename = $match[1];
+
+    include $_SERVER['DOCUMENT_ROOT'] . "/include/do-download.inc";
+    $filename = get_actual_download_file($filename);
+
+    if ($filename) {
+        // Found the file, so we do a redirect to the file directly
+        status_header(200);
+        download_file($MYSITE, $filename);
+    } else {
+        // File missing on the server
+        status_header(404);
+        include $_SERVER['DOCUMENT_ROOT'] . "/include/get-download.inc";
+    }
+
+    exit;
+}
 
 // ============================================================================
 // Nice URLs for download files, so wget works completely well with download links

--- a/include/site.inc
+++ b/include/site.inc
@@ -250,9 +250,11 @@ function print_mirror_box($countryname, $countrycode, $mirrors, $file = null, $d
 <?php
     $url = $mirror["url"];
     $urltitle = substr($url, strpos($url, '//') + 2, -1);
-    if ($file) {
-        $what = $direct_download ? "this" : "a";
-        $url = $mirror["url"] . "get/$file/from/$what/mirror";
+
+    if ($file && $direct_download) {
+        $url = $mirror["url"] . "download/$file";
+    } elseif ($file && !$direct_download) {
+        $url = $mirror["url"] . "get/$file/from/a/mirror";
     }
 ?>
             <div class="entry">


### PR DESCRIPTION
This patch addresses https://bugs.php.net/bug.php?id=69292 by creating a new routing method in **error.php** that handles file downloads by serving up files directly using `http://www.mirror.com/download/filename.ext`. This preserves all the original download methods, so existing links will **not** be affected.

This patch also remaps the file download page to give out the new `/download/` style links.

wget downloads will now output the correct filename.
