### PR TITLE
Add ability to to download latest PHP7 stuff using PHP7-LATEST

### DIFF
--- a/error.php
+++ b/error.php
@@ -137,7 +137,10 @@ if (preg_match("!^get/([^/]+)$!", $URI, $what)) {
 if (preg_match("!^get/([^/]+)/from/([^/]+)(/mirror)?$!", $URI, $dlinfo)) {
     
     $df = $dlinfo[1];
-    if(strpos($df, "5-LATEST") !== false) {
+    if(strpos($df, "7-LATEST") !== false) {
+        include_once $_SERVER['DOCUMENT_ROOT'] . "/include/version.inc";
+        $df = str_replace("7-LATEST", $PHP_7_VERSION, $df);
+    } elseif(strpos($df, "5-LATEST") !== false) {
         include_once $_SERVER['DOCUMENT_ROOT'] . "/include/version.inc";
         $df = str_replace("5-LATEST", $PHP_5_VERSION, $df);
     } elseif(strpos($df, "4-LATEST") !== false) {


### PR DESCRIPTION
This was already supported for PHP4-LATEST and PHP5-LATEST as noted in [Bug 70946](https://bugs.php.net/bug.php?id=70946). The PR simply adds the functionality for PHP7-LATEST.