### PR TITLE
Vertically center search box

### DIFF
--- a/styles/theme-base.css
+++ b/styles/theme-base.css
@@ -182,7 +182,7 @@ textarea {
 .navbar-search {
   position: relative;
   float: left;
-  margin-top: .625rem;
+  margin-top: .770rem;
   margin-bottom: 0;
   width:100%;
   -moz-box-sizing:border-box;


### PR DESCRIPTION
I don't know if it's my OCD but this was taking my attention every time I visited php.net:

<img width="1211" alt="captura de tela 2018-03-29 as 00 53 52" src="https://user-images.githubusercontent.com/3002249/38069580-77b77dee-32ed-11e8-83b1-ac792a597ec3.png">

This very small PR moves the search field closer to the middle.

<img width="1214" alt="captura de tela 2018-03-29 as 00 54 12" src="https://user-images.githubusercontent.com/3002249/38069591-829bf5a0-32ed-11e8-9a95-36ed8005afdb.png">
