### PR TITLE
Move Korean translation to $INACTIVE_ONLINE_LANGUAGES

### DIFF
--- a/include/languages.inc
+++ b/include/languages.inc
@@ -73,6 +73,7 @@ $INACTIVE_ONLINE_LANGUAGES = array(
     'hu'    => 'Hungarian',
     'id'    => 'Indonesian',
     'it'    => 'Italian',
+    'kr'    => 'Korean',
     'lt'    => 'Lithuanian',
     'no'    => 'Norwegian',
     'pl'    => 'Polish',


### PR DESCRIPTION
Apparently, the Korean translation of the PHP manual is very incomplete,
and even worse, most of what's there is out-dated,[1] so we mark the
translation as inactive for the time being.

[1] http://doc.php.net/revcheck.php?p=graph&lang=kr
