### PR TITLE
Changed Google Custom Search to no longer open links in new window

### DIFF
--- a/include/prepend.inc
+++ b/include/prepend.inc
@@ -48,7 +48,7 @@ if (!isset($_SERVER["SERVER_ADDR"])) {
     $_SERVER["SERVER_ADDR"] = "127.0.0.1";
 }
 
-// As of PHP 5.3.0 multibyte sequence errors are no longer 
+// As of PHP 5.3.0 multibyte sequence errors are no longer
 // silent. Prior to that version this bitfield does not exist
 // so define it to prevent notices on older versions
 if (!defined("ENT_IGNORE")) {
@@ -220,7 +220,6 @@ function google_cse($default = '', $lang = 'en') {
         s.parentNode.insertBefore(gcse, s);
     })();
 </script>
-<gcse:search></gcse:search>
+<div class="gcse-search" data-linktarget></div>
 <?php
 }
-


### PR DESCRIPTION
The "Full website search" results provided by Google Custom Search open a new window or tab when they're clicked. This behaviour is at odds with the way links work throughout the rest of the site, as well as good user experience, which should let the user choose whether to open a new tab rather than forcing it upon them. Since the new window behaviour is the Google CSE default, I assume this is an oversight rather than a deliberate design choice.

I also took the liberty of upgrading the CSE tag to the [new HTML5 format](https://developers.google.com/custom-search/docs/element#html5) to future-proof it a bit, which is why the tag has been completely replaced; otherwise we'd just be adding the `linktarget` option, which is unset, causing the `target` attribute to be removed from the search result links thus using the browser's default link target instead of setting it to `_blank` by default, as before, causing it to open in a new tab.