### PR TITLE
Add 2020 news archive

### DIFF
--- a/archive/2020.php
+++ b/archive/2020.php
@@ -1,0 +1,24 @@
+<?php
+
+$_SERVER['BASE_PAGE'] = 'archive/2020.php';
+include_once __DIR__ . '/../include/prepend.inc';
+include_once __DIR__ . '/../include/pregen-news.inc';
+news_archive_sidebar();
+site_header("News Archive - 2020");
+//site_header("News Archive - 2020", array("cache" => true));
+?>
+
+<h1>News Archive - 2020</h1>
+
+<p>
+ Here are the most important news items we have published in 2020 on PHP.net.
+</p>
+
+<hr>
+
+<?php
+
+print_news($NEWS_ENTRIES, null, 500, 2020);
+
+/* %s/<a href="\(.*\)"><img src="\/images\/news\/\(.*\)" alt="\(.*\)" width.*><\/a>/<?php news_image("\1", "\2", "\3"); ?>/g */
+site_footer(array('elephpants' => true, 'sidebar' => $SIDEBAR_DATA));


### PR DESCRIPTION
Fix "archive/2020.php doesn't exist." error.

## How to reproduce?

click the "PHP 7.4.2 Released" announcement link on the front page.

![image](https://user-images.githubusercontent.com/2707563/72967852-94588380-3dc2-11ea-9a2d-c1a1a678ba8a.png)
