### PR TITLE
.editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,23 @@
+# http://editorconfig.org/
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{php,inc}]
+indent_style = space
+indent_size = 4
+
+[{bin/bumpRelease,bin/createNewsEntry,bin/news2html}]
+indent_style = space
+indent_size = 4
+
+[*.{css,html,js,xml}]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
Hello,

this patch adds [.editorconfig file](http://editorconfig.org) for consistency and code beautification in editors that use it and to sync the coding style used in this particular repository.

Coding styles in this commit are set to the following defaults:

All mentioned file types are set to:
* UTF-8 encoding
* Unix-style newlines with a newline ending
* trailing whitespace is trimmed

MarkDown files
* trimming of trailing whitespace is disabled since there might appear some to indicate a new line

CSS, JavaScript, HTML, XML files:
* indentation 2 spaces

PHP files (*.php and *.inc and few bin/ PHP CLI scripts)
* indentation 4 spaces

In case this is inconvenient for people maintaining this repository, let me know and I can adjust it accordingly. The picked settings are somehow most used in other open source code (PHP files somehow mostly use 4 spaces in open source libraries and frameworks), JS and CSS (from my point of view, use 2 spaces).