### PR TITLE
breadcrumbs and next/prev links is now fixed as navbar

### DIFF
--- a/include/header.inc
+++ b/include/header.inc
@@ -122,6 +122,37 @@ if (!isset($config["languages"])) {
       <input type="search" name="pattern" class="search-query" placeholder="Search" accesskey="s">
     </form>
   </div>
+    <?php if (!empty($config['breadcrumbs'])): ?>
+        <div id="breadcrumbs" class="clearfix">
+            <div id="breadcrumbs-inner">
+                <?php if (isset($config['next'])): ?>
+                    <div class="next">
+                        <a href="<?php echo $config['next'][0]; ?>">
+                            <?php echo $config['next'][1]; ?> &raquo;
+                        </a>
+                    </div>
+                <?php endif; ?>
+                <?php if (isset($config['prev'])): ?>
+                    <div class="prev">
+                        <a href="<?php echo $config['prev'][0]; ?>">
+                            &laquo; <?php echo $config['prev'][1]; ?>
+                        </a>
+                    </div>
+                <?php endif; ?>
+                <ul>
+                    <?php
+                    $breadcrumbs = $config['breadcrumbs'];
+                    $last = array_pop($breadcrumbs);
+                    foreach ($breadcrumbs as $crumb) {
+                        echo "      <li><a href='{$crumb['link']}'>{$crumb['title']}</a></li>";
+                    }
+                    echo "      <li><a href='{$last['link']}'>{$last['title']}</a></li>";
+
+                    ?>
+                </ul>
+            </div>
+        </div>
+    <?php endif; ?>
   <div id="flash-message"></div>
 </nav>
 <?php if (!empty($config["headsup"])): ?>

--- a/styles/theme-base.css
+++ b/styles/theme-base.css
@@ -1511,6 +1511,7 @@ div.soft-deprecation-notice blockquote.sidebar {
 #breadcrumbs a:link,
 #breadcrumbs a:visited {
     border-width:0;
+    text-shadow: none;
 }
 
 #breadcrumbs .next,
@@ -1526,7 +1527,7 @@ div.soft-deprecation-notice blockquote.sidebar {
     transform: translateZ(0);
   }
   body {
-    margin:3.25rem 0 0;
+    margin:6.25rem 0 0;
   }
   #breadcrumbs {
     display:block;

--- a/styles/theme-medium.css
+++ b/styles/theme-medium.css
@@ -445,7 +445,8 @@ aside.tips a:focus {
 
 /* {{{ Breadcrumbs */
 #breadcrumbs {
-    color: #999;
+  color: #999;
+  background: #333 url(/images/bg-texture-00.svg);
 }
 /* }}} */
 


### PR DESCRIPTION
hi !

breadcrumbs and next/prev links is now fixed as navbar

this is necessary in order to make it easier to switch to the next page, since now, after reading the page, you don’t have to scroll to the very beginning of the page

![image](https://user-images.githubusercontent.com/9282567/82594990-dca47880-9bdf-11ea-9d08-a850c627b1ec.png)
![image](https://user-images.githubusercontent.com/9282567/82595015-e332f000-9bdf-11ea-8e3a-81b8c2867b0a.png)

