### PR TITLE
Fix typo for CVE in 09 July release announcements

### DIFF
--- a/archive/entries/2020-07-09-2.xml
+++ b/archive/entries/2020-07-09-2.xml
@@ -14,7 +14,7 @@
 
 <p>For windows users running an official build, this release contains a
 patched version of <a href="https://curl.haxx.se">libcurl</a> addressing
-<a href="https://curl.haxx.se/docs/CVE-2020-8169.html">CVE-2020-8159</a>.</p>
+<a href="https://curl.haxx.se/docs/CVE-2020-8169.html">CVE-2020-8169</a>.</p>
 
 <p>For all other consumers of PHP, this is a bug fix release.</p>
 

--- a/archive/entries/2020-07-09-3.xml
+++ b/archive/entries/2020-07-09-3.xml
@@ -19,7 +19,7 @@
       <p>
         For windows users running an official build, this release contains a
         patched version of <a href="https://curl.haxx.se">libcurl</a> addressing
-        <a href="https://curl.haxx.se/docs/CVE-2020-8169.html">CVE-2020-8159</a>.
+        <a href="https://curl.haxx.se/docs/CVE-2020-8169.html">CVE-2020-8169</a>.
       </p>
 
       <p>

--- a/archive/entries/2020-07-09-4.xml
+++ b/archive/entries/2020-07-09-4.xml
@@ -16,7 +16,7 @@ href="https://windows.php.net/">official Windows builds</a> of PHP.</p>
 
 <p>For windows users running an official build, this release contains a
 patched version of <a href="https://curl.haxx.se">libcurl</a> addressing
-<a href="https://curl.haxx.se/docs/CVE-2020-8169.html">CVE-2020-8159</a>.</p>
+<a href="https://curl.haxx.se/docs/CVE-2020-8169.html">CVE-2020-8169</a>.</p>
 
 <p>For all other consumers of PHP, this is a bug fix release.</p>
 

--- a/releases/7_2_32.php
+++ b/releases/7_2_32.php
@@ -14,7 +14,7 @@ site_header('PHP 7.2.32 Release Announcement');
 <p>
   For windows users running an official build, this release contains a
   patched version of <a href="https://curl.haxx.se">libcurl</a> addressing
-  <a href="https://curl.haxx.se/docs/CVE-2020-8169.html">CVE-2020-8159</a>.
+  <a href="https://curl.haxx.se/docs/CVE-2020-8169.html">CVE-2020-8169</a>.
 </p>
 
 <p>

--- a/releases/7_3_20.php
+++ b/releases/7_3_20.php
@@ -10,7 +10,7 @@ site_header('PHP 7.3.20 Release Announcement');
 
 <p>For windows users running an official build, this release contains a
 patched version of <a href="https://curl.haxx.se">libcurl</a> addressing
-<a href="https://curl.haxx.se/docs/CVE-2020-8169.html">CVE-2020-8159</a>.</p>
+<a href="https://curl.haxx.se/docs/CVE-2020-8169.html">CVE-2020-8169</a>.</p>
 
 <p>For all other consumers of PHP, this is a bug fix release.</p>
 

--- a/releases/7_4_8.php
+++ b/releases/7_4_8.php
@@ -11,7 +11,7 @@ href="https://windows.php.net/">official Windows builds</a> of PHP.</p>
 
 <p>For windows users running an official build, this release contains a
 patched version of <a href="https://curl.haxx.se">libcurl</a> addressing
-<a href="https://curl.haxx.se/docs/CVE-2020-8169.html">CVE-2020-8159</a>.</p>
+<a href="https://curl.haxx.se/docs/CVE-2020-8169.html">CVE-2020-8169</a>.</p>
 
 <p>For all other consumers of PHP, this is a bug fix release.</p>
 


### PR DESCRIPTION
Link and text different by 1 digit. CVE from text is completely unrelated so changed to match link from curl website. :)