### PR TITLE
Update Autoconf version requirements on Git page

### DIFF
--- a/git.php
+++ b/git.php
@@ -44,7 +44,12 @@ site_header("Git Access", array("current" => "community"));
 </p>
 
 <ul>
- <li><i>autoconf</i>: 2.59+</li>
+ <li><i>autoconf</i>:
+  <ul>
+   <li><i>PHP 5.4 - 7.1</i>: 2.59+</li>
+   <li><i>PHP 7.2</i>: 2.64+</li>
+  </ul>
+ </li>
  <li><i>automake</i>: 1.4+</li>
  <li><i>libtool</i>: 1.4.x+ (except 1.4.2)</li>
  <li><i>re2c</i>: 0.13.4+</li>


### PR DESCRIPTION
Hello, the [Git page](http://php.net/git.php) mentions which autotools versions are required to successfully build PHP.

For PHP 5.4 to 7.1, Autoconf 2.59 or newer is required. For PHP 7.2 Autoconf 2.64 or newer is required.

This patch refreshes that a bit according to current state.