### PR TITLE
Simplify front page news entry selection to latest 25 entries with "frontpage" category

### DIFF
--- a/index.php
+++ b/index.php
@@ -45,22 +45,15 @@ mirror_setcookie("LAST_NEWS", $_SERVER["REQUEST_TIME"], 60*60*24*365);
 
 
 $content = "<div class='home-content'>";
-$releasenews = 0;
 $frontpage = array();
 foreach($NEWS_ENTRIES as $entry) {
-    $maybe = false;
     foreach($entry["category"] as $category) {
-        if ($category["term"] == "releases") {
-            if ($releasenews++ > 5) {
-                continue 2;
+        if ($category["term"] == "frontpage") {
+            $frontpage[] = $entry;
+            if (count($frontpage) >= 25) {
+                break 2;
             }
         }
-        if ($category["term"] == "frontpage") {
-            $maybe = $entry;
-        }
-    }
-    if ($maybe) {
-        $frontpage[] = $maybe;
     }
 }
 foreach($frontpage as $entry) {


### PR DESCRIPTION
The news entry selection on the php.net homepage makes for strange reading.  The first entries are sensible, most usually the newest release announcements (we rarely have any other type of front page news any more).  Then there is a jump back to a pile of ancient PHP X.Y.0\* pre-release announcements.

This PR simplifies the logic to just show the latest 25 news entries with the `frontpage` category.

Before | After
------ | -----
PHP 8.0.0 Alpha 1 available for testing | PHP 8.0.0 Alpha 1 available for testing
PHP 7.4.7 Released! | PHP 7.4.7 Released!
PHP 7.3.19 Released | PHP 7.3.19 Released
PHP 7.4.6 Released! | PHP 7.4.6 Released!
PHP 7.3.18 Released | PHP 7.3.18 Released
PHP 7.2.31 Released | PHP 7.2.31 Released
PHP 7.2.30 Release Announcement | PHP 7.2.30 Release Announcement
PHP 7.4.0RC6 Released! | PHP 7.4.5 Released
PHP 7.4.0RC5 released! | PHP 7.3.17 Released
PHP 7.4.0RC4 Released! | PHP 7.4.4 Released!
PHP 7.4.0RC3 Released! | PHP 7.2.29 Released
PHP 7.4.0RC2 Released! | PHP 7.3.16 Released
PHP 7.4.0RC1 Released! | PHP 7.4.3 released
PHP 7.4.0beta4 released! | PHP 7.3.15 Released
PHP 7.4.0beta2 released! | PHP 7.2.28 Released
PHP 7.4.0beta1 released! | PHP 7.3.14 Released
PHP 7.4.0 alpha 3 Released | PHP 7.2.27 Released
PHP 7.4.0 alpha 2 Released | PHP 7.4.2 Released
PHP 7.4.0 alpha 1 Released | PHP 7.2.26 Released
PHP 7.3.0RC6 Released | PHP 7.3.13 Released
PHP 7.3.0RC5 Released | PHP 7.4.1 Released!
PHP 7.3.0RC4 Released | PHP 7.4.0 Released!
PHP 7.3.0RC3 Released | PHP 7.2.25 Released
PHP 7.3.0RC2 Released | PHP 7.3.12 Released
PHP 7.3.0RC1 Released | PHP 7.4.0RC6 Released!
... | 