### PR TITLE
Add historical maintainer for lv1.php.net (15+ years)

### DIFF
--- a/include/historical_mirrors.inc
+++ b/include/historical_mirrors.inc
@@ -49,6 +49,7 @@ $historical_mirrors = array(
 	array("LTU", "lt1.php.net", "UAB \"Interneto vizija\"", "http://serveriai.lt/"),
 	array("LUX", "lu1.php.net", "root eSolutions ISP", "http://www.root.lu"),
 	array("LVA", "lv1.php.net", "Māris Ozoliņš", "http://netparks.lv/"),
+	array("LVA", "lv1.php.net", "Kaspars Foigts", "https://laacz.lv/"),
 	array("MYS", "my1.php.net", "MaxDedicated", "http://www.maxdedicated.com/"),
 	array("MEX", "mx1.php.net", "uServers Mexico", "http://www.uservers.net/?in=php"),
 	array("MEX", "mx2.php.net", "Universidad Autónoma Metropolitana Azcapotzalco", "http://www.azc.uam.mx"),


### PR DESCRIPTION
There was another maintainer of php.net's Latvia mirror site since early 2000s (until August of 2018). That was me. If not much of trouble, I'd like to be mentioned.