### PR TITLE
Enhancement: Document platform requirement in `composer.json`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+/vendor/
+
 backend/mirror.gif
 backend/mirror.png
 backend/mirror.jpg

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,19 @@
+{
+    "name": "php/web-php",
+    "description": "The www.php.net site.",
+    "license": "proprietary",
+    "type": "project",
+    "homepage": "https://www.php.net/",
+    "support": {
+        "source": "https://github.com/php/web-php"
+    },
+    "require": {
+        "php": "^7.3"
+    },
+    "config": {
+        "platform": {
+            "php": "7.3.19"
+        },
+        "sort-packages": true
+    }
+}

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,23 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "c0f8a9b8c5c6efaa1eed8cf44ed8695e",
+    "packages": [],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": "^7.3"
+    },
+    "platform-dev": [],
+    "platform-overrides": {
+        "php": "7.3.19"
+    },
+    "plugin-api-version": "2.3.0"
+}


### PR DESCRIPTION
This pull request

* [x] documents the platform requirement in `composer.json`

Follows https://github.com/php/web-php/pull/606#discussion_r912514942.

💁‍♂️ This project currently does not use `composer` to manage its dependencies, but it does not need to stay that way. Apart from using `composer` to manage dependencies, `composer.json` also serves documentation purposes. For a start, I propose to add `composer.json` with platform requirements - we can take it from there, if that make sense for you.