### PR TITLE
Fixed ridiculous example

### DIFF
--- a/releases/8.0/de.php
+++ b/releases/8.0/de.php
@@ -98,11 +98,13 @@ META
         <div class="php8-compare__label">PHP 7</div>
         <div class="php8-code phpcode">
             <?php highlight_php_trimmed(
-                '/**
-* @Route("/api/posts/{id}", methods={"GET", "HEAD"})
-*/
-class User
-{'
+                'class PostsController
+{
+    /**
+     * @Route("/api/posts/{id}", methods={"GET"})
+     */
+    public function get($id) { /* ... */ }
+}'
             );?>
         </div>
       </div>
@@ -111,9 +113,11 @@ class User
         <div class="php8-compare__label php8-compare__label_new">PHP 8</div>
         <div class="php8-code phpcode">
             <?php highlight_php_trimmed(
-                '#[Route("/api/posts/{id}", methods: ["GET", "HEAD"])]
-class User
-{'
+                'class PostsController
+{
+    #[Route("/api/posts/{id}", methods: ["GET"])]
+    public function get($id) { /* ... */ }
+}'
             );?>
         </div>
       </div>

--- a/releases/8.0/en.php
+++ b/releases/8.0/en.php
@@ -95,11 +95,13 @@ META
         <div class="php8-compare__label">PHP 7</div>
         <div class="php8-code phpcode">
             <?php highlight_php_trimmed(
-                '/**
-* @Route("/api/posts/{id}", methods={"GET", "HEAD"})
-*/
-class User
-{'
+                'class PostsController
+{
+    /**
+     * @Route("/api/posts/{id}", methods={"GET"})
+     */
+    public function get($id) { /* ... */ }
+}'
             );?>
         </div>
       </div>
@@ -108,9 +110,11 @@ class User
         <div class="php8-compare__label php8-compare__label_new">PHP 8</div>
         <div class="php8-code phpcode">
             <?php highlight_php_trimmed(
-                '#[Route("/api/posts/{id}", methods: ["GET", "HEAD"])]
-class User
-{'
+                'class PostsController
+{
+    #[Route("/api/posts/{id}", methods: ["GET"])]
+    public function get($id) { /* ... */ }
+}'
             );?>
         </div>
       </div>

--- a/releases/8.0/pt_BR.php
+++ b/releases/8.0/pt_BR.php
@@ -98,11 +98,13 @@ META
                     <div class="php8-compare__label">PHP 7</div>
                     <div class="php8-code phpcode">
                         <?php highlight_php_trimmed(
-                            '/**
-* @Route("/api/posts/{id}", methods={"GET", "HEAD"})
-*/
-class User
-{'
+                            'class PostsController
+{
+    /**
+     * @Route("/api/posts/{id}", methods={"GET"})
+     */
+    public function get($id) { /* ... */ }
+}'
                         );?>
                     </div>
                 </div>
@@ -111,9 +113,11 @@ class User
                     <div class="php8-compare__label php8-compare__label_new">PHP 8</div>
                     <div class="php8-code phpcode">
                         <?php highlight_php_trimmed(
-                            '#[Route("/api/posts/{id}", methods: ["GET", "HEAD"])]
-class User
-{'
+                            'class PostsController
+{
+    #[Route("/api/posts/{id}", methods: ["GET"])]
+    public function get($id) { /* ... */ }
+}'
                         );?>
                     </div>
                 </div>

--- a/releases/8.0/ru.php
+++ b/releases/8.0/ru.php
@@ -97,11 +97,13 @@ META
         <div class="php8-compare__label">PHP 7</div>
         <div class="php8-code phpcode">
             <?php highlight_php_trimmed(
-                '/**
-* @Route("/api/posts/{id}", methods={"GET", "HEAD"})
-*/
-class User
-{'
+                'class PostsController
+{
+    /**
+     * @Route("/api/posts/{id}", methods={"GET"})
+     */
+    public function get($id) { /* ... */ }
+}'
             );?>
         </div>
       </div>
@@ -110,9 +112,11 @@ class User
         <div class="php8-compare__label php8-compare__label_new">PHP 8</div>
         <div class="php8-code phpcode">
             <?php highlight_php_trimmed(
-                '#[Route("/api/posts/{id}", methods: ["GET", "HEAD"])]
-class User
-{'
+                'class PostsController
+{
+    #[Route("/api/posts/{id}", methods: ["GET"])]
+    public function get($id) { /* ... */ }
+}'
             );?>
         </div>
       </div>


### PR DESCRIPTION
Now class `User` processes the **routing** for **posts** action :grinning: 

![image](https://user-images.githubusercontent.com/6815714/100370647-a1b05100-3017-11eb-9901-eb6b804d3d53.png)

I've fixed ridiculoues example of routing classes :+1: 

![image](https://user-images.githubusercontent.com/6815714/100370600-92c99e80-3017-11eb-84cc-0752bbd46883.png)
