### PR TITLE
Add Midwest PHP 2019 to Conferences

### DIFF
--- a/archive/archive.xml
+++ b/archive/archive.xml
@@ -9,6 +9,7 @@
     <uri>http://php.net/contact</uri>
     <email>php-webmaster@lists.php.net</email>
   </author>
+  <xi:include href="entries/2019-02-06-1.xml"/>
   <xi:include href="entries/2019-02-01-1.xml"/>
   <xi:include href="entries/2019-01-31-1.xml"/>
   <xi:include href="entries/2019-01-29-1.xml"/>

--- a/archive/entries/2019-02-06-1.xml
+++ b/archive/entries/2019-02-06-1.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<entry xmlns="http://www.w3.org/2005/Atom" xmlns:default="http://php.net/ns/news">
+  <title>Midwest PHP 2019</title>
+  <id>http://php.net/archive/2019.php#id2019-02-06-1</id>
+  <published>2019-02-06T11:22:01+00:00</published>
+  <updated>2019-02-06T11:22:01+00:00</updated>
+  <default:finalTeaserDate xmlns="http://php.net/ns/news">2019-03-08</default:finalTeaserDate>
+  <category term="conferences" label="Conference announcement"/>
+  <link href="http://php.net/conferences/index.php#id2019-02-06-1" rel="alternate" type="text/html"/>
+  <default:newsImage xmlns="http://php.net/ns/news" link="https://2019.midwestphp.org" title="Midwest PHP Conference">midwest-php-logo.png</default:newsImage>
+  <link href="https://2019.midwestphp.org" rel="via" type="text/html"/>
+  <content type="xhtml">
+    <div xmlns="http://www.w3.org/1999/xhtml">
+     The Midwest PHP Conference is hosted by the Minnesota PHP User Group community through the North Foundation in Bloomington, Minnesota from March 8th - 9th, 2019. This is our seventh year and each year the conference continues to become better. Our goal is to share best practices, ideas, and techniques about building state-of-the-art software applications.
+
+     The conference is at the Radisson Blu Mall of America in Bloomington, Minnesota. We can't think of a better place to connect with friends, old and new, than in a relaxed environment with entertainment at your front door, and inspiring talks from people doing amazing things.
+    </div>
+  </content>
+</entry>

--- a/archive/entries/2019-02-06-1.xml
+++ b/archive/entries/2019-02-06-1.xml
@@ -11,9 +11,8 @@
   <link href="https://2019.midwestphp.org" rel="via" type="text/html"/>
   <content type="xhtml">
     <div xmlns="http://www.w3.org/1999/xhtml">
-     The Midwest PHP Conference is hosted by the Minnesota PHP User Group community through the North Foundation in Bloomington, Minnesota from March 8th - 9th, 2019. This is our seventh year and each year the conference continues to become better. Our goal is to share best practices, ideas, and techniques about building state-of-the-art software applications.
-
-     The conference is at the Radisson Blu Mall of America in Bloomington, Minnesota. We can't think of a better place to connect with friends, old and new, than in a relaxed environment with entertainment at your front door, and inspiring talks from people doing amazing things.
+      <p>The Midwest PHP Conference is hosted by the Minnesota PHP User Group community through the North Foundation in Bloomington, Minnesota from March 8th - 9th, 2019. This is our seventh year and each year the conference continues to become better. Our goal is to share best practices, ideas, and techniques about building state-of-the-art software applications.</p>
+      <p>The conference is at the Radisson Blu Mall of America in Bloomington, Minnesota. We can't think of a better place to connect with friends, old and new, than in a relaxed environment with entertainment at your front door, and inspiring talks from people doing amazing things.</p>
     </div>
   </content>
 </entry>


### PR DESCRIPTION
Not much more to say here, added Midwest PHP Conference 2019 to the conferences listing.