### PR TITLE
Fix bug #71939 (Double escaped search)

### DIFF
--- a/error.php
+++ b/error.php
@@ -544,7 +544,7 @@ if (strpos($URI, "manual/") === 0) {
 $fallback = (myphpnet_urlsearch() === MYPHPNET_URL_MANUAL ? "404manual" : "404quickref");
 mirror_redirect(
     '/search.php?show=' . $fallback . '&lang=' . urlencode($LANG) .
-    '&pattern=' . urlencode(substr($_SERVER['REQUEST_URI'], 1))
+    '&pattern=' . substr($_SERVER['REQUEST_URI'], 1)
 );
 /*
  * vim: set et ts=4 sw=4 ft=php: :


### PR DESCRIPTION
`$_SERVER['REQUEST_URI']` is already escaped, see https://bugs.php.net/bug.php?id=71939.