### PR TITLE
Bump minimum PHP requirement for php.net sites to 5.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,5 +24,5 @@ To install a full official mirror please see [the mirroring guidelines](http://p
 
 ## Code requirements
 
-Code must function on a vanilla PHP 5.3 installation as some php.net mirrors still run PHP 5.3.
+Code must function on a vanilla PHP 5.4 installation as some php.net mirrors still run PHP 5.4.
 Please keep this in mind before filing a pull request.

--- a/mirroring.php
+++ b/mirroring.php
@@ -51,7 +51,7 @@ site_header(
 </p>
 
 <p>
- Official mirror program participants are required to use PHP 5.3.21 or
+ Official mirror program participants are required to use PHP 5.4 or
  greater, but please note that we encourage maintainers to always use the
  latest stable versions of actively-developed branches.  Please note that
  we do, somewhat regularly (about once per year) require existing


### PR DESCRIPTION
Currently all mirrors already use at least 5.4 versions and also the code in the repository already uses 5.4 syntax in some places, such as `releases/feed.php` file with `__DIR__` constant.

This patch syncs this state a bit.