### PR TITLE
Removed dead information from Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,7 @@ operation of this website, such as
  - User contributed notes for manual pages
  - A "router" for the builtin PHP webserver
 
-
-## Setting up an official mirror
-
-To install a full official mirror please see [the mirroring guidelines](http://php.net/mirroring).
-
 ## Code requirements
 
-Code must function on a vanilla PHP 5.3 installation as some php.net mirrors still run PHP 5.3.
+Code must function on a vanilla PHP 7.3 installation. 
 Please keep this in mind before filing a pull request.


### PR DESCRIPTION
Removed official mirrors from readme, there are no official mirrors anymore. 

Removed PHP 5.3 (!) requirement from readme, replaced with 7.3