### PR TITLE
Remove source.php from robots.txt

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -3,7 +3,6 @@ Disallow: /backend/
 Disallow: /distributions/
 Disallow: /stats/
 Disallow: /server-status/
-Disallow: /source.php
 Disallow: /search.php
 Disallow: /mod.php
 Disallow: /manual/add-note.php


### PR DESCRIPTION
I've removed source.php from robots.txt as source.php no longer exists, and was still in the list from the previous version of PHP.net.