### PR TITLE
Change mailing list rules link

### DIFF
--- a/mailing-lists.php
+++ b/mailing-lists.php
@@ -172,7 +172,7 @@ if (isset($_POST['maillist'])) {
 </ul>
 <p>
  And make sure you have read our
- <a href="https://github.com/php/php-src/raw/master/docs/mailinglist-rules.md">Mailinglist Rules</a>.
+ <a href="https://github.com/php/php-src/blob/master/docs/mailinglist-rules.md">Mailinglist Rules</a>.
 </p>
 <?php
 


### PR DESCRIPTION
This updates the mailing list rules link to the Github URL instead of the raw file URL. The reasoning for it is that the raw file does not correctly transform markdown formatting, and instead displays as if it were code. It decreases readability, and defeats the purpose of having the rules as a markdown file.

I am not sure if this is the best URL that can be linked to, but I think it's an improvement over the current URL.