### PR TITLE
Change encoding from iso-8859-1 to utf-8 for includes/countries.inc

### DIFF
--- a/include/countries.inc
+++ b/include/countries.inc
@@ -167,7 +167,7 @@ $COUNTRIES = array(
 'QAT' => 'Qatar',
 'KOR' => 'Republic of Korea',
 'MDA' => 'Republic of Moldova',
-'REU' => 'Réunion',
+'REU' => 'RÃ©union',
 'ROU' => 'Romania',
 'RUS' => 'Russian Federation',
 'RWA' => 'Rwanda',
@@ -233,4 +233,3 @@ $COUNTRIES = array(
 'ZMB' => 'Zambia',
 'ZWE' => 'Zimbabwe',
 );
-


### PR DESCRIPTION
File `includes/countries.inc` has been encoded in iso-8859-1 and this patch should hopefully change it to utf-8. It's not a bug fix, but more of a convenience and consistency thingy. Thanks for considering merging it or taking a look.