### PR TITLE
Fixed dates to prevent event collision

### DIFF
--- a/archive/entries/2017-06-17-1.xml
+++ b/archive/entries/2017-06-17-1.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <entry xmlns="http://www.w3.org/2005/Atom" xmlns:default="http://php.net/ns/news">
   <title>LaravelConf Taiwan 2017</title>
-  <id>http://php.net/archive/2017.php#id2017-06-14-1</id>
-  <published>2017-06-14T18:48:00+00:00</published>
-  <updated>2017-06-14T18:48:00+00:00</updated>
+  <id>http://php.net/archive/2017.php#id2017-06-17-1</id>
+  <published>2017-06-17T18:48:00+00:00</published>
+  <updated>2017-06-17T18:48:00+00:00</updated>
   <default:finalTeaserDate xmlns="http://php.net/ns/news">2017-07-01</default:finalTeaserDate>
   <category term="conferences" label="Conference announcement"/>
-  <link href="http://php.net/conferences/index.php#id2017-06-14-1" rel="alternate" type="text/html"/>
+  <link href="http://php.net/conferences/index.php#id2017-06-17-1" rel="alternate" type="text/html"/>
   <default:newsImage xmlns="http://php.net/ns/news" link="https://laravelconf.tw/" title="LaravelConf Taiwan 2017">laravelConfTaiwan_2017.png</default:newsImage>
   <link href="https://laravelconf.tw/" rel="via" type="text/html"/>
   <content type="xhtml">


### PR DESCRIPTION
The event contained dates that did not follow convention and collided with another event.