### PR TITLE
Redirect from inactive languages to EN (doc bug #77637)

### DIFF
--- a/error.php
+++ b/error.php
@@ -635,6 +635,17 @@ if (preg_match("!^manual/(.+)/function\.(.+)-(.+).php$!", $URI, $array)) {
     }
 }
 
+// ============================================================================
+// For manual pages for inactive languages, if the EN page exists, redirect there
+if (preg_match("!^manual/([^/]+)/([^/]+).php$!", $URI, $match) &&
+    isset($INACTIVE_ONLINE_LANGUAGES[$match[1]])) {
+    $try = find_manual_page("en", $match[2]);
+    if ($try) {
+        status_header(301);
+        mirror_redirect($try);
+        exit;
+    }
+}
 
 // ============================================================================
 // 404 page for manual pages (eg. not built language)


### PR DESCRIPTION
This patch adds in redirects from manual page links for inactive languages to go to their English equivalent.

For example, since our Bulgarian translation is marked as inactive, visitors going to http://php.net/manual/bg/function.strpos.php will get redirected to http://php.net/manual/en/function.strpos.php

