### PR TITLE
Proposed improvements to PHP 8 page

### DIFF
--- a/releases/8.0/en.php
+++ b/releases/8.0/en.php
@@ -248,6 +248,7 @@ echo $result;
         <li>Match is an expression, meaning its result can be stored in a variable or returned.</li>
         <li>Match branches only support single-line expressions and do not need a break; statement.</li>
         <li>Match does strict comparisons.</li>
+        <li>Match throws an <code>UnhandledMatchError</code> if no match is found and no <code>default</code> is provided.</li>
       </ul>
     </div>
   </div>
@@ -289,8 +290,8 @@ if ($session !== null) {
       </div>
     </div>
     <div class="php8-compare__content">
-      <p>Instead of null check conditions, you can now use a chain of calls with the new nullsafe operator. When the
-        evaluation of one element in the chain fails, the execution of the entire chain aborts and the entire chain
+      <p>Instead of null check conditions, you can now use a chain of calls with the new nullsafe operator. When one
+        element in the chain evaluates to null, the execution of the entire chain aborts and the entire chain
         evaluates to null.</p>
     </div>
   </div>

--- a/styles/php8.css
+++ b/styles/php8.css
@@ -278,6 +278,14 @@
   }
 }
 
+.php8-compare__content code {
+  color: rgba(39, 40, 44, 0.7);
+  background-color: rgba(39, 40, 44, 0.05);
+  padding: .2em .4em;
+  font-size: 85%;
+  border-radius: 6px;
+}
+
 .php8-code {
   display: -webkit-box;
   display: -ms-flexbox;


### PR DESCRIPTION
As [proposed on @internals](https://externals.io/message/112307#112308), a couple suggestions to improve the PHP 8 page:

- what happens when `match()` doesn't match;
- clarification of the nullsafe operator: IMO, "fails" could imply that an unknown property, or a property that evaluates to a non-object is acceptable.