### PR TITLE
Add sha256 hashes to the download page.

### DIFF
--- a/downloads.php
+++ b/downloads.php
@@ -61,6 +61,7 @@ site_header("Downloads",
           <?php download_link($rel['filename'], $rel['filename']); ?>
           <span class="releasedate"><?php echo date('d M Y', strtotime($rel['date'])); ?></span>
           <span class="md5sum"><?php echo $rel['md5']; ?></span>
+          <span class="sha256"><?php echo $rel['sha256']; ?></span>
           <?php if (isset($rel['note']) && $rel['note']): ?>
             <p>
               <strong>Note:</strong>

--- a/include/version.inc
+++ b/include/version.inc
@@ -7,6 +7,7 @@
  *                 "filename" => "filename.tar.bz2",
  *                 "name"     => "package name",
  *                 "md5"      => "crc32, right?",
+ *                 "sha256"   => "shasum -256",
  *                 "date"     => "this files release date",
  *                 "note"     => "this file was updated 29feb due to broken phar files..",
  *             ),
@@ -26,6 +27,11 @@ $PHP_5_6_MD5     = array(
                        "tar.gz"        => "0167d60fd45891f131f0ccdb51c13cb5",
                        "tar.xz"        => "526a5a7f593de632cd9e8546335de8b7",
 );
+$PHP_5_6_SHA256     = array(
+                       "tar.bz2"       => "0af0045745d61eeb74a3ea744529a2481b27cb689da720e6c0250675043724e4",
+                       "tar.gz"        => "c5b1c75c5671c239473eb611129f33ac432a55a1c341990b70009a2aa3b8dbc3",
+                       "tar.xz"        => "4c417387b88e100ca306adeda8051eb9fad93dae8da983f962dabf91a14b2b7b",
+);
 /* PHP 5.5 Release */
 $PHP_5_5_RC =  false; // Current RC version (e.g., '5.6.7RC1') or false
 $PHP_5_5_RC_DATE = '2 Apr 2015';
@@ -37,6 +43,11 @@ $PHP_5_5_MD5     = array(
                        "tar.gz"        => "f5666659d9279f725f4351866bb73bed",
                        "tar.xz"        => "32e5ab1d77186142474cb65c685659bd",
 );
+$PHP_5_5_SHA256     = array(
+                       "tar.bz2"       => "801b5cf2e0c01b07314d4ac3c8a7c28d524bdd8263ebdd0e33a99008251316a2",
+                       "tar.gz"        => "43e6b83fe8151f8d2062ca4da915312fc92e47789801049231c705a8b29b05bc",
+                       "tar.xz"        => "ffb6235a25043cab71e6445cfc9e8bf16ae80a2835f0373cdd948fcc31eafe57",
+);
 /* PHP 5.4 Release */
 $PHP_5_4_RC = false; // Current RC version (e.g., '5.6.7RC1') or false
 $PHP_5_4_RC_DATE = '4 Sep 2014';
@@ -46,6 +57,10 @@ $PHP_5_4_DATE            = "16 Apr 2015";
 $PHP_5_4_MD5     = array(
                        "tar.bz2"       => "19dafb2b9fc31517cf5c3309fb8a9923",
                        "tar.gz"        => "df24e449e79f06981a4b4162105a9cd4",
+);
+$PHP_5_4_SHA256     = array(
+                       "tar.bz2"       => "4898ffe8ac3ccb2d8cc94f7d76a9ea0414d954f5d4479895ddfccdc2e158a51a",
+                       "tar.gz"        => "663f5d06cd648e81ba4f2d6ad621bb580d83de70240c832dae527c97954da33d",
 );
 
 $RELEASES = array(
@@ -57,18 +72,21 @@ $RELEASES = array(
                     "filename" => "php-$PHP_5_6_VERSION.tar.bz2",
                     "name"     => "PHP $PHP_5_6_VERSION (tar.bz2)",
                     "md5"      => $PHP_5_6_MD5["tar.bz2"],
+                    "sha256"   => $PHP_5_6_SHA256["tar.bz2"],
                     "date"     => $PHP_5_6_DATE,
                 ),
                 array(
                     "filename" => "php-$PHP_5_6_VERSION.tar.gz",
                     "name"     => "PHP $PHP_5_6_VERSION (tar.gz)",
                     "md5"      => $PHP_5_6_MD5["tar.gz"],
+                    "sha256"   => $PHP_5_6_SHA256["tar.gz"],
                     "date"     => $PHP_5_6_DATE,
                 ),
                 array(
                     "filename" => "php-$PHP_5_6_VERSION.tar.xz",
                     "name"     => "PHP $PHP_5_6_VERSION (tar.xz)",
                     "md5"      => $PHP_5_6_MD5["tar.xz"],
+                    "sha256"   => $PHP_5_6_SHA256["tar.xz"],
                     "date"     => $PHP_5_6_DATE,
                 ),
             ),
@@ -80,18 +98,21 @@ $RELEASES = array(
                     "filename" => "php-$PHP_5_5_VERSION.tar.bz2",
                     "name"     => "PHP $PHP_5_5_VERSION (tar.bz2)",
                     "md5"      => $PHP_5_5_MD5["tar.bz2"],
+                    "sha256"   => $PHP_5_5_SHA256["tar.bz2"],
                     "date"     => $PHP_5_5_DATE,
                 ),
                 array(
                     "filename" => "php-$PHP_5_5_VERSION.tar.gz",
                     "name"     => "PHP $PHP_5_5_VERSION (tar.gz)",
                     "md5"      => $PHP_5_5_MD5["tar.gz"],
+                    "sha256"   => $PHP_5_5_SHA256["tar.gz"],
                     "date"     => $PHP_5_5_DATE,
                 ),
                 array(
                     "filename" => "php-$PHP_5_5_VERSION.tar.xz",
                     "name"     => "PHP $PHP_5_5_VERSION (tar.xz)",
                     "md5"      => $PHP_5_5_MD5["tar.xz"],
+                    "sha256"   => $PHP_5_5_SHA256["tar.xz"],
                     "date"     => $PHP_5_5_DATE,
                 ),
             ),
@@ -103,12 +124,14 @@ $RELEASES = array(
                     "filename" => "php-$PHP_5_4_VERSION.tar.bz2",
                     "name"     => "PHP $PHP_5_4_VERSION (tar.bz2)",
                     "md5"      => $PHP_5_4_MD5["tar.bz2"],
+                    "sha256"   => $PHP_5_4_SHA256["tar.bz2"],
                     "date"     => $PHP_5_4_DATE,
                 ),
                 array(
                     "filename" => "php-$PHP_5_4_VERSION.tar.gz",
                     "name"     => "PHP $PHP_5_4_VERSION (tar.gz)",
                     "md5"      => $PHP_5_4_MD5["tar.gz"],
+                    "sha256"   => $PHP_5_4_SHA256["tar.gz"],
                     "date"     => $PHP_5_4_DATE,
                 ),
             ),

--- a/styles/theme-base.css
+++ b/styles/theme-base.css
@@ -1139,12 +1139,16 @@ fieldset {
 .content-header .changelog {
     color:#369;
 }
-.content-box .md5sum {
+.content-box .md5sum, .content-box .sha256 {
     display: block;
     font: normal 0.875rem/1.5rem "Fira Mono", "Source Code Pro", monospace;
 }
 .content-box .md5sum:before {
     content: "md5: ";
+    font-family: "Fira Sans", "Source Sans Pro", Helvetica, Arial, sans-serif;
+}
+.content-box .sha256:before {
+    content: "sha256: ";
     font-family: "Fira Sans", "Source Sans Pro", Helvetica, Arial, sans-serif;
 }
 .content-box .releasedate {


### PR DESCRIPTION
MD5 is broken and should not be used anymore. I have added SHA-256 hashes to the current release info and downloads page.

In the future it would be better to remove the MD5 hashes but for now both can exist on the downloads page.