### PR TITLE
Replace link to edit.php.net with link to github

### DIFF
--- a/get-involved.php
+++ b/get-involved.php
@@ -33,7 +33,7 @@ site_header("Get Involved", array("current" => "community"));
   <li>Filing and resolving bug reports
       at <a href="http://bugs.php.net">bugs.php.net</a></li>
   <li>Help maintain and or translate documentation files
-      at <a href="http://edit.php.net">edit.php.net</a>. Check out our
+      at the doc-* repositories on <a href="https://github.com/php">github</a>. Check out our
       <a href="http://doc.php.net/tutorial/">guide for contributors</a>.</li>
  </ol>
 

--- a/get-involved.php
+++ b/get-involved.php
@@ -33,7 +33,7 @@ site_header("Get Involved", array("current" => "community"));
   <li>Filing and resolving bug reports
       at <a href="http://bugs.php.net">bugs.php.net</a></li>
   <li>Help maintain and or translate documentation files
-      at the doc-* repositories on <a href="https://github.com/php">github</a>. Check out our
+      at the doc-* repositories on <a href="https://github.com/php/?q=doc">github</a>. Check out our
       <a href="http://doc.php.net/tutorial/">guide for contributors</a>.</li>
  </ol>
 


### PR DESCRIPTION
Due to the move of the documentation to git this should direct epople to the right place. Which (currently) is not edit.php.net anymore.