### PR TITLE
Add Laracon Online 2019 to conference list

### DIFF
--- a/archive/archive.xml
+++ b/archive/archive.xml
@@ -9,6 +9,7 @@
     <uri>http://php.net/contact</uri>
     <email>php-webmaster@lists.php.net</email>
   </author>
+  <xi:include href="entries/2019-01-22-1.xml"/>
   <xi:include href="entries/2019-01-15-1.xml"/>
   <xi:include href="entries/2019-01-10-4.xml"/>
   <xi:include href="entries/2019-01-10-3.xml"/>

--- a/archive/entries/2019-01-22-1.xml
+++ b/archive/entries/2019-01-22-1.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<entry xmlns="http://www.w3.org/2005/Atom" xmlns:default="http://php.net/ns/news">
+  <title>Laracon Online</title>
+  <id>http://php.net/archive/2019.php#id2019-01-22-1</id>
+  <published>2019-01-22T02:42:11+00:00</published>
+  <updated>2019-01-22T02:42:11+00:00</updated>
+  <default:finalTeaserDate xmlns="http://php.net/ns/news">2019-03-06</default:finalTeaserDate>
+  <category term="conferences" label="Conference announcement"/>
+  <link href="http://php.net/conferences/index.php#id2019-01-22-1" rel="alternate" type="text/html"/>
+  <link href="http://php.net/archive/2019.php#id2019-01-22-1" rel="via" type="text/html"/>
+  <content type="xhtml">
+    <div xmlns="http://www.w3.org/1999/xhtml">
+        <p><a href="https://laracon.net">Laracon Online</a> is the easiest and most affordable way to get the Laracon experience from anywhere in the world. </p>
+     
+     <p>We’ve put together a full day of talks featuring some of Laravel’s brightest minds, and streaming them directly to your home or office.</p>
+     
+     <p>These talks are brand new, never before presented at any Laracon and tickets are just $12 during early registration. Don't miss the largest Laravel event ever!</p>
+    </div>
+  </content>
+</entry>


### PR DESCRIPTION
This PR adds [Laracon Online](https://laracon.net) to the conference news list. 