### PR TITLE
Keep CVEs in changelog

### DIFF
--- a/bin/news2html
+++ b/bin/news2html
@@ -54,7 +54,7 @@ foreach($entries as $module => $items) {
 	echo "<li>$module:\n<ul>\n";
 	foreach($items as $item) {
 		// strip author
-		$item = preg_replace('/\.\s+\(.+?\)\s*$/', '.', $item);
+		$item = preg_replace('/\s+\([^()]+\)\s*$/', '', $item);
 		// encode HTML
 		$item = htmlspecialchars($item, ENT_NOQUOTES);
 		// convert bug numbers


### PR DESCRIPTION
When snipping the author attribution from each changelog entry, we have
to keep eventual CVEs.  We therefore only remove the last parenthesized
part and possibly surrounding whitespace.