### PR TITLE
Move PHP 4 warning

### DIFF
--- a/docs.php
+++ b/docs.php
@@ -65,14 +65,14 @@ foreach ($ACTIVE_ONLINE_LANGUAGES as $langcode => $langname) {
  </tr>
 </table>
 
-    <div>
-        <p>
-            Documentation for PHP 4 has been removed from the
-            manual, but there is archived version still available. For
-            more informations, please read <a href="/manual/php4.php">
-                Documentation for PHP 4</a>.
-        </p>
-    </div>
+<div>
+ <p>
+  Documentation for PHP 4 has been removed from the
+  manual, but there is archived version still available. For
+  more information, please read <a href="/manual/php4.php">
+  Documentation for PHP 4</a>.
+ </p>
+</div>
 
 <h2 class="content-header">More documentation</h2>
 <ul class="content-box listed">

--- a/docs.php
+++ b/docs.php
@@ -25,15 +25,6 @@ site_header("Documentation", array("current" => "docs"));
  parts might be outdated. The translation teams are open to
  contributions.
 </p>
-
- <div class="warning">
-  <p>
-   Documentation for PHP 4 has been removed from the
-   manual, but there is archived version still available. For
-   more informations, please read <a href="/manual/php4.php">
-   Documentation for PHP 4</a>.
-  </p>
- </div>
 </div>
 
 <table class="standard">
@@ -73,6 +64,15 @@ foreach ($ACTIVE_ONLINE_LANGUAGES as $langcode => $langname) {
   </td>
  </tr>
 </table>
+
+    <div>
+        <p>
+            Documentation for PHP 4 has been removed from the
+            manual, but there is archived version still available. For
+            more informations, please read <a href="/manual/php4.php">
+                Documentation for PHP 4</a>.
+        </p>
+    </div>
 
 <h2 class="content-header">More documentation</h2>
 <ul class="content-box listed">


### PR DESCRIPTION
Hi!

I feel like a _red giant warning about PHP 4 documentation_ is not the first thing people should see in 2019 when looking for documentation.

I think it's a little less confusing and attention grabbing below the table, like this:

![Screenshot 2019-09-16 at 18 05 51](https://user-images.githubusercontent.com/205852/64974436-1e408f00-d8ad-11e9-854f-916d0ce90f77.png)

What do you think?

(Oh, and there's no such thing as _informations_)