### PR TITLE
Announce Bulgaria PHP Conference 2019 CFP

### DIFF
--- a/archive/archive.xml
+++ b/archive/archive.xml
@@ -9,6 +9,7 @@
     <uri>http://php.net/contact</uri>
     <email>php-webmaster@lists.php.net</email>
   </author>
+  <xi:include href="entries/2019-03-10-1.xml"/>
   <xi:include href="entries/2019-03-07-3.xml"/>
   <xi:include href="entries/2019-03-07-2.xml"/>
   <xi:include href="entries/2019-03-07-1.xml"/>

--- a/archive/entries/2019-03-10-1.xml
+++ b/archive/entries/2019-03-10-1.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<entry xmlns="http://www.w3.org/2005/Atom" xmlns:default="http://php.net/ns/news">
+  <title>Bulgaria PHP Conference 2019</title>
+  <id>http://php.net/archive/2019.php#id2019-03-10-1</id>
+  <published>2019-03-10T10:32:05+02:00</published>
+  <updated>2019-03-10T10:32:05+02:00</updated>
+  <default:finalTeaserDate xmlns="http://php.net/ns/news">2019-05-08</default:finalTeaserDate>
+  <category term="cfp" label="Call for Papers"/>
+  <link href="http://php.net/conferences/index.php#id2019-03-10-1" rel="alternate" type="text/html"/>
+  <default:newsImage xmlns="http://php.net/ns/news" link="https://www.bgphp.org/" title="Bulgaria PHP Conference 2019">bgphp-logo-dark-350.png</default:newsImage>
+  <link href="https://www.bgphp.org/" rel="via" type="text/html"/>
+  <content type="xhtml">
+    <div xmlns="http://www.w3.org/1999/xhtml">
+     <p>We are proud to announce the return of Bulgaria PHP Conference!</p>
+     <p>
+	 The 2019 edition will take place from the <strong>8th</strong> to the <strong>10th</strong> of <strong>November</strong>
+         in the emblematic National Palace of Culture in the heart of Sofia, Bulgaria.
+         The conference will consist of a training day and two conference days with two tracks,
+         an unConf, a great theme, an awesome party, exquisite food and lot's of beer (we take fun really seriously on the Balkans).
+     </p>
+     
+          <p>
+             Follow us on twitter <a href="https://twitter.com/bgphpconf">@bgphpconf</a>, on <a href="https://www.bgphp.org/">www.bgphp.org</a> and on our Facebook page <a href="https://www.facebook.com/Bulgaria-PHP-Conference-792916594079571">https://www.facebook.com/Bulgaria-PHP-Conference-792916594079571</a> for more news!
+         </p>
+     
+          <p>
+             Our <strong>Call for Papers</strong> is now <strong>open</strong>, so, please, do apply and see you in November in Bulgaria!
+         </p>
+     
+    </div>
+  </content>
+</entry>


### PR DESCRIPTION
Bulgaria PHP Conference 2019 opened their CFP, so it'd be great to have the conference listed under "Conferences calling for papers"

NOTE: There is an entry for the conference already under "Upcoming conferences". I am not sure how the process works, so I did not remove it. If I should, please, reject this PR and let me know that I should, so I can fix the situation and create a new one.