### PR TITLE
Fixed PHP fwdays 2020 logo

### DIFF
--- a/archive/entries/2019-07-31-2.xml
+++ b/archive/entries/2019-07-31-2.xml
@@ -8,7 +8,7 @@
   <link href="https://fwdays.com/en/event/php-fwdays-2020" rel="via" type="text/html"/>
   <default:finalTeaserDate xmlns="http://php.net/ns/news">2019-12-24</default:finalTeaserDate>
   <category term="conferences" label="Conference announcement"/>
-  <default:newsImage xmlns="http://php.net/ns/news" link="https://fwdays.com/en/event/php-fwdays-2020" title="PHP fwdays'20">phpfworksday-logo.png</default:newsImage>
+  <default:newsImage xmlns="http://php.net/ns/news" link="https://fwdays.com/en/event/php-fwdays-2020" title="PHP fwdays'20">fwdays.png</default:newsImage>
   <content type="xhtml">
     <div xmlns="http://www.w3.org/1999/xhtml">
         <p>We are thrilled to announce the 8th edition of <a href="https://fwdays.com/en/event/php-fwdays-2020">PHP fwdays conference</a> &#8212; the biggest PHP conf of Eastern Europe, which will be held on <strong>May 30, 2020 in Kyiv, Ukraine</strong>.</p>


### PR DESCRIPTION
This pull request fixes the path to conference logo. The original logo submitted in the https://github.com/php/web-php/pull/292 is the old one.