### PR TITLE
Legacy manuals

### DIFF
--- a/include/errors.inc
+++ b/include/errors.inc
@@ -524,7 +524,7 @@ function get_legacy_manual_urls(string $uri): array
     $filename = $_SERVER["DOCUMENT_ROOT"] . "/manual/legacyurls.json";
     $pages_ids = json_decode(file_get_contents($filename), true);
     $page_id = preg_replace_callback('/^manual\/.*\/(.*?)(\.php)?$/', function (array $matches): string {
-        if (count($matches) !== 3) {
+        if (count($matches) < 2) {
             return '';
         }
         return $matches[1] ;

--- a/manual/php4.php
+++ b/manual/php4.php
@@ -7,32 +7,44 @@ site_header('PHP Version 4 Documentation');
 <h1>Documentation for PHP 4</h1>
 
 <h2>Introduction</h2>
-<p>
- The PHP 4 documentation was removed from the PHP Manual in August 2014,
- approximately six years after PHP 4 reached its end of life. However, we have
- provided downloadable copies of the manual for anyone who would need it.
-</p>
+ <p>
+  The PHP 4 documentation was removed from the PHP Manual in August 2014,
+  approximately six years after PHP 4 reached its end of life. However, we have
+  provided downloadable copies of the manual for anyone who would need it, as well
+  as a link to a hosted third-party version.
+ </p>
 
 <h2>PHP 4 Manual</h2>
 <p>
- An attempt has been made to preserve as much documentation related to PHP 4, as
+ An attempt has been made to preserve as much documentation related to PHP 4 as
  possible. Despite this, we don't have a nice, separate manual covering only PHP 4.
- The reason for this is how our documentation is structured. Even so, the archived copy
- describes more aspects of PHP 4 than actual manual described in August 2014 (e.g.
+ The reason for this is how our documentation is structured. Even so, the linked copies
+ describe more aspects of PHP 4 than the actual manual described in August 2014 (e.g.
  it covers more PHP 4 extensions).
 </p>
 
+<ul>
+ <li>
+  You can download a copy in the <a href="http://doc.php.net/archives/">documentation archives</a>.
+ </li>
+ <li>
+  You can also find the <a href="https://php-legacy-docs.zend.com/manual/php4/en/index">PHP 4 legacy manual</a>
+  on the Zend site, which was created from the official archives. This version of the manual is
+  maintained by Zend and not the PHP Documentation Group. Any questions about its content should be reported
+  via the "Report a Bug" links on the appropriate pages.
+ </li>
+</ul>
+
 <p>
- To download a copy of the manual for PHP 4, see the <a href="http://doc.php.net/archives/">
- documentation archives</a>. Please, remember, that archived version <strong>should not
- </strong> be used in everyday development, unless you are developing PHP 4 applications.
- This version lacks many topics connected with newer PHP versions and it is not updated anymore.
+ Please remember that these documentation versions <strong>should not
+ </strong> be used in everyday development, unless you are maintaining PHP 4 applications.
+ These versions lacks many topics connected with newer PHP versions and are not updated anymore.
 </p>
 
 <h2>Migrating to supported PHP version</h2>
 <p>
  All users are strongly encouraged to upgrade their environments to  newest PHP version.
- Please, read our guides for <a href="http://php.net/manual/en/migration5.php">Migrating
+ Please read our guides for <a href="http://php.net/manual/en/migration5.php">Migrating
  from PHP 4 to PHP 5.0.x</a> for more information.
 </p>
 

--- a/manual/php4.php
+++ b/manual/php4.php
@@ -7,12 +7,12 @@ site_header('PHP Version 4 Documentation');
 <h1>Documentation for PHP 4</h1>
 
 <h2>Introduction</h2>
- <p>
-  The PHP 4 documentation was removed from the PHP Manual in August 2014,
-  approximately six years after PHP 4 reached its end of life. However, we have
-  provided downloadable copies of the manual for anyone who would need it, as well
-  as a link to a hosted third-party version.
- </p>
+<p>
+ The PHP 4 documentation was removed from the PHP Manual in August 2014,
+ approximately six years after PHP 4 reached its end of life. However, we have
+ provided downloadable copies of the manual for anyone who would need it, as well
+ as a link to a hosted third-party version.
+</p>
 
 <h2>PHP 4 Manual</h2>
 <p>

--- a/manual/php5.php
+++ b/manual/php5.php
@@ -10,29 +10,41 @@ site_header('PHP Version 5 Documentation');
 <p>
  The PHP 5 documentation was removed from the PHP Manual in September 2020,
  approximately two years after PHP 5 reached its end of life. However, we have
- provided downloadable copies of the manual for anyone who would need it.
+ provided downloadable copies of the manual for anyone who would need it, as well
+ as a link to a hosted third-party version.
 </p>
 
 <h2>PHP 5 Manual</h2>
 <p>
- An attempt has been made to preserve as much documentation related to PHP 5, as
+ An attempt has been made to preserve as much documentation related to PHP 5 as
  possible. Despite this, we don't have a nice, separate manual covering only PHP 5.
- The reason for this is how our documentation is structured. Even so, the archived copy
- describes more aspects of PHP 5 than actual manual described in September 2020 (e.g.
+ The reason for this is how our documentation is structured. Even so, the linked copies
+ describe more aspects of PHP 5 than the actual manual described in September 2020 (e.g.
  it covers more PHP 5 extensions).
 </p>
 
+<ul>
+ <li>
+  You can download a copy in the <a href="http://doc.php.net/archives/">documentation archives</a>.
+ </li>
+ <li>
+  You can also find the <a href="https://php-legacy-docs.zend.com/manual/php5/en/index">PHP 5 legacy manual</a>
+  on the Zend site, which was created from the official archives. This version of the manual is
+  maintained by Zend and not the PHP Documentation Group. Any questions about its content should be reported
+  via the "Report a Bug" links on the appropriate pages.
+ </li>
+</ul>
+
 <p>
- To download a copy of the manual for PHP 5, see the <a href="http://doc.php.net/archives/">
- documentation archives</a>. Please, remember, that archived version <strong>should not
- </strong> be used in everyday development, unless you are developing PHP 5 applications.
- This version lacks many topics connected with newer PHP versions and it is not updated anymore.
+ Please remember that these documentation versions <strong>should not
+ </strong> be used in everyday development, unless you are maintaining PHP 5 applications.
+ These versions lacks many topics connected with newer PHP versions and are not updated anymore.
 </p>
 
 <h2>Migrating to supported PHP version</h2>
 <p>
- All users are strongly encouraged to upgrade their environments to  newest PHP version.
- Please, read our guides for <a href="http://php.net/manual/en/migration70.php">Migrating
+ All users are strongly encouraged to upgrade their environments to newest PHP version.
+ Please read our guides for <a href="http://php.net/manual/en/migration70.php">Migrating
  from PHP 5.6 to PHP 7.0</a> for more information.
 </p>
 


### PR DESCRIPTION
Provide a link to the hosted legacy docs, in addition to the archive link. Use similar disclaimer about accountability as here: https://github.com/php/web-php/pull/385
I also fixed a few grammar mistakes.

Screenshot:
![image](https://user-images.githubusercontent.com/199835/102642412-a0140d80-412b-11eb-95be-e1b8ed1d436f.png)
