### PR TITLE
Remove automake as a dependency to build PHP

### DIFF
--- a/git.php
+++ b/git.php
@@ -50,7 +50,6 @@ site_header("Git Access", array("current" => "community"));
    <li><i>PHP 7.3</i>: 2.68+</li>
   </ul>
  </li>
- <li><i>automake</i>: 1.4+</li>
  <li><i>libtool</i>: 1.4.x+ (except 1.4.2)</li>
  <li><i>re2c</i>: 0.13.4+</li>
  <li id="bison"><i>bison</i>:
@@ -124,7 +123,7 @@ site_header("Git Access", array("current" => "community"));
 
  <li>
   <div class="tip" style="margin: 10px 0 10px 20px;">
-   <p>Note that certain combinations of autoconf, automake and libtool may not
+   <p>Note that certain combinations of autoconf and libtool may not
    work when used together, particularly with historical versions of PHP. See
    <a href="#buildconf_fail">below</a> for details.<br>
    Also, certain versions of autoconf may generate warnings of <code>AC_PROG_CPP
@@ -174,7 +173,7 @@ site_header("Git Access", array("current" => "community"));
 
 <h2>Historical issues</h2>
 
-<h3 id="buildconf_fail">autoconf, automake and libtool information for PHP 5.3 and below</h3>
+<h3 id="buildconf_fail">autoconf and libtool information for PHP 5.3 and below</h3>
 
 <p>
  There seem to be problems with libtool 1.4.2. It is suggested
@@ -189,6 +188,8 @@ site_header("Git Access", array("current" => "community"));
  <li>autoconf 2.13, automake 1.4 and libtool 1.4.3</li>
  <li>autoconf 2.13, automake 1.5 and libtool 1.4.3</li>
 </ul>
+
+<p>Since PHP 4.3 automake and its aclocal program are no longer needed to build PHP.</p>
 
 <p>
  If you have multiple versions of autoconf installed on your computer, as is


### PR DESCRIPTION
The Automake and aclocal were part of the previous PHP build system
where Automake created Makefile from the Makefile.in templates and
aclocal was used to produce the aclocal.m4. Need for Automake as a
dependency to build PHP has been removed in PHP 4.3.0 release and
aclocal also in that period of 4.3 releases.

Refs:
- http://php.net/ChangeLog-4.php
- http://git.php.net/?p=php-src.git;h=e715fb00f8850990d51cee4e08e84a58f0eb0012
- http://git.php.net/?p=php-src.git;h=9d9d39a0de3bec962c343051011f5a2ed7d7b242