### PR TITLE
add Stanislav Malyshev GPG key to PHP 5.5 branch

### DIFF
--- a/include/gpg-keys.inc
+++ b/include/gpg-keys.inc
@@ -57,6 +57,12 @@ pub   4096R/7267B52D 2012-03-20 [expires: 2016-03-19]
       Key fingerprint = 0B96 609E 270F 565C 1329  2B24 C13C 70B8 7267 B52D
 uid                  David Soria Parra &lt;dsp@php.net&gt;
 
+pub   2048D/5DA04B5D 2012-03-19
+      Key fingerprint = F382 5282 6ACD 957E F380  D39F 2F79 56BC 5DA0 4B5D
+uid                  Stanislav Malyshev (PHP key) &lt;smalyshev@gmail.com&gt;
+uid                  Stanislav Malyshev (PHP key) &lt;stas@php.net&gt;
+uid                  Stanislav Malyshev (PHP key) &lt;smalyshev@sugarcrm.com&gt;
+
 GPG
 ,
     "5.4" => <<< GPG


### PR DESCRIPTION
Tarball for PHP 5.5.28 is signed with Stanislav Malyshev's GPG keys of the PHP 5.4 branch (checked with [php-5.5.28.tar.xz.asc](https://secure.php.net/get/php-5.5.28.tar.xz.asc/from/this/mirror)). It's the only tarball in the entire branch that I've detected (I've only checked PHP 5.5 releases with no extra trailing suffix, i.e., X.Y.Z semver format).

This PR adds that key to the list of GPG keys for PHP 5.5 branch.