### PR TITLE
Fix typo in changelog

### DIFF
--- a/ChangeLog-7.php
+++ b/ChangeLog-7.php
@@ -6800,7 +6800,7 @@ site_header("PHP 7 ChangeLog", array("current" => "docs", "css" => array("change
   <ul>
     <li>Implemented asynchronous signal handling without TICKS.</li>
     <li>Added pcntl_signal_get_handler() that returns the current signal handler for a particular signal. Addresses FR <?php bugl(72409); ?>.</li>
-    <li>Add signinfo to pcntl_signal() handler args (Bishop Bettini, David Walker)</li>
+    <li>Add siginfo to pcntl_signal() handler args (Bishop Bettini, David Walker)</li>
   </ul></li>
 <li>PCRE:
   <ul>


### PR DESCRIPTION
This relates to https://github.com/php/doc-en/pull/274. The [PHP 7.1.0 changelog](https://www.php.net/ChangeLog-7.php#7.1.0) has the following entry:

> Add sig**n**info to pcntl_signal() handler args (Bishop Bettini, David Walker)

As described in the PR above, the pcntl_signal docs page incorrectly used both the spelling `siginfo` and the typo `signinfo` interchangably to represent this one argument. The source itself always uses the former:

https://github.com/php/php-src/blob/22bf92564ca2ff7e4827e69c364942c4291931dc/ext/pcntl/pcntl.c#L1287

Now the docs have been fixed to consistently use this spelling, it would be good if the changelog did too; a typo in the feature name itself makes it difficult to search for.