### PR TITLE
Remove unused Git attributes ident

### DIFF
--- a/ChangeLog-4.php
+++ b/ChangeLog-4.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'ChangeLog-4.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/changelogs.inc';

--- a/ChangeLog-5.php
+++ b/ChangeLog-5.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'ChangeLog-5.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/changelogs.inc';

--- a/archive/1998.php
+++ b/archive/1998.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'archive/1998.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 news_archive_sidebar();

--- a/archive/1999.php
+++ b/archive/1999.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'archive/1999.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 news_archive_sidebar();

--- a/archive/2000.php
+++ b/archive/2000.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'archive/2000.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 news_archive_sidebar();

--- a/archive/2001.php
+++ b/archive/2001.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'archive/2001.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 news_archive_sidebar();

--- a/archive/2002.php
+++ b/archive/2002.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'archive/2002.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 news_archive_sidebar();

--- a/archive/2003.php
+++ b/archive/2003.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'archive/2003.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 news_archive_sidebar();

--- a/archive/2004.php
+++ b/archive/2004.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'archive/2004.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 news_archive_sidebar();

--- a/archive/2005.php
+++ b/archive/2005.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'archive/2005.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 news_archive_sidebar();

--- a/archive/2006.php
+++ b/archive/2006.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'archive/2006.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 news_archive_sidebar();

--- a/archive/2007.php
+++ b/archive/2007.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'archive/2007.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 news_archive_sidebar();

--- a/archive/2008.php
+++ b/archive/2008.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'archive/2008.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 news_archive_sidebar();

--- a/archive/2009.php
+++ b/archive/2009.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'archive/2009.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 news_archive_sidebar();

--- a/archive/2010.php
+++ b/archive/2010.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'archive/2010.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 news_archive_sidebar();

--- a/archive/2011.php
+++ b/archive/2011.php
@@ -1,5 +1,4 @@
 <?php
-// $Id: 2010.php 293613 2010-01-16 13:38:42Z bjori $
 $_SERVER['BASE_PAGE'] = 'archive/2011.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 news_archive_sidebar();

--- a/archive/2012.php
+++ b/archive/2012.php
@@ -1,5 +1,4 @@
 <?php
-// $Id: 2010.php 293613 2010-01-16 13:38:42Z bjori $
 $_SERVER['BASE_PAGE'] = 'archive/2012.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 news_archive_sidebar();

--- a/archive/index.php
+++ b/archive/index.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 $i = 0;
 do {

--- a/backend/index.php
+++ b/backend/index.php
@@ -1,6 +1,4 @@
 <?php
-// $Id$
-
 // Simulate a /backend shortcut call (which will lead to a manual page)
 $_SERVER['REQUEST_URI'] = '/backend';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';

--- a/bin/index.php
+++ b/bin/index.php
@@ -1,6 +1,4 @@
 <?php
-// $Id$
-
 // Simulate a /bin shortcut call (which will lead to a manual page)
 $_SERVER['REQUEST_URI'] = '/bin';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';

--- a/build-setup.php
+++ b/build-setup.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'get-involved.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 

--- a/cal.php
+++ b/cal.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'cal.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 

--- a/conferences/index.php
+++ b/conferences/index.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'conferences/index.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/pregen-news.inc';

--- a/contact.php
+++ b/contact.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'contact.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("Contact", array("current" => "community"));

--- a/copyright.php
+++ b/copyright.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'copyright.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 $SIDEBAR_DATA = '

--- a/credits.php
+++ b/credits.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'credits.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 

--- a/docs.php
+++ b/docs.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'docs.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 

--- a/download-docs.php
+++ b/download-docs.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'download-docs.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 

--- a/download-logos.php
+++ b/download-logos.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'download-logos.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 $SIDEBAR_DATA = '

--- a/downloads.php
+++ b/downloads.php
@@ -1,5 +1,4 @@
 <?php // vim: et
-// $Id$
 $_SERVER['BASE_PAGE'] = 'downloads.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/gpg-keys.inc';

--- a/elephpant.php
+++ b/elephpant.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'elephpant.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 $SIDEBAR_DATA = '

--- a/error.php
+++ b/error.php
@@ -1,6 +1,4 @@
 <?php
-// $Id$
-
 /*
 
  This script handles all 401, 403 and 404 error redirects,

--- a/get-involved.php
+++ b/get-involved.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'get-involved.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 

--- a/git.php
+++ b/git.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'git.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 $SIDEBAR_DATA = '

--- a/images/index.php
+++ b/images/index.php
@@ -1,6 +1,4 @@
 <?php
-// $Id$
-
 // Simulate a /images shortcut call (which will lead to a manual page)
 $_SERVER['REQUEST_URI'] = '/images';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';

--- a/include/changelogs.inc
+++ b/include/changelogs.inc
@@ -1,6 +1,4 @@
 <?php
-/* $Id$ */
-
 function bugfix($number) { 
     echo "Fixed bug "; bugl($number); 
 }

--- a/include/do-download.inc
+++ b/include/do-download.inc
@@ -1,7 +1,5 @@
 <?php
 
-// $Id$
-
 /*
    This code redirects the user to the exact file to
    download, and logs the download if it's something

--- a/include/email-validation.inc
+++ b/include/email-validation.inc
@@ -1,7 +1,5 @@
 <?php
 
-// $Id$
-
 // Try to remove anti-SPAM bits
 function clean_AntiSPAM($email)
 {

--- a/include/errors.inc
+++ b/include/errors.inc
@@ -1,6 +1,4 @@
 <?php
-// $Id$
-
 /*
   This script provides functions to print out
   error messages for users in case something is

--- a/include/get-download.inc
+++ b/include/get-download.inc
@@ -1,6 +1,4 @@
 <?php
-// $Id$
-
 // Try to make this page non-cached
 header_nocache();
 

--- a/include/header.inc
+++ b/include/header.inc
@@ -1,6 +1,4 @@
 <?php
-/* $Id$ */
-
 $css_files = array(
     '/fonts/Fira/fira.css',
     '/fonts/Font-Awesome/css/fontello.css',

--- a/include/index.php
+++ b/include/index.php
@@ -1,6 +1,4 @@
 <?php
-// $Id$
-
 // Simulate a /include shortcut call (which will lead to a manual page)
 $_SERVER['REQUEST_URI'] = '/include';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';

--- a/include/ip-to-country.inc
+++ b/include/ip-to-country.inc
@@ -1,7 +1,5 @@
 <?php // -*- C++ -*-
 
-// $Id$
-
 /*
 
  This script uses the local copy of the ip-to-country.com

--- a/include/langchooser.inc
+++ b/include/langchooser.inc
@@ -1,7 +1,5 @@
 <?php // -*- C++ -*-
 
-// $Id$
-
 /*
 
  This script tries to guess what language to use for

--- a/include/languages.inc
+++ b/include/languages.inc
@@ -1,7 +1,5 @@
 <?php // -*- C++ -*-
 
-// $Id$
-
 /*
  This is a list of all manual languages hosted
  within PHP SVN modules (phpdoc-{lang})

--- a/include/layout.inc
+++ b/include/layout.inc
@@ -1,6 +1,4 @@
 <?php
-/* $Id$ */
-
 $_SERVER['STATIC_ROOT'] = $MYSITE;
 $_SERVER['MYSITE'] = $MYSITE;
 

--- a/include/loadavg.inc
+++ b/include/loadavg.inc
@@ -1,7 +1,5 @@
 <?php # vim:ft=php
 
-// $Id$
-
 /*
  Offload to the visitor's nearest mirror if the load is too high.
  We use the sys_getloadavg() function that requires PHP 5.1.3+

--- a/include/manual-lookup.inc
+++ b/include/manual-lookup.inc
@@ -1,7 +1,5 @@
 <?php // -*- C++ -*-
 
-// $Id$
-
 // We need this for error reporting 
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/errors.inc';
 

--- a/include/posttohost.inc
+++ b/include/posttohost.inc
@@ -1,7 +1,5 @@
 <?php
 
-// $Id$
-
 /*
  This code is used to post data to the central server which
  can store the data in database and/or mail notices or requests

--- a/include/prepend.inc
+++ b/include/prepend.inc
@@ -2,8 +2,6 @@
 // Compress all pages, if ext/zlib is available on the mirror
 ini_set("zlib.output_compression", 1);
 
-// $Id$
-
 // See http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9
 // for cache control header descriptions (used in many places on the site).
 

--- a/include/results.inc
+++ b/include/results.inc
@@ -1,5 +1,4 @@
 <?php
-// $Id: $
 function search_results($res, $q, $profile='all', $per_page=10, $s=0, $l='en', $show_title=true, $show_foot=true, $show_attrib=true) {
 	$start_result = $s;
 	$end_result = $s + $res['ResultSet']['totalResultsReturned'] -1;

--- a/include/shared-manual.inc
+++ b/include/shared-manual.inc
@@ -1,7 +1,5 @@
 <?php // -*- C++ -*-
 
-// $Id$
-
 /*
 
  This file is included directly on all manual pages,

--- a/include/shared-stat.inc
+++ b/include/shared-stat.inc
@@ -1,5 +1,4 @@
 <?php // -*- C++ -*-
-// $Id$
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 
 function commonStatHeader($title) {

--- a/include/site.inc
+++ b/include/site.inc
@@ -1,7 +1,5 @@
 <?php // -*- C++ -*-
 
-// $Id$
-
 // Define $MIRRORS array, and some constants
 include $_SERVER['DOCUMENT_ROOT'] . '/include/mirrors.inc';
 

--- a/license/contrib-guidelines-code.php
+++ b/license/contrib-guidelines-code.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'license/contrib-guidelines-code.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("License Information", array("current" => "help"));

--- a/license/distrib-guidelines-code.php
+++ b/license/distrib-guidelines-code.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'license/distrib-guidelines-code.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("License Information", array("current" => "help"));

--- a/license/index.php
+++ b/license/index.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'license/index.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 

--- a/mailing-lists.php
+++ b/mailing-lists.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'mailing-lists.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/posttohost.inc';

--- a/manual-lookup.php
+++ b/manual-lookup.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'manual-lookup.php';
 include $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 include $_SERVER['DOCUMENT_ROOT'] . '/include/loadavg.inc';

--- a/manual/add-note.php
+++ b/manual/add-note.php
@@ -1,6 +1,4 @@
 <?php
-// $Id$
-
 $ip_spam_lookup_url = 'http://www.dnsbl.info/dnsbl-database-check.php?IP=';
 
 $_SERVER['BASE_PAGE'] = 'manual/add-note.php';

--- a/manual/change.php
+++ b/manual/change.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 
 $page = isset($_GET['page']) ? htmlspecialchars($_GET['page'], ENT_QUOTES, 'UTF-8') : '';

--- a/manual/help-translate.php
+++ b/manual/help-translate.php
@@ -1,6 +1,4 @@
 <?php
-// $Id$
-
 $_SERVER['BASE_PAGE'] = 'manual/help-translate.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/shared-manual.inc';

--- a/manual/index.php
+++ b/manual/index.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 mirror_redirect("/manual/$LANG/index.php");
 ?>

--- a/manual/php3.php
+++ b/manual/php3.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'manual/php3.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header('PHP Version 3 Documentation');

--- a/manual/phpfi2.php
+++ b/manual/phpfi2.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'manual/phpfi2.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header('PHP/FI Version 2.0 Documentation');

--- a/manual/spam_challenge.php
+++ b/manual/spam_challenge.php
@@ -1,6 +1,4 @@
 <?php
-// $Id$
-
 // simple and stupid SPAM protection (using little challenges)
 
 $nums = array('zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine');

--- a/manual/vote-note.php
+++ b/manual/vote-note.php
@@ -1,6 +1,4 @@
 <?php
-// $Id$
-
 $_SERVER['BASE_PAGE'] = 'manual/vote-note.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/posttohost.inc';

--- a/mirror-info.php
+++ b/mirror-info.php
@@ -1,6 +1,4 @@
 <?php
-// $Id$
-
 // Define $MYSITE and $LAST_UPDATED variables
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 

--- a/mirror.php
+++ b/mirror.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'mirror.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 $SIDEBAR_DATA = '

--- a/mirroring-stats.php
+++ b/mirroring-stats.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'mirroring-stats.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("Setting Up Local Stats", array("current" => "community"));

--- a/mirroring-troubles.php
+++ b/mirroring-troubles.php
@@ -1,6 +1,4 @@
 <?php
-// $Id$
-
 $_SERVER['BASE_PAGE'] = 'mirroring-troubles.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 

--- a/mirroring.php
+++ b/mirroring.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'mirroring.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 $SIDEBAR_DATA = '

--- a/mirrors.php
+++ b/mirrors.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'mirrors.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/layout.inc';

--- a/mod.php
+++ b/mod.php
@@ -1,6 +1,4 @@
 <?php
-// $Id$
-
 /*
  This page supports the PHP.net automoderation system
  with enabling users to confirm their emails via the web.

--- a/my.php
+++ b/my.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'my.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 

--- a/pear/index.php
+++ b/pear/index.php
@@ -1,6 +1,4 @@
 <?php
-// $Id$
-
 // Simulate a /pear shortcut call (which will lead to a manual page)
 $_SERVER['REQUEST_URI'] = '/pear';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';

--- a/quickref.php
+++ b/quickref.php
@@ -1,6 +1,4 @@
 <?php
-// $Id$
-
 /*
 
  This page is either directly called from the browser, in

--- a/releases/4_1_0.php
+++ b/releases/4_1_0.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/4_1_0.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 4.1.0 Release Announcement");

--- a/releases/4_1_0_fr.php
+++ b/releases/4_1_0_fr.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/4_1_0_fr.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("Annonce de publication de PHP 4.1.0", array("lang" => "fr"));

--- a/releases/4_1_1.php
+++ b/releases/4_1_1.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/4_1_1.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 4.1.1 Release Announcement");

--- a/releases/4_1_2_win32.php
+++ b/releases/4_1_2_win32.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/4_1_2_win32.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 4.1.2 Windows (Win32) Release Announcement");

--- a/releases/4_2_0.php
+++ b/releases/4_2_0.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/4_2_0.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 4.2.0 Release Announcement");

--- a/releases/4_2_0_fr.php
+++ b/releases/4_2_0_fr.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/4_2_0_fr.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("Annonce de publication de PHP 4.2.0", array("lang" => "fr"));

--- a/releases/4_2_1.php
+++ b/releases/4_2_1.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/4_2_1.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 4.2.1 Release Announcement");

--- a/releases/4_2_1_fr.php
+++ b/releases/4_2_1_fr.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/4_2_1_fr.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("Annonce de publication de PHP 4.2.1", array("lang" => "fr"));

--- a/releases/4_2_2.php
+++ b/releases/4_2_2.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/4_2_2.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 4.2.2 Release Announcement");

--- a/releases/4_2_2_fr.php
+++ b/releases/4_2_2_fr.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/4_2_2_fr.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("Annonce de publication de PHP 4.2.2", array("lang" => "fr"));

--- a/releases/4_3_0.php
+++ b/releases/4_3_0.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/4_3_0.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 4.3.0 Release Announcement");

--- a/releases/4_3_0_fr.php
+++ b/releases/4_3_0_fr.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/4_3_0_fr.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("Annonce de publication de PHP 4.3.0", array("lang" => "fr"));

--- a/releases/4_3_1.php
+++ b/releases/4_3_1.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/4_3_1.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 4.3.1 Release Announcement");

--- a/releases/4_3_10.php
+++ b/releases/4_3_10.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/4_3_10.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 4.3.10 Release Announcement");

--- a/releases/4_3_10_fr.php
+++ b/releases/4_3_10_fr.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/4_3_10.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 4.3.10 Release Announcement");

--- a/releases/4_3_11.php
+++ b/releases/4_3_11.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/4_3_11.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 4.3.11 Release Announcement");

--- a/releases/4_3_11_fr.php
+++ b/releases/4_3_11_fr.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/4_3_10.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("Annonce de PHP 4.3.11");

--- a/releases/4_3_2.php
+++ b/releases/4_3_2.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/4_3_2.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 4.3.2 Release Announcement");

--- a/releases/4_3_2_fr.php
+++ b/releases/4_3_2_fr.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/4_3_2_fr.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("Annonce de publication de PHP 4.3.2", array("lang" => "fr"));

--- a/releases/4_3_3.php
+++ b/releases/4_3_3.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/4_3_3.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 4.3.3 Release Announcement");

--- a/releases/4_3_3_fr.php
+++ b/releases/4_3_3_fr.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/4_3_3.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("Annonce de publication de PHP 4.3.3");

--- a/releases/4_3_4.php
+++ b/releases/4_3_4.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/4_3_4.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 4.3.4 Release Announcement");

--- a/releases/4_3_4_fr.php
+++ b/releases/4_3_4_fr.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/4_3_4.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("Annonce de publication de PHP 4.3.4", array("lang" => "fr"));

--- a/releases/4_3_5.php
+++ b/releases/4_3_5.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/4_3_5.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 4.3.5 Release Announcement");

--- a/releases/4_3_5_fr.php
+++ b/releases/4_3_5_fr.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/4_3_5.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("Annonce de publication de PHP 4.3.5");

--- a/releases/4_3_6.php
+++ b/releases/4_3_6.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/4_3_6.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 4.3.6 Release Announcement");

--- a/releases/4_3_6_fr.php
+++ b/releases/4_3_6_fr.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/4_3_6.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("Annonce de publication de PHP 4.3.6");

--- a/releases/4_3_7.php
+++ b/releases/4_3_7.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/4_3_7.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 4.3.7 Release Announcement");

--- a/releases/4_3_7_fr.php
+++ b/releases/4_3_7_fr.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/4_3_7.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("Annonce de publication de PHP 4.3.7");

--- a/releases/4_3_8.php
+++ b/releases/4_3_8.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/4_3_8.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 4.3.8 Release Announcement");

--- a/releases/4_3_9.php
+++ b/releases/4_3_9.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/4_3_9.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 4.3.9 Release Announcement");

--- a/releases/4_3_9_fr.php
+++ b/releases/4_3_9_fr.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/4_3_9.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 4.3.9 Release Announcement");

--- a/releases/4_4_0.php
+++ b/releases/4_4_0.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/4_4_0.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 4.4.0 Release Announcement");

--- a/releases/4_4_1.php
+++ b/releases/4_4_1.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/4_4_1.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 4.4.1 Release Announcement");

--- a/releases/4_4_2.php
+++ b/releases/4_4_2.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/4_4_1.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 4.4.2 Release Announcement");

--- a/releases/4_4_3.php
+++ b/releases/4_4_3.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/4_4_3.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 4.4.3 Release Announcement");

--- a/releases/4_4_4.php
+++ b/releases/4_4_4.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/4_4_4.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 4.4.4 Release Announcement");

--- a/releases/4_4_5.php
+++ b/releases/4_4_5.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/4_4_5.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 4.4.5 Release Announcement");

--- a/releases/4_4_6.php
+++ b/releases/4_4_6.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/4_4_6.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 4.4.6 Release Announcement");

--- a/releases/4_4_7.php
+++ b/releases/4_4_7.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/4_4_7.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 4.4.7 Release Announcement");

--- a/releases/4_4_8.php
+++ b/releases/4_4_8.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/4_4_8.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 4.4.8 Release Announcement");

--- a/releases/4_4_9.php
+++ b/releases/4_4_9.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/4_4_9.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 4.4.9 Release Announcement");

--- a/releases/5_1_0.php
+++ b/releases/5_1_0.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_1_0.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.1.0 Release Announcement");

--- a/releases/5_1_1.php
+++ b/releases/5_1_1.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_1_1.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.1.1 Release Announcement");

--- a/releases/5_1_2.php
+++ b/releases/5_1_2.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_1_2.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.1.2 Release Announcement");

--- a/releases/5_1_3.php
+++ b/releases/5_1_3.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_1_3.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.1.3 Release Announcement");

--- a/releases/5_1_4.php
+++ b/releases/5_1_4.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_1_4.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.1.4 Release Announcement");

--- a/releases/5_1_5.php
+++ b/releases/5_1_5.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_1_5.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.1.5 Release Announcement");

--- a/releases/5_1_6.php
+++ b/releases/5_1_6.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_1_6.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.1.6 Release Announcement");

--- a/releases/5_2_0.php
+++ b/releases/5_2_0.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_2_0.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.2.0 Release Announcement");

--- a/releases/5_2_1.php
+++ b/releases/5_2_1.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_2_1.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.2.1 Release Announcement");

--- a/releases/5_2_10.php
+++ b/releases/5_2_10.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_2_10.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.2.10 Release Announcement");

--- a/releases/5_2_11.php
+++ b/releases/5_2_11.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_2_11.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.2.11 Release Announcement");

--- a/releases/5_2_12.php
+++ b/releases/5_2_12.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_2_12.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.2.12 Release Announcement");

--- a/releases/5_2_13.php
+++ b/releases/5_2_13.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_2_13.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.2.13 Release Announcement");

--- a/releases/5_2_14.php
+++ b/releases/5_2_14.php
@@ -1,5 +1,4 @@
 <?php
-// $Id $
 $_SERVER['BASE_PAGE'] = 'releases/5_2_14.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.2.14 Release Announcement");

--- a/releases/5_2_15.php
+++ b/releases/5_2_15.php
@@ -1,5 +1,4 @@
 <?php
-// $Id $
 $_SERVER['BASE_PAGE'] = 'releases/5_2_15.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.2.15 Release Announcement");

--- a/releases/5_2_16.php
+++ b/releases/5_2_16.php
@@ -1,5 +1,4 @@
 <?php
-// $Id $
 $_SERVER['BASE_PAGE'] = 'releases/5_2_16.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.2.16 Release Announcement");

--- a/releases/5_2_17.php
+++ b/releases/5_2_17.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
                $_SERVER['BASE_PAGE'] = 'releases/5.2.17.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.2.17 Release Announcement");

--- a/releases/5_2_2.php
+++ b/releases/5_2_2.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_2_2.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.2.2 Release Announcement");

--- a/releases/5_2_3.php
+++ b/releases/5_2_3.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_2_3.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.2.3 Release Announcement");

--- a/releases/5_2_4.php
+++ b/releases/5_2_4.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_2_4.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.2.4 Release Announcement");

--- a/releases/5_2_5.php
+++ b/releases/5_2_5.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_2_5.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.2.5 Release Announcement");

--- a/releases/5_2_6.php
+++ b/releases/5_2_6.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_2_6.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.2.6 Release Announcement");

--- a/releases/5_2_7.php
+++ b/releases/5_2_7.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_2_7.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.2.7 Release Announcement");

--- a/releases/5_2_8.php
+++ b/releases/5_2_8.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_2_8.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.2.8 Release Announcement");

--- a/releases/5_2_9.php
+++ b/releases/5_2_9.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_2_9.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.2.9 Release Announcement");

--- a/releases/5_3_0.php
+++ b/releases/5_3_0.php
@@ -1,5 +1,4 @@
 <?php
-// $Id: 5_2_0.php,v 1.4 2007/01/16 16:04:05 bjori Exp $
 $_SERVER['BASE_PAGE'] = 'releases/5_3_0.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.3.0 Release Announcement");

--- a/releases/5_3_1.php
+++ b/releases/5_3_1.php
@@ -1,5 +1,4 @@
 <?php
-// $Id: 5_2_0.php,v 1.4 2007/01/16 16:04:05 bjori Exp $
 $_SERVER['BASE_PAGE'] = 'releases/5_3_1.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.3.1 Release Announcement");

--- a/releases/5_3_10.php
+++ b/releases/5_3_10.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_3_10.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.3.10 Release Announcement");

--- a/releases/5_3_11.php
+++ b/releases/5_3_11.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_3_11.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.3.11 Release Announcement");

--- a/releases/5_3_12.php
+++ b/releases/5_3_12.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_3_12.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.3.12 Release Announcement");

--- a/releases/5_3_13.php
+++ b/releases/5_3_13.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_3_13.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.3.13 Release Announcement");

--- a/releases/5_3_14.php
+++ b/releases/5_3_14.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_3_14.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.3.14 Release Announcement");

--- a/releases/5_3_15.php
+++ b/releases/5_3_15.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_3_15.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.3.15 Release Announcement");

--- a/releases/5_3_16.php
+++ b/releases/5_3_16.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_3_16.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.3.16 Release Announcement");

--- a/releases/5_3_17.php
+++ b/releases/5_3_17.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_3_17.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.3.17 Release Announcement");

--- a/releases/5_3_18.php
+++ b/releases/5_3_18.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_3_18.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.3.18 Release Announcement");

--- a/releases/5_3_19.php
+++ b/releases/5_3_19.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_3_19.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.3.19 Release Announcement");

--- a/releases/5_3_2.php
+++ b/releases/5_3_2.php
@@ -1,5 +1,4 @@
 <?php
-// $Id: 5_2_0.php,v 1.4 2007/01/16 16:04:05 bjori Exp $
 $_SERVER['BASE_PAGE'] = 'releases/5_3_2.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.3.2 Release Announcement");

--- a/releases/5_3_20.php
+++ b/releases/5_3_20.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_3_20.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.3.20 Release Announcement");

--- a/releases/5_3_21.php
+++ b/releases/5_3_21.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_3_21.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.3.21 Release Announcement");

--- a/releases/5_3_22.php
+++ b/releases/5_3_22.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_3_22.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.3.22 Release Announcement");

--- a/releases/5_3_23.php
+++ b/releases/5_3_23.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_3_23.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.3.23 Release Announcement");

--- a/releases/5_3_24.php
+++ b/releases/5_3_24.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_3_24.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.3.24 Release Announcement");

--- a/releases/5_3_25.php
+++ b/releases/5_3_25.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_3_25.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.3.25 Release Announcement");

--- a/releases/5_3_26.php
+++ b/releases/5_3_26.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_3_26.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.3.26 Release Announcement");

--- a/releases/5_3_27.php
+++ b/releases/5_3_27.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_3_27.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.3.27 Release Announcement");

--- a/releases/5_3_28.php
+++ b/releases/5_3_28.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_3_28.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.3.28 Release Announcement");

--- a/releases/5_3_29.php
+++ b/releases/5_3_29.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_3_29.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.3.29 Release Announcement");

--- a/releases/5_3_3.php
+++ b/releases/5_3_3.php
@@ -1,5 +1,4 @@
 <?php
-// $Id $
 $_SERVER['BASE_PAGE'] = 'releases/5_3_3.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.3.3 Release Announcement");

--- a/releases/5_3_4.php
+++ b/releases/5_3_4.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_3_4.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.3.4 Release Announcement");

--- a/releases/5_3_5.php
+++ b/releases/5_3_5.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_3_5.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.3.5 Release Announcement");

--- a/releases/5_3_6.php
+++ b/releases/5_3_6.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_3_6.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.3.6 Release Announcement");

--- a/releases/5_3_7.php
+++ b/releases/5_3_7.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_3_7.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.3.7 Release Announcement");

--- a/releases/5_3_8.php
+++ b/releases/5_3_8.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_3_8.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.3.8 Release Announcement");

--- a/releases/5_3_9.php
+++ b/releases/5_3_9.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_3_9.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.3.9 Release Announcement");

--- a/releases/5_4_0.php
+++ b/releases/5_4_0.php
@@ -1,5 +1,4 @@
 <?php
-// $Id: 5_2_0.php,v 1.4 2007/01/16 16:04:05 bjori Exp $
 $_SERVER['BASE_PAGE'] = 'releases/5_4_0.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.4.0 Release Announcement");

--- a/releases/5_4_1.php
+++ b/releases/5_4_1.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_4_1.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.4.1 Release Announcement");

--- a/releases/5_4_10.php
+++ b/releases/5_4_10.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_4_10.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.4.10 Release Announcement");

--- a/releases/5_4_11.php
+++ b/releases/5_4_11.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_4_11.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.4.11 Release Announcement");

--- a/releases/5_4_12.php
+++ b/releases/5_4_12.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_4_12.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.4.12 Release Announcement");

--- a/releases/5_4_13.php
+++ b/releases/5_4_13.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_4_13.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.4.13 Release Announcement");

--- a/releases/5_4_14.php
+++ b/releases/5_4_14.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_4_14.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.4.14 Release Announcement");

--- a/releases/5_4_15.php
+++ b/releases/5_4_15.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_4_15.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.4.15 Release Announcement");

--- a/releases/5_4_16.php
+++ b/releases/5_4_16.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_4_16.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.4.16 Release Announcement");

--- a/releases/5_4_17.php
+++ b/releases/5_4_17.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_4_17.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.4.17 Release Announcement");

--- a/releases/5_4_18.php
+++ b/releases/5_4_18.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_4_18.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.4.18 Release Announcement");

--- a/releases/5_4_19.php
+++ b/releases/5_4_19.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_4_19.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.4.19 Release Announcement");

--- a/releases/5_4_2.php
+++ b/releases/5_4_2.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_4_2.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.4.2 Release Announcement");

--- a/releases/5_4_20.php
+++ b/releases/5_4_20.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_4_20.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.4.20 Release Announcement");

--- a/releases/5_4_21.php
+++ b/releases/5_4_21.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_4_21.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.4.21 Release Announcement");

--- a/releases/5_4_22.php
+++ b/releases/5_4_22.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_4_22.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.4.22 Release Announcement");

--- a/releases/5_4_23.php
+++ b/releases/5_4_23.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_4_23.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.4.23 Release Announcement");

--- a/releases/5_4_24.php
+++ b/releases/5_4_24.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_4_24.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.4.24 Release Announcement");

--- a/releases/5_4_25.php
+++ b/releases/5_4_25.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_4_25.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.4.25 Release Announcement");

--- a/releases/5_4_26.php
+++ b/releases/5_4_26.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_4_26.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.4.26 Release Announcement");

--- a/releases/5_4_27.php
+++ b/releases/5_4_27.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_4_27.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.4.27 Release Announcement");

--- a/releases/5_4_28.php
+++ b/releases/5_4_28.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_4_28.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.4.28 Release Announcement");

--- a/releases/5_4_29.php
+++ b/releases/5_4_29.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_4_29.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.4.29 Release Announcement");

--- a/releases/5_4_3.php
+++ b/releases/5_4_3.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_4_3.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.4.3 Release Announcement");

--- a/releases/5_4_30.php
+++ b/releases/5_4_30.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_4_30.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.4.30 Release Announcement");

--- a/releases/5_4_31.php
+++ b/releases/5_4_31.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_4_31.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.4.31 Release Announcement");

--- a/releases/5_4_32.php
+++ b/releases/5_4_32.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_4_32.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.4.32 Release Announcement");

--- a/releases/5_4_33.php
+++ b/releases/5_4_33.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_4_33.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.4.33 Release Announcement");

--- a/releases/5_4_34.php
+++ b/releases/5_4_34.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_4_34.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.4.34 Release Announcement");

--- a/releases/5_4_35.php
+++ b/releases/5_4_35.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_4_35.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.4.35 Release Announcement");

--- a/releases/5_4_36.php
+++ b/releases/5_4_36.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_4_36.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.4.36 Release Announcement");

--- a/releases/5_4_37.php
+++ b/releases/5_4_37.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_4_37.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.4.37 Release Announcement");

--- a/releases/5_4_38.php
+++ b/releases/5_4_38.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_4_38.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.4.38 Release Announcement");

--- a/releases/5_4_39.php
+++ b/releases/5_4_39.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_4_39.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.4.39 Release Announcement");

--- a/releases/5_4_4.php
+++ b/releases/5_4_4.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_4_4.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.4.4 Release Announcement");

--- a/releases/5_4_40.php
+++ b/releases/5_4_40.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_4_40.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.4.40 Release Announcement");

--- a/releases/5_4_41.php
+++ b/releases/5_4_41.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_4_41.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.4.41 Release Announcement");

--- a/releases/5_4_42.php
+++ b/releases/5_4_42.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_4_42.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.4.42 Release Announcement");

--- a/releases/5_4_43.php
+++ b/releases/5_4_43.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_4_43.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.4.43 Release Announcement");

--- a/releases/5_4_44.php
+++ b/releases/5_4_44.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_4_44.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.4.44 Release Announcement");

--- a/releases/5_4_45.php
+++ b/releases/5_4_45.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_4_45.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.4.45 Release Announcement");

--- a/releases/5_4_5.php
+++ b/releases/5_4_5.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_4_5.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.4.5 Release Announcement");

--- a/releases/5_4_6.php
+++ b/releases/5_4_6.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_4_6.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.4.6 Release Announcement");

--- a/releases/5_4_7.php
+++ b/releases/5_4_7.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_4_7.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.4.7 Release Announcement");

--- a/releases/5_4_8.php
+++ b/releases/5_4_8.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_4_8.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.4.8 Release Announcement");

--- a/releases/5_4_9.php
+++ b/releases/5_4_9.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_4_9.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.4.9 Release Announcement");

--- a/releases/5_5_0.php
+++ b/releases/5_5_0.php
@@ -1,5 +1,4 @@
 <?php
-// $Id: 5_2_0.php,v 1.4 2007/01/16 16:04:05 bjori Exp $
 $_SERVER['BASE_PAGE'] = 'releases/5_5_0.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.5.0 Release Announcement");

--- a/releases/5_5_1.php
+++ b/releases/5_5_1.php
@@ -1,5 +1,4 @@
 <?php
-// $Id: 5_2_0.php,v 1.4 2007/01/16 16:04:05 bjori Exp $
 $_SERVER['BASE_PAGE'] = 'releases/5_5_1.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.5.1 Release Announcement");

--- a/releases/5_5_10.php
+++ b/releases/5_5_10.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_5_10.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.5.9 Release Announcement");

--- a/releases/5_5_11.php
+++ b/releases/5_5_11.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_5_11.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.5.11 Release Announcement");

--- a/releases/5_5_12.php
+++ b/releases/5_5_12.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_5_12.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.5.12 Release Announcement");

--- a/releases/5_5_13.php
+++ b/releases/5_5_13.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_5_13.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.5.13 Release Announcement");

--- a/releases/5_5_14.php
+++ b/releases/5_5_14.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_5_14.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.5.14 Release Announcement");

--- a/releases/5_5_15.php
+++ b/releases/5_5_15.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_5_15.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.5.15 Release Announcement");

--- a/releases/5_5_16.php
+++ b/releases/5_5_16.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_5_16.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.5.16 Release Announcement");

--- a/releases/5_5_17.php
+++ b/releases/5_5_17.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_5_17.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.5.17 Release Announcement");

--- a/releases/5_5_18.php
+++ b/releases/5_5_18.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_5_18.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.5.18 Release Announcement");

--- a/releases/5_5_19.php
+++ b/releases/5_5_19.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_5_19.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.5.19 Release Announcement");

--- a/releases/5_5_2.php
+++ b/releases/5_5_2.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_5_2.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.5.2 Release Announcement");

--- a/releases/5_5_20.php
+++ b/releases/5_5_20.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_5_20.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.5.20 Release Announcement");

--- a/releases/5_5_21.php
+++ b/releases/5_5_21.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_5_21.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.5.21 Release Announcement");

--- a/releases/5_5_22.php
+++ b/releases/5_5_22.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_5_22.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.5.22 Release Announcement");

--- a/releases/5_5_23.php
+++ b/releases/5_5_23.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_5_23.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.5.23 Release Announcement");

--- a/releases/5_5_24.php
+++ b/releases/5_5_24.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_5_24.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.5.24 Release Announcement");

--- a/releases/5_5_25.php
+++ b/releases/5_5_25.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_5_25.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.5.25 Release Announcement");

--- a/releases/5_5_26.php
+++ b/releases/5_5_26.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_5_26.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.5.26 Release Announcement");

--- a/releases/5_5_27.php
+++ b/releases/5_5_27.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_5_27.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.5.27 Release Announcement");

--- a/releases/5_5_28.php
+++ b/releases/5_5_28.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_5_28.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.5.28 Release Announcement");

--- a/releases/5_5_29.php
+++ b/releases/5_5_29.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_5_29.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.5.29 Release Announcement");

--- a/releases/5_5_3.php
+++ b/releases/5_5_3.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_5_3.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.5.3 Release Announcement");

--- a/releases/5_5_30.php
+++ b/releases/5_5_30.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_5_30.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.5.30 Release Announcement");

--- a/releases/5_5_31.php
+++ b/releases/5_5_31.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_5_31.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.5.31 Release Announcement");

--- a/releases/5_5_32.php
+++ b/releases/5_5_32.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_5_32.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.5.32 Release Announcement");

--- a/releases/5_5_33.php
+++ b/releases/5_5_33.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_5_33.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.5.33 Release Announcement");

--- a/releases/5_5_34.php
+++ b/releases/5_5_34.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_5_34.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.5.34 Release Announcement");

--- a/releases/5_5_35.php
+++ b/releases/5_5_35.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_5_35.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.5.35 Release Announcement");

--- a/releases/5_5_36.php
+++ b/releases/5_5_36.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_5_36.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.5.36 Release Announcement");

--- a/releases/5_5_37.php
+++ b/releases/5_5_37.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_5_37.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.5.37 Release Announcement");

--- a/releases/5_5_38.php
+++ b/releases/5_5_38.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_5_38.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.5.38 Release Announcement");

--- a/releases/5_5_4.php
+++ b/releases/5_5_4.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_5_4.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.5.4 Release Announcement");

--- a/releases/5_5_5.php
+++ b/releases/5_5_5.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_5_5.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.5.5 Release Announcement");

--- a/releases/5_5_6.php
+++ b/releases/5_5_6.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_5_6.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.5.6 Release Announcement");

--- a/releases/5_5_7.php
+++ b/releases/5_5_7.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_5_7.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.5.7 Release Announcement");

--- a/releases/5_5_8.php
+++ b/releases/5_5_8.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_5_8.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.5.7 Release Announcement");

--- a/releases/5_5_9.php
+++ b/releases/5_5_9.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_5_9.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.5.9 Release Announcement");

--- a/releases/5_6_0.php
+++ b/releases/5_6_0.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_6_0.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.6.0 Release Announcement");

--- a/releases/5_6_1.php
+++ b/releases/5_6_1.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_6_1.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.6.1 Release Announcement");

--- a/releases/5_6_10.php
+++ b/releases/5_6_10.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_6_10.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.6.10 Release Announcement");

--- a/releases/5_6_11.php
+++ b/releases/5_6_11.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_6_11.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.6.11 Release Announcement");

--- a/releases/5_6_12.php
+++ b/releases/5_6_12.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_6_12.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.6.12 Release Announcement");

--- a/releases/5_6_13.php
+++ b/releases/5_6_13.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_6_13.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.6.13 Release Announcement");

--- a/releases/5_6_14.php
+++ b/releases/5_6_14.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_6_14.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.6.14 Release Announcement");

--- a/releases/5_6_15.php
+++ b/releases/5_6_15.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_6_15.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.6.15 Release Announcement");

--- a/releases/5_6_16.php
+++ b/releases/5_6_16.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_6_16.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.6.15 Release Announcement");

--- a/releases/5_6_17.php
+++ b/releases/5_6_17.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_6_17.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.6.17 Release Announcement");

--- a/releases/5_6_18.php
+++ b/releases/5_6_18.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_6_18.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.6.18 Release Announcement");

--- a/releases/5_6_19.php
+++ b/releases/5_6_19.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_6_19.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.6.19 Release Announcement");

--- a/releases/5_6_2.php
+++ b/releases/5_6_2.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_6_2.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.6.2 Release Announcement");

--- a/releases/5_6_20.php
+++ b/releases/5_6_20.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_6_20.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.6.20 Release Announcement");

--- a/releases/5_6_21.php
+++ b/releases/5_6_21.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_6_21.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.6.21 Release Announcement");

--- a/releases/5_6_22.php
+++ b/releases/5_6_22.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_6_22.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.6.22 Release Announcement");

--- a/releases/5_6_23.php
+++ b/releases/5_6_23.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_6_23.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.6.23 Release Announcement");

--- a/releases/5_6_24.php
+++ b/releases/5_6_24.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_6_24.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.6.24 Release Announcement");

--- a/releases/5_6_25.php
+++ b/releases/5_6_25.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_6_25.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.6.25 Release Announcement");

--- a/releases/5_6_26.php
+++ b/releases/5_6_26.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_6_26.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.6.26 Release Announcement");

--- a/releases/5_6_27.php
+++ b/releases/5_6_27.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_6_27.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.6.27 Release Announcement");

--- a/releases/5_6_28.php
+++ b/releases/5_6_28.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_6_28.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.6.28 Release Announcement");

--- a/releases/5_6_29.php
+++ b/releases/5_6_29.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_6_29.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.6.29 Release Announcement");

--- a/releases/5_6_3.php
+++ b/releases/5_6_3.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_6_3.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.6.3 Release Announcement");

--- a/releases/5_6_30.php
+++ b/releases/5_6_30.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_6_30.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.6.30 Release Announcement");

--- a/releases/5_6_31.php
+++ b/releases/5_6_31.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_6_31.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.6.31 Release Announcement");

--- a/releases/5_6_32.php
+++ b/releases/5_6_32.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_6_32.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.6.32 Release Announcement");

--- a/releases/5_6_33.php
+++ b/releases/5_6_33.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_6_33.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.6.33 Release Announcement");

--- a/releases/5_6_34.php
+++ b/releases/5_6_34.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_6_34.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.6.34 Release Announcement");

--- a/releases/5_6_35.php
+++ b/releases/5_6_35.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_6_35.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.6.35 Release Announcement");

--- a/releases/5_6_36.php
+++ b/releases/5_6_36.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_6_36.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.6.36 Release Announcement");

--- a/releases/5_6_4.php
+++ b/releases/5_6_4.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_6_4.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.6.4 Release Announcement");

--- a/releases/5_6_5.php
+++ b/releases/5_6_5.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_6_5.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.6.5 Release Announcement");

--- a/releases/5_6_6.php
+++ b/releases/5_6_6.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_6_6.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.6.6 Release Announcement");

--- a/releases/5_6_7.php
+++ b/releases/5_6_7.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_6_7.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.6.7 Release Announcement");

--- a/releases/5_6_8.php
+++ b/releases/5_6_8.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_6_8.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.6.8 Release Announcement");

--- a/releases/5_6_9.php
+++ b/releases/5_6_9.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/5_6_9.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 5.6.9 Release Announcement");

--- a/releases/7_0_1.php
+++ b/releases/7_0_1.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/7_0_1.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 7.0.1 Release Announcement");

--- a/releases/7_0_10.php
+++ b/releases/7_0_10.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/7_0_10.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 7.0.10 Release Announcement");

--- a/releases/7_0_11.php
+++ b/releases/7_0_11.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/7_0_11.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 7.0.11 Release Announcement");

--- a/releases/7_0_12.php
+++ b/releases/7_0_12.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/7_0_12.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 7.0.12 Release Announcement");

--- a/releases/7_0_13.php
+++ b/releases/7_0_13.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/7_0_13.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 7.0.13 Release Announcement");

--- a/releases/7_0_14.php
+++ b/releases/7_0_14.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/7_0_14.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 7.0.14 Release Announcement");

--- a/releases/7_0_15.php
+++ b/releases/7_0_15.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/7_0_15.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 7.0.15 Release Announcement");

--- a/releases/7_0_16.php
+++ b/releases/7_0_16.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/7_0_16.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 7.0.16 Release Announcement");

--- a/releases/7_0_17.php
+++ b/releases/7_0_17.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/7_0_17.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 7.0.17 Release Announcement");

--- a/releases/7_0_18.php
+++ b/releases/7_0_18.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/7_0_18.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 7.0.18 Release Announcement");

--- a/releases/7_0_19.php
+++ b/releases/7_0_19.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/7_0_19.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 7.0.19 Release Announcement");

--- a/releases/7_0_2.php
+++ b/releases/7_0_2.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/7_0_2.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 7.0.2 Release Announcement");

--- a/releases/7_0_20.php
+++ b/releases/7_0_20.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/7_0_20.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 7.0.20 Release Announcement");

--- a/releases/7_0_21.php
+++ b/releases/7_0_21.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/7_0_21.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 7.0.21 Release Announcement");

--- a/releases/7_0_22.php
+++ b/releases/7_0_22.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/7_0_22.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 7.0.22 Release Announcement");

--- a/releases/7_0_23.php
+++ b/releases/7_0_23.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/7_0_23.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 7.0.23 Release Announcement");

--- a/releases/7_0_24.php
+++ b/releases/7_0_24.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/7_0_24.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 7.0.24 Release Announcement");

--- a/releases/7_0_25.php
+++ b/releases/7_0_25.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/7_0_25.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 7.0.25 Release Announcement");

--- a/releases/7_0_26.php
+++ b/releases/7_0_26.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/7_0_26.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 7.0.26 Release Announcement");

--- a/releases/7_0_27.php
+++ b/releases/7_0_27.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/7_0_27.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 7.0.27 Release Announcement");

--- a/releases/7_0_28.php
+++ b/releases/7_0_28.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/7_0_28.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 7.0.28 Release Announcement");

--- a/releases/7_0_29.php
+++ b/releases/7_0_29.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/7_0_29.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 7.0.29 Release Announcement");

--- a/releases/7_0_3.php
+++ b/releases/7_0_3.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/7_0_3.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 7.0.3 Release Announcement");

--- a/releases/7_0_30.php
+++ b/releases/7_0_30.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/7_0_30.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 7.0.30 Release Announcement");

--- a/releases/7_0_4.php
+++ b/releases/7_0_4.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/7_0_4.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 7.0.4 Release Announcement");

--- a/releases/7_0_5.php
+++ b/releases/7_0_5.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/7_0_5.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 7.0.5 Release Announcement");

--- a/releases/7_0_6.php
+++ b/releases/7_0_6.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/7_0_6.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 7.0.6 Release Announcement");

--- a/releases/7_0_7.php
+++ b/releases/7_0_7.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/7_0_7.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 7.0.7 Release Announcement");

--- a/releases/7_0_8.php
+++ b/releases/7_0_8.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/7_0_8.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 7.0.8 Release Announcement");

--- a/releases/7_0_9.php
+++ b/releases/7_0_9.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/7_0_9.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 7.0.9 Release Announcement");

--- a/releases/7_1_0.php
+++ b/releases/7_1_0.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/7_1_0.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 7.1.0 Release Announcement");

--- a/releases/7_1_1.php
+++ b/releases/7_1_1.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/7_1_1.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 7.1.1 Release Announcement");

--- a/releases/7_1_10.php
+++ b/releases/7_1_10.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/7_1_10.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 7.1.10 Release Announcement");

--- a/releases/7_1_11.php
+++ b/releases/7_1_11.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/7_1_11.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 7.1.11 Release Announcement");

--- a/releases/7_1_12.php
+++ b/releases/7_1_12.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/7_1_12.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 7.1.12 Release Announcement");

--- a/releases/7_1_13.php
+++ b/releases/7_1_13.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/7_1_13.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 7.1.13 Release Announcement");

--- a/releases/7_1_14.php
+++ b/releases/7_1_14.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/7_1_14.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 7.1.14 Release Announcement");

--- a/releases/7_1_15.php
+++ b/releases/7_1_15.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/7_1_15.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 7.1.15 Release Announcement");

--- a/releases/7_1_16.php
+++ b/releases/7_1_16.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/7_1_16.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 7.1.16 Release Announcement");

--- a/releases/7_1_17.php
+++ b/releases/7_1_17.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/7_1_17.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 7.1.17 Release Announcement");

--- a/releases/7_1_18.php
+++ b/releases/7_1_18.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/7_1_18.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 7.1.18 Release Announcement");

--- a/releases/7_1_19.php
+++ b/releases/7_1_19.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/7_1_19.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 7.1.19 Release Announcement");

--- a/releases/7_1_2.php
+++ b/releases/7_1_2.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/7_1_2.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 7.1.2 Release Announcement");

--- a/releases/7_1_3.php
+++ b/releases/7_1_3.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/7_1_2.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 7.1.3 Release Announcement");

--- a/releases/7_1_4.php
+++ b/releases/7_1_4.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/7_1_4.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 7.1.4 Release Announcement");

--- a/releases/7_1_5.php
+++ b/releases/7_1_5.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/7_1_5.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 7.1.5 Release Announcement");

--- a/releases/7_1_6.php
+++ b/releases/7_1_6.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/7_1_6.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 7.1.6 Release Announcement");

--- a/releases/7_1_7.php
+++ b/releases/7_1_7.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/7_1_7.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 7.1.7 Release Announcement");

--- a/releases/7_1_8.php
+++ b/releases/7_1_8.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/7_1_8.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 7.1.8 Release Announcement");

--- a/releases/7_1_9.php
+++ b/releases/7_1_9.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/7_1_9.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 7.1.9 Release Announcement");

--- a/releases/7_2_0.php
+++ b/releases/7_2_0.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/7_2_0.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 7.2.0 Release Announcement");

--- a/releases/7_2_1.php
+++ b/releases/7_2_1.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/7_2_1.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 7.2.1 Release Announcement");

--- a/releases/7_2_2.php
+++ b/releases/7_2_2.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/7_2_2.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 7.2.2 Release Announcement");

--- a/releases/7_2_3.php
+++ b/releases/7_2_3.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/7_2_3.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 7.2.3 Release Announcement");

--- a/releases/7_2_4.php
+++ b/releases/7_2_4.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/7_2_4.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 7.2.4 Release Announcement");

--- a/releases/7_2_5.php
+++ b/releases/7_2_5.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/7_2_5.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 7.2.5 Release Announcement");

--- a/releases/7_2_6.php
+++ b/releases/7_2_6.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/7_2_6.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 7.2.6 Release Announcement");

--- a/releases/7_2_7.php
+++ b/releases/7_2_7.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/7_2_7.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP 7.2.7 Release Announcement");

--- a/releases/index.php
+++ b/releases/index.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'releases/index.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 include_once $_SERVER["DOCUMENT_ROOT"] . "/include/branches.inc";

--- a/results.php
+++ b/results.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'results.php';
 include $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 include $_SERVER['DOCUMENT_ROOT'] . '/include/results.inc';

--- a/search.php
+++ b/search.php
@@ -1,5 +1,4 @@
 <?php // vim: et
-// $Id$
 $_SERVER['BASE_PAGE'] = 'search.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 

--- a/security-note.php
+++ b/security-note.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'security-note.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("A Note on Security in PHP", array("current" => "docs"));

--- a/security/crypt_blowfish.php
+++ b/security/crypt_blowfish.php
@@ -1,5 +1,4 @@
 <?php
-// $Id: index.php 230994 2007-03-01 17:10:22Z bjori $
 $_SERVER['BASE_PAGE'] = 'security/index.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 

--- a/security/index.php
+++ b/security/index.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'security/index.php';
 
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';

--- a/sitemap.php
+++ b/sitemap.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'sitemap.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("Sitemap", array("current" => "help"));

--- a/software.php
+++ b/software.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'software.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("PHP Software", array("current" => "help"));

--- a/stats/index.php
+++ b/stats/index.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 /*
  This page is displayed if there is no alias to
  override the stats directory distributed by rsync,

--- a/styles/index.php
+++ b/styles/index.php
@@ -1,6 +1,4 @@
 <?php
-// $Id$
-
 // Simulate a /styles shortcut call (which will lead to a manual page)
 $_SERVER['REQUEST_URI'] = '/styles';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';

--- a/submit-event.php
+++ b/submit-event.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'submit-event.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/posttohost.inc';

--- a/support.php
+++ b/support.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'support.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 

--- a/thanks.php
+++ b/thanks.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'thanks.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 site_header("Thanks", array("current" => "community"));

--- a/ug.php
+++ b/ug.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'ug.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 

--- a/unsub.php
+++ b/unsub.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'unsub.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 $SIDEBAR_DATA = '

--- a/urlhowto.php
+++ b/urlhowto.php
@@ -1,5 +1,4 @@
 <?php
-// $Id$
 $_SERVER['BASE_PAGE'] = 'urlhowto.php';
 include_once $_SERVER['DOCUMENT_ROOT'] . '/include/prepend.inc';
 


### PR DESCRIPTION
Hello,

The `$Id$` keywords were used in Subversion where they can be substituted with filename, last revision number change, last changed date, and last user who changed it.

In Git this functionality is different and can be done with Git attribute ident. These need to be defined manually for each file in the `.gitattributes` file and are afterwards replaced with 40-character
hexadecimal blob object name which is based only on the particular file contents.

This patch simplifies handling of `$Id$` keywords by removing them since they are not used anymore.