### PR TITLE
Update license page to recognize versions later than PHP 7.

### DIFF
--- a/license/index.php
+++ b/license/index.php
@@ -27,7 +27,7 @@ site_header("License Information", array("current" => "help"));
 
 <ul>
  <li>
-  PHP 4, PHP 5 and PHP 7 are distributed under the
+  Starting with PHP 4, versions of the PHP software are distributed under the
   <a href="http://www.php.net/license/3_01.txt">PHP License v3.01</a>, copyright (c) the <a href="/credits.php">PHP Group</a>.
   <ul>
    <li>


### PR DESCRIPTION
Previously the page stated "PHP 4, PHP 5 and PHP 7 are distributed..." even though PHP 8 has been released. This commit changes the wording to be "Starting with PHP 4, versions of the PHP software are distributed..."