### PR TITLE
Bug #72707: Filter releases by minor or patch version

### DIFF
--- a/include/branches.inc
+++ b/include/branches.inc
@@ -358,8 +358,6 @@ function compare_version($arrayA, $versionB)
 
 function version_array($version, $length = null)
 {
-	static $fill = array(0, 0);
-
 	$versionArray = array_map(
 		'intval',
 		explode('.', $version)

--- a/include/branches.inc
+++ b/include/branches.inc
@@ -359,24 +359,21 @@ function compare_version($arrayA, $versionB)
 function version_array($version, $length = null)
 {
 	static $fill = array(0, 0);
+
 	$versionArray = array_map(
 		'intval',
 		explode('.', $version)
 	);
-	if (is_int($length)) {
-		$versionArray = array_merge(
-			$versionArray,
-			$fill
-		);
-	} else {
-		$length = 3;
-	}
 
-	array_slice(
-		$versionArray,
-		0,
-		$length
-	);
+	if (is_int($length)) {
+		$versionArray = count($versionArray) < $length
+			? array_pad($versionArray, $length, 0)
+			: array_slice(
+				$versionArray,
+				0,
+				$length
+			);
+	}
 
 	return $versionArray;
 }

--- a/include/branches.inc
+++ b/include/branches.inc
@@ -330,3 +330,53 @@ function get_branch_support_state($branch) {
 
 	return null;
 }
+
+function compare_version($arrayA, $versionB)
+{
+	static $sortValues = array(
+		true => 1,
+		false => -1,
+	);
+
+	$length = count($arrayA);
+	$arrayB = version_array($versionB, $length);
+
+	if (!is_array($arrayA) || !is_array($arrayB)) {
+		return $sortValues[$arrayA > $arrayB];
+	}
+
+	foreach ($arrayA as $index => $componentA) {
+		$componentA = $arrayA[$index];
+		$componentB = $arrayB[$index];
+		if ($componentA != $componentB) {
+			return $sortValues[$componentA > $componentB];
+		}
+	}
+
+	return 0;
+}
+
+function version_array($version, $length = null)
+{
+	static $fill = array(0, 0);
+	$versionArray = array_map(
+		'intval',
+		explode('.', $version)
+	);
+	if (is_int($length)) {
+		$versionArray = array_merge(
+			$versionArray,
+			$fill
+		);
+	} else {
+		$length = 3;
+	}
+
+	array_slice(
+		$versionArray,
+		0,
+		$length
+	);
+
+	return $versionArray;
+}

--- a/releases/index.php
+++ b/releases/index.php
@@ -10,7 +10,9 @@ if (isset($_GET["serialize"]) || isset($_GET["json"])) {
 	$machineReadable = array();
 
 	if (isset($_GET["version"])) {
-		$ver = (int)$_GET["version"];
+		$versionArray = version_array($_GET["version"]);
+		$ver = $versionArray[0];
+		$length = count($versionArray);
 
 		if (isset($RELEASES[$ver])) {
 			$RELEASES = array_replace_recursive($RELEASES, $OLDRELEASES);
@@ -30,13 +32,15 @@ if (isset($_GET["serialize"]) || isset($_GET["json"])) {
 			$machineReadable = array();
 
 			$count = 0;
-
 			foreach ($RELEASES[$ver] as $version => $release) {
-				if ($max <= $count++) {
+				if ($max <= $count) {
 					break;
 				}
 
-				$machineReadable[$version] = $release;
+				if (compare_version($versionArray, $version) == 0) {
+					$machineReadable[$version] = $release;
+					$count++;
+				}
 			}
 
 			if (!$maxSet) {

--- a/releases/index.php
+++ b/releases/index.php
@@ -12,7 +12,6 @@ if (isset($_GET["serialize"]) || isset($_GET["json"])) {
 	if (isset($_GET["version"])) {
 		$versionArray = version_array($_GET["version"]);
 		$ver = $versionArray[0];
-		$length = count($versionArray);
 
 		if (isset($RELEASES[$ver])) {
 			$RELEASES = array_replace_recursive($RELEASES, $OLDRELEASES);

--- a/releases/index.php
+++ b/releases/index.php
@@ -28,8 +28,6 @@ if (isset($_GET["serialize"]) || isset($_GET["json"])) {
 				$max = PHP_INT_MAX;
 			}
 
-
-
 			$count = 0;
 			foreach ($RELEASES[$ver] as $version => $release) {
 				if ($max <= $count) {

--- a/releases/index.php
+++ b/releases/index.php
@@ -14,7 +14,7 @@ if (isset($_GET["serialize"]) || isset($_GET["json"])) {
 		$ver = $versionArray[0];
 
 		if (isset($RELEASES[$ver])) {
-			$RELEASES = array_replace_recursive($RELEASES, $OLDRELEASES);
+			$combinedReleases = array_replace_recursive($RELEASES, $OLDRELEASES);
 
 			if (isset($_GET["max"])) {
 				$max = (int)$_GET["max"];
@@ -29,7 +29,7 @@ if (isset($_GET["serialize"]) || isset($_GET["json"])) {
 			}
 
 			$count = 0;
-			foreach ($RELEASES[$ver] as $version => $release) {
+			foreach ($combinedReleases[$ver] as $version => $release) {
 				if ($max <= $count) {
 					break;
 				}

--- a/releases/index.php
+++ b/releases/index.php
@@ -28,7 +28,7 @@ if (isset($_GET["serialize"]) || isset($_GET["json"])) {
 				$max = PHP_INT_MAX;
 			}
 
-			$machineReadable = array();
+
 
 			$count = 0;
 			foreach ($RELEASES[$ver] as $version => $release) {
@@ -47,11 +47,12 @@ if (isset($_GET["serialize"]) || isset($_GET["json"])) {
 				$machineReadable = current($machineReadable);
 				$machineReadable["version"] = $version;
 			}
-		} else {
+		}
+
+		if (empty($machineReadable)) {
 			$machineReadable = array("error" => "Unknown version");
 		}
 	} else {
-		$machineReadable = array();
 		foreach($RELEASES as $major => $release) {
 			list($version, $r) = each($release);
 			$r["version"] = $version;

--- a/releases/index.php
+++ b/releases/index.php
@@ -13,33 +13,36 @@ if (isset($_GET["serialize"]) || isset($_GET["json"])) {
 		$ver = (int)$_GET["version"];
 
 		if (isset($RELEASES[$ver])) {
-			list($version, $r) = each($RELEASES[$ver]);
+			$RELEASES = array_replace_recursive($RELEASES, $OLDRELEASES);
 
 			if (isset($_GET["max"])) {
 				$max = (int)$_GET["max"];
-				if ($max == -1) { $max = PHP_INT_MAX; }
-
-				$machineReadable = array($version => $r);
-
-				$count = 1;
-
-				/* check if other $RELEASES[$ver] are there */
-				/* e.g., 5_3, 5_4, and 5_5 all exist and have a release */
-				while(($z = each($RELEASES[$ver])) && $count++ < $max) {
-					$machineReadable[$z[0]] = $z[1];
-				}
-
-				foreach($OLDRELEASES[$ver] as $version => $release) {
-					if ($max <= $count++) {
-						break;
-					}
-
-					$machineReadable[$version] = $release;
-				}
+				$maxSet = true;
 			} else {
-				$r["version"] = $version;
+				$max = 1;
+				$maxSet = false;
+			}
 
-				$machineReadable = $r;
+			if ($max == -1) {
+				$max = PHP_INT_MAX;
+			}
+
+			$machineReadable = array();
+
+			$count = 0;
+
+			foreach ($RELEASES[$ver] as $version => $release) {
+				if ($max <= $count++) {
+					break;
+				}
+
+				$machineReadable[$version] = $release;
+			}
+
+			if (!$maxSet) {
+				$version = key($machineReadable);
+				$machineReadable = current($machineReadable);
+				$machineReadable["version"] = $version;
 			}
 		} else {
 			$machineReadable = array("error" => "Unknown version");

--- a/releases/index.php
+++ b/releases/index.php
@@ -40,7 +40,7 @@ if (isset($_GET["serialize"]) || isset($_GET["json"])) {
 				}
 			}
 
-			if (!$maxSet) {
+			if (!$maxSet && !empty($machineReadable)) {
 				$version = key($machineReadable);
 				$machineReadable = current($machineReadable);
 				$machineReadable["version"] = $version;


### PR DESCRIPTION
Before: https://secure.php.net/releases/index.php?json&version=7.1&max=10 returns all version 7 releases, minor version ignored.

After: https://secure.php.net/releases/index.php?json&version=7.1&max=10 only returns version 7.1 releases.

Also after: https://secure.php.net/releases/index.php?json&version=7.1.22 returns version 7.1.22 only.

Existing functionality (e.g., filtering by major versions like 4, 5, 7, etc.) should be unaffected.