### PR TITLE
Update old licenses to show they are superseded by 3.01

### DIFF
--- a/license/2_01.txt
+++ b/license/2_01.txt
@@ -1,3 +1,15 @@
+============= An example PHP License, version 2.01 file ============
+
+This is the original PHP License, version 2.01 which applies only to
+very old versions of PHP software (such as versions 4.0RC2 and earlier).
+
+This license is provided here for historical purposes only.
+
+This license has been superseded by the PHP License, version 3.01,
+available at <https://www.php.net/license/3_01.txt>. All new works
+using the PHP License should use the PHP License, version 3.01.
+
+
 --------------------------------------------------------------------
                   The PHP License, version 2.01
 Copyright (c) 1999 The PHP Group. All rights reserved.

--- a/license/2_02.txt
+++ b/license/2_02.txt
@@ -1,3 +1,15 @@
+============= An example PHP License, version 2.02 file ============
+
+This is the original PHP License, version 2.02 which applies only to
+very old versions of PHP software (such as versions 4.2.2 and earlier).
+
+This license is provided here for historical purposes only.
+
+This license has been superseded by the PHP License, version 3.01,
+available at <https://www.php.net/license/3_01.txt>. All new works
+using the PHP License should use the PHP License, version 3.01.
+
+
 --------------------------------------------------------------------
                   The PHP License, version 2.02
 Copyright (c) 1999 - 2002 The PHP Group. All rights reserved.

--- a/license/3_0.txt
+++ b/license/3_0.txt
@@ -1,3 +1,17 @@
+============= An example PHP License, version 3.0 file =============
+
+This is the original PHP License, version 3.0 which applies only to
+very old versions of PHP software (such as versions 5.1.1, 4.4.1, and
+earlier).
+
+The PHP License, version 3.0 is an Open Source Initiative approved
+license, available at <https://opensource.org/licenses/PHP-3.0>.
+
+This license has been superseded by the PHP License, version 3.01,
+available at <https://www.php.net/license/3_01.txt>. All new works
+using the PHP License should use the PHP License, version 3.01.
+
+
 --------------------------------------------------------------------
                   The PHP License, version 3.0
 Copyright (c) 1999 - 2006 The PHP Group. All rights reserved.


### PR DESCRIPTION
A few days ago, an email sent to the php.general mailing list pointed
out that the PHP License, version 3.01 is not listed on the Open Source
Initiative list of approved licenses, while the older 3.0 version is
listed<sup>[1]</sup>.

I volunteered<sup>[2]</sup> to discuss this with the OSI to see what steps we need
to take to get the 3.01 version of the license listed. I followed their
procedures to submit a request for "legacy approval" of the 3.01
license, since it's been in use for over 14 years<sup>[3]</sup>.

After some discussion<sup>[4]</sup>, we were advised to explicitly note the older
version as being deprecated and superceded by the 3.01 version<sup>[5]</sup>.

This pull request updates our past licenses, similar to how Apache
presents their old licenses<sup>[6]</sup>, to note that:

1. The 3.0 license is an OSI approved license, but the 3.01 version
   supercedes this license.
2. The 2.02 and 2.01 licenses are listed for historical purposes
   and are superseded by the 3.01 license.

[1]: https://news-web.php.net/php.general/327010
[2]: https://news-web.php.net/php.internals/108846
[3]: http://lists.opensource.org/pipermail/license-review_lists.opensource.org/2020-March/004716.html
[4]: http://lists.opensource.org/pipermail/license-review_lists.opensource.org/2020-March/thread.html
[5]: http://lists.opensource.org/pipermail/license-review_lists.opensource.org/2020-March/004741.html
[6]: https://www.apache.org/licenses/LICENSE-1.0