### PR TITLE
Update Autoconf requirement for PHP-7.3 on Git page

### DIFF
--- a/git.php
+++ b/git.php
@@ -48,6 +48,7 @@ site_header("Git Access", array("current" => "community"));
   <ul>
    <li><i>PHP 5.4 - 7.1</i>: 2.59+</li>
    <li><i>PHP 7.2</i>: 2.64+</li>
+   <li><i>PHP 7.3</i>: 2.68+</li>
   </ul>
  </li>
  <li><i>automake</i>: 1.4+</li>


### PR DESCRIPTION
For PHP-7.3 the minimum required Autoconf version is 2.68 and above.

Pathed in http://git.php.net/?p=php-src.git;a=commit;h=0b0d4b5f0d5de7d3172e995c34e951790fedafb5

Related to discussion at https://github.com/php/php-src/pull/3562

Thank you.