### PR TITLE
Add links to event and cfp

### DIFF
--- a/bin/createNewsEntry
+++ b/bin/createNewsEntry
@@ -97,6 +97,19 @@ if ($conf) {
 		fwrite(STDERR, "I told you I would run it through strtotime()!\n");
 	} while(1);
 	$item->appendChild($dom->createElementNs("http://php.net/ns/news", "finalTeaserDate", date("Y-m-d", $t)));
+
+	do {
+		fwrite(STDOUT, "What's the URL of the conference/cfp-Website? ");
+		$i = trim(fgets(STDIN));
+		$u = filter_var($i, FILTER_VALIDATE_URL);
+		if (false !== $u) {
+			break;
+		}
+
+		fwrite(STDERR, "That doesn't seem to be a valid URL");
+	} while(1);
+	$item->appendChild($dom->createElementNs("http://php.net/ns/news", "website", $u));
+
 } else {
 	$href = $BASE . "/index.php";
 }

--- a/bin/createNewsEntry
+++ b/bin/createNewsEntry
@@ -89,6 +89,34 @@ foreach($cat as $keys) {
 }
 
 $href = $BASE . "/index.php";
+
+if ($cfp) {
+    /* /cfp news item */
+    do {
+        fwrite(STDOUT, "When does the cfp end? (strtotime() compatible syntax): ");
+        $t = strtotime(fgets(STDIN));
+        if ($t) {
+            break;
+        }
+
+        fwrite(STDERR, "I told you I would run it through strtotime()!\n");
+    } while(1);
+    $item->appendChild($dom->createElementNs("http://php.net/ns/news", "finalTeaserDate", date("Y-m-d", $t)));
+    $item->appendChild($dom->createElementNs("http://php.net/ns/news", "cfpEnd", date("Y-m-d", $t)));
+
+    do {
+        fwrite(STDOUT, "What's the URL of the cfp-Website? ");
+        $i = trim(fgets(STDIN));
+        $u = filter_var($i, FILTER_VALIDATE_URL);
+        if (false !== $u) {
+            break;
+        }
+
+        fwrite(STDERR, "That doesn't seem to be a valid URL");
+    } while(1);
+    $item->appendChild($dom->createElementNs("http://php.net/ns/news", "cfpwebsite", $u));
+}
+
 if ($conf) {
 	/* /conferences news item */
 	$href = $BASE . "/conferences/index.php";
@@ -116,33 +144,6 @@ if ($conf) {
 		fwrite(STDERR, "That doesn't seem to be a valid URL");
 	} while(1);
 	$item->appendChild($dom->createElementNs("http://php.net/ns/news", "website", $u));
-}
-
-if ($cfp) {
-    /* /cfp news item */
-    do {
-        fwrite(STDOUT, "When does the cfp end? (strtotime() compatible syntax): ");
-        $t = strtotime(fgets(STDIN));
-        if ($t) {
-            break;
-        }
-
-        fwrite(STDERR, "I told you I would run it through strtotime()!\n");
-    } while(1);
-    $item->appendChild($dom->createElementNs("http://php.net/ns/news", "finalTeaserDate", date("Y-m-d", $t)));
-    $item->appendChild($dom->createElementNs("http://php.net/ns/news", "cfpEnd", date("Y-m-d", $t)));
-
-    do {
-        fwrite(STDOUT, "What's the URL of the cfp-Website? ");
-        $i = trim(fgets(STDIN));
-        $u = filter_var($i, FILTER_VALIDATE_URL);
-        if (false !== $u) {
-            break;
-        }
-
-        fwrite(STDERR, "That doesn't seem to be a valid URL");
-    } while(1);
-    $item->appendChild($dom->createElementNs("http://php.net/ns/news", "cfpwebsite", $u));
 }
 
 foreach($cat as $n) {

--- a/bin/createNewsEntry
+++ b/bin/createNewsEntry
@@ -51,7 +51,8 @@ $categories = array(
 	array("conferences" => "Conference announcement"),
 	array("cfp"         => "Call for Papers"),
 );
-$confs = array(2, 3);
+$confs = array(2);
+$cfps  = array(3);
 
 do {
 	fwrite(STDOUT, "Categories:\n");
@@ -77,18 +78,23 @@ ce($dom, "updated", date(DATE_ATOM), array(), $item);
 
 
 $conf = false;
+$cfp = false;
 foreach($cat as $keys) {
 	if (in_array($keys, $confs)) {
-		$conf = true;
-		break;
+        $conf = true;
 	}
+    if (in_array($keys, $cfps)) {
+        $cfp = true;
+    }
 }
+
+$href = $BASE . "/index.php";
 if ($conf) {
 	/* /conferences news item */
 	$href = $BASE . "/conferences/index.php";
 
 	do {
-		fwrite(STDOUT, "When does the conference start/cfp end? (strtotime() compatible syntax): ");
+		fwrite(STDOUT, "When does the conference start? (strtotime() compatible syntax): ");
 		$t = strtotime(fgets(STDIN));
 		if ($t) {
 			break;
@@ -97,9 +103,10 @@ if ($conf) {
 		fwrite(STDERR, "I told you I would run it through strtotime()!\n");
 	} while(1);
 	$item->appendChild($dom->createElementNs("http://php.net/ns/news", "finalTeaserDate", date("Y-m-d", $t)));
+	$item->appendChild($dom->createElementNs("http://php.net/ns/news", "conferenceStart", date("Y-m-d", $t)));
 
 	do {
-		fwrite(STDOUT, "What's the URL of the conference/cfp-Website? ");
+		fwrite(STDOUT, "What's the URL of the conference? ");
 		$i = trim(fgets(STDIN));
 		$u = filter_var($i, FILTER_VALIDATE_URL);
 		if (false !== $u) {
@@ -109,9 +116,33 @@ if ($conf) {
 		fwrite(STDERR, "That doesn't seem to be a valid URL");
 	} while(1);
 	$item->appendChild($dom->createElementNs("http://php.net/ns/news", "website", $u));
+}
 
-} else {
-	$href = $BASE . "/index.php";
+if ($cfp) {
+    /* /cfp news item */
+    do {
+        fwrite(STDOUT, "When does the cfp end? (strtotime() compatible syntax): ");
+        $t = strtotime(fgets(STDIN));
+        if ($t) {
+            break;
+        }
+
+        fwrite(STDERR, "I told you I would run it through strtotime()!\n");
+    } while(1);
+    $item->appendChild($dom->createElementNs("http://php.net/ns/news", "finalTeaserDate", date("Y-m-d", $t)));
+    $item->appendChild($dom->createElementNs("http://php.net/ns/news", "cfpEnd", date("Y-m-d", $t)));
+
+    do {
+        fwrite(STDOUT, "What's the URL of the cfp-Website? ");
+        $i = trim(fgets(STDIN));
+        $u = filter_var($i, FILTER_VALIDATE_URL);
+        if (false !== $u) {
+            break;
+        }
+
+        fwrite(STDERR, "That doesn't seem to be a valid URL");
+    } while(1);
+    $item->appendChild($dom->createElementNs("http://php.net/ns/news", "cfpwebsite", $u));
 }
 
 foreach($cat as $n) {


### PR DESCRIPTION
Currently when a news-item is created for a conference with a CfP there is no way of telling whether the given date and link refer to the conference or the CfP. To be able to use the information provided here as source for f.i. callingallpapers.com that isn't as nice as it could be.

I therefore altered the script to create a new news-entry slightly to query informations for Conference and CfP separately and write them to the XML-file in separate ways to be able to distinguish between the two.

This adds the following new XML-Elements:
- default:conferenceStart - holds the date the conference starts
- defaul:cfpEnd - holds the date the cfp ends
- default:cfpwebsite - holds the URL to the CFP-site

Along with that there can be now two XML-Tags `default:finalTeaserDate` containing the Conference-Start-Date and the CfP-End-Date respectively. 

If that is a problem ping me and I'll see to a fix.
