### PR TITLE
Allow to access symlinked docs

### DIFF
--- a/.router.php
+++ b/.router.php
@@ -2,14 +2,11 @@
 $_SERVER["SERVER_ADDR"] = $_SERVER["HTTP_HOST"];
 
 $filename = isset($_SERVER["PATH_INFO"]) ? $_SERVER["PATH_INFO"] : $_SERVER["SCRIPT_NAME"];
-$afilename = $_SERVER["DOCUMENT_ROOT"] . $filename;
-$len = strlen($_SERVER["DOCUMENT_ROOT"]);
 
-if (strncmp($_SERVER["DOCUMENT_ROOT"], $afilename, $len) == 0) {
-    if (file_exists($afilename)) {
-        /* This could be an image or whatever, so don't try to compress it */
-        ini_set("zlib.output_compression", 0);
-        return false;
-    }
+if (file_exists($_SERVER["DOCUMENT_ROOT"] . $filename)) {
+    /* This could be an image or whatever, so don't try to compress it */
+    ini_set("zlib.output_compression", 0);
+    return false;
 }
+
 include_once "error.php";

--- a/.router.php
+++ b/.router.php
@@ -3,7 +3,6 @@ $_SERVER["SERVER_ADDR"] = $_SERVER["HTTP_HOST"];
 
 $filename = isset($_SERVER["PATH_INFO"]) ? $_SERVER["PATH_INFO"] : $_SERVER["SCRIPT_NAME"];
 $afilename = $_SERVER["DOCUMENT_ROOT"] . $filename;
-$afilename = realpath($afilename);
 $len = strlen($_SERVER["DOCUMENT_ROOT"]);
 
 if (strncmp($_SERVER["DOCUMENT_ROOT"], $afilename, $len) == 0) {


### PR DESCRIPTION
Since `realpath()` resolves links, symlinked docs as suggested by the
"Setting up Documentation environment" page[1] are incompatible with
the router script.  Of course, the Webserver can be run without the
router script, but in that case shortcuts (e.g. `/json_decode`) won't
work.

Thus, we remove the `realpath()` resolution.

[1] <http://doc.php.net/tutorial/local-setup.php>