### PR TITLE
Fix search bar under https://secure.php.net site

### DIFF
--- a/include/footer.inc
+++ b/include/footer.inc
@@ -88,7 +88,7 @@
  $jsfiles = array("ext/modernizr.js", "ext/hogan-2.0.0.min.js", "ext/typeahead.min.js", "ext/mousetrap.min.js", "search.js", "common.js");
  foreach ($jsfiles as $filename) {
    $path = dirname(dirname(__FILE__)).'/js/'.$filename;
-   echo '<script type="text/javascript" src="' . $MYSITE . 'cached.php?t=' . @filemtime($path) . '&amp;f=/js/' . $filename . '"></script>'."\n";
+   echo '<script type="text/javascript" src="/cached.php?t=' . @filemtime($path) . '&amp;f=/js/' . $filename . '"></script>'."\n";
  }
 ?>
 

--- a/include/header.inc
+++ b/include/header.inc
@@ -80,7 +80,7 @@ if (!isset($config["languages"])) {
 <?php endforeach ?>
 
 <?php foreach($CSS as $filename => $modified): ?>
-<link rel="stylesheet" type="text/css" href="<?php echo $MYSITE ?>cached.php?t=<?php echo $modified?>&amp;f=<?php echo $filename?>" media="screen">
+<link rel="stylesheet" type="text/css" href="/cached.php?t=<?php echo $modified?>&amp;f=<?php echo $filename?>" media="screen">
 <?php endforeach ?>
 
  <!--[if lte IE 7]>


### PR DESCRIPTION
Due to whatever configuration difficulty you haven't solved on the site for several years now, the search bar only works in the non-https version. Browsers block the scripts because of CORS protections. This should solve that problem.