### PR TITLE
Alters email-verification

### DIFF
--- a/include/email-validation.inc
+++ b/include/email-validation.inc
@@ -12,22 +12,30 @@ function clean_AntiSPAM($email)
 // Try to check that this email address is valid
 function is_emailable_address($email)
 {
-    // Exclude our mailing list hosting servers
-    $hosts_regex = "!(lists\.php\.net|chek[^\.*]\.com)!i";
-    $excluded_hosts = preg_match($hosts_regex, $email);
-
-    // Email addresses need to match this pattern
-    $email_regex = ":^([-!#\$%&'*+./0-9=?A-Z^_`a-z{|}~ ])+" .
-                   "@([-!#\$%&'*+/0-9=?A-Z^_`a-z{|}~ ]+\\.)+" .
-                   "[a-zA-Z]{2,6}\$:i";
-    
-    // If address is not under excluded hosts, and fits the regex,
-    // then we belive that it is a good email address
-    if (!$excluded_hosts && !empty($email)) {
-        return preg_match($email_regex, $email);
-    } else {
-        return FALSE;
+    // No email, no validation
+    if (empty($email)) {
+        return false;
     }
+
+    $parts = explode('@', $email);
+    // An email-address with more than one '@' can't be valid
+    if (count($parts) != 2) {
+        return false;
+    }
+
+    // addresses from our mailing-list servers
+    $host_part_regex = "!(lists\.php\.net|chek[^\.*]\.com)!i";
+    if (preg_match($host_part_regex, $email)) {
+        return false;
+    }
+
+    // When no MX-Entry can be found it's for sure not a valid email-address.
+    if (getmxrr($parts[1], $return_values) === false) {
+        return false;
+    }
+
+    $address_part_regex = ":^([-!#$%&'*+./0-9=?A-Z^_`a-z{|}~ ])+:i";
+    return (bool) preg_match($address_part_regex, $parts[0]);
 }
 
 /**

--- a/include/email-validation.inc
+++ b/include/email-validation.inc
@@ -12,30 +12,25 @@ function clean_AntiSPAM($email)
 // Try to check that this email address is valid
 function is_emailable_address($email)
 {
+    $email = filter_var($email, FILTER_VALIDATE_EMAIL);
     // No email, no validation
-    if (empty($email)) {
+    if (! $email) {
         return false;
     }
 
-    $parts = explode('@', $email);
-    // An email-address with more than one '@' can't be valid
-    if (count($parts) != 2) {
-        return false;
-    }
-
+    $host = substr($email, strrpos($email, '@') + 1);
     // addresses from our mailing-list servers
-    $host_part_regex = "!(lists\.php\.net|chek[^\.*]\.com)!i";
-    if (preg_match($host_part_regex, $email)) {
+    $host_regex = "!(lists\.php\.net|chek[^\.*]\.com)!i";
+    if (preg_match($host_regex, $host)) {
         return false;
     }
 
     // When no MX-Entry can be found it's for sure not a valid email-address.
-    if (getmxrr($parts[1], $return_values) === false) {
+    if (getmxrr($host, $return_values) === false) {
         return false;
     }
 
-    $address_part_regex = ":^([-!#$%&'*+./0-9=?A-Z^_`a-z{|}~ ])+:i";
-    return (bool) preg_match($address_part_regex, $parts[0]);
+    return true;
 }
 
 /**


### PR DESCRIPTION
The current email-verification is completely based on regex that is notup-to-date any more in regard to newer TLDs. For example the current version checks whether the TLD is between 2 and 6 chars long which fails for ".digital" and some other longer TLDs

I've altered it so that the host-check is done by actually checking for an MX-record so host that currently validate against the regex will fail in future when no MX is available.

The Address-Part is still matched against a Regex.