### PR TITLE
Fixed the vertical align of "supported versions" chart

### DIFF
--- a/images/supported-versions.php
+++ b/images/supported-versions.php
@@ -91,7 +91,7 @@ $height = $header_height + $footer_height + (count($branches) * $branch_height);
 			}
 
 			.branch-labels text {
-				alignment-baseline: central;
+				dominant-baseline: central;
 				text-anchor: middle;
 			}
 


### PR DESCRIPTION
The chart in http://php.net/supported-versions.php has a minor issue in Firefox. The version labels are not vertically aligned.

## Before (Chrome, Firefox, Safari)
![before](https://user-images.githubusercontent.com/73419/43416198-e9221344-9437-11e8-8a65-775a72aad39a.png)

## After (Chrome, Firefox, Safari)
![after](https://user-images.githubusercontent.com/73419/43416201-ebc72cd8-9437-11e8-8211-092bb13fbf31.png)
