### PR TITLE
feat: include sha256 if available

### DIFF
--- a/releases/feed.php
+++ b/releases/feed.php
@@ -51,6 +51,7 @@ XML;
         echo <<< XML
         <link rel="enclosure" title="{$source["name"]}" href="/get/{$source["filename"]}/from/this/mirror">
             <php:md5>{$source["md5"]}</php:md5>
+            <php:sha256>{$source["sha256"]}</php:sha256>
             <php:releaseDate>{$released}</php:releaseDate>
         </link>
 

--- a/releases/index.php
+++ b/releases/index.php
@@ -182,7 +182,10 @@ function mk_rel($major, $ver, $date, $announcement, $source, $windows, $museum) 
 			if (isset($src['filename'])) {
 				download_link($src["filename"], $src["name"]); echo "<br>\n";
 				if (isset($src["md5"])) {
-					echo '<span class="md5sum">md5: ' .$src["md5"]. "</span>\n";
+					echo '<span class="md5sum">md5: ' .$src["md5"]. "</span><br>\n";
+				}
+				if (isset($src["sha256"])) {
+					echo '<span class="sha256">sha256: ' .$src["sha256"]. "</span>\n";
 				}
 			} else {
 				echo '<a href="'.$src['link'].'">'.$src['name'].'</a>';


### PR DESCRIPTION
Includes the sha256 for the feed & index.php on https://secure.php.net/releases/ 

Unsure on what people would prefer on the styling so any required changes let me know.