### PR TITLE
Remove unused .cvsignore file

### DIFF
--- a/backend/.cvsignore
+++ b/backend/.cvsignore
@@ -1,3 +1,0 @@
-mirror.gif
-mirror.png
-mirror.jpg


### PR DESCRIPTION
The `.cvsignore` file in backend folder has been replaced with `.gitignore` with migration to Git.