### PR TITLE
Correct 7.1.23 release date

### DIFF
--- a/include/releases.inc
+++ b/include/releases.inc
@@ -32,7 +32,7 @@ $OLDRELEASES = array (
           'date' => '11 Oct 2018',
         ),
       ),
-      'date' => '08 Nov 2018',
+      'date' => '11 Oct 2018',
       'museum' => false,
     ),
     '7.2.11' => 


### PR DESCRIPTION
I think 7.1.23 release date was wrong on [http://php.net/releases/](http://php.net/releases/)