### PR TITLE
Remove old .cvsignore file

### DIFF
--- a/backend/.cvsignore
+++ b/backend/.cvsignore
@@ -1,3 +1,0 @@
-mirror.gif
-mirror.png
-mirror.jpg


### PR DESCRIPTION
The PHP project used to be organized in the CVS repository and then migrated into SVN in 2009 and partially to GIT in 2012. This patch removes an unused `.cvsignore` file. Since I'm not exactly very familiar with the repositories structure and if that's incorrect, you can close it. Otherwise I think it's important to have as clean folder structure and files updated as much as possible. Thanks for considering merging it or taking a look.