### PR TITLE
fix blacklisted() to treat $mosquitoes as literals (not regexps)

### DIFF
--- a/include/email-validation.inc
+++ b/include/email-validation.inc
@@ -99,6 +99,6 @@ function blacklisted($email) {
 	'graduatecentral',
     );
     foreach ($mosquitoes as $m) {
-        if (preg_match('/'.$m.'/i',$email)) return true;
+        if (preg_match('/'.preg_quote($m, '/').'/i',$email)) return true;
     }
 }


### PR DESCRIPTION
Currently, the blacklisted email addresses are treated as regular expression, but it appears that they are not written as such. Especially dots (.) in values of the $mosquitoes array might give false positives.

An alternative to this fix would be to properly escape the $mosquitoes. Not sure what's best.