### PR TITLE
Remove the link to the EOL versions download page

### DIFF
--- a/supported-versions.php
+++ b/supported-versions.php
@@ -51,9 +51,13 @@ site_header('Supported Versions', array('css' => array('supported-versions.css')
 				?>
 				<tr class="<?php echo $state ?>">
 					<td>
-						<a href="/downloads.php#v<?php echo htmlspecialchars($release['version']) ?>">
+						<?php if ($state == 'eol'): ?>
 							<?php echo htmlspecialchars($branch) ?>
-						</a>
+						<?php else: ?>
+							<a href="/downloads.php#v<?php echo htmlspecialchars($release['version']) ?>">
+								<?php echo htmlspecialchars($branch) ?>
+							</a>
+						<?php endif; ?>
 					</td>
 					<td><?php echo htmlspecialchars($initial->format('j M Y')) ?></td>
 					<td class="collapse-phone"><em><?php echo htmlspecialchars(format_interval($initial, null)) ?></em></td>


### PR DESCRIPTION
Hi,

This PR is just a proposition to remove the link to the download page for EOL versions in the supported versions matrix. Tell me if you think it's a good idea, if not you can close this PR :-)

I personaly think it's important to show people it's not a good idea to download this version and they should consider an other option.

I'm new to this repo so I'm not sure if it's the good way to do it (this kind of condition in HTML).

Thanks,