### PR TITLE
Fix to allow news2html to handle multi-line 'module'

### DIFF
--- a/bin/news2html
+++ b/bin/news2html
@@ -42,13 +42,23 @@ while(($ln = fgets($fp)) !== false) {
 	if ($ln[0] == '-') {
 		// module
 		$module = trim(substr($ln, 1), " \t\n:");
-	} elseif (preg_match('/^\s+\.\s/',$ln)) {
-		$entries[$module][] = trim(preg_replace('/^\s+\.\s+/', '', $ln));
-	} else {
-		// continued line
-		$c = count($entries[$module])-1;
-		$entries[$module][$c] = trim($entries[$module][$c] )." ".trim($ln);
+		continue;
 	}
+
+	if (preg_match('/^\s+\.\s/',$ln)) {
+		$entries[$module][] = trim(preg_replace('/^\s+\.\s+/', '', $ln));
+		continue;
+    }
+
+	if ( !isset($entries[$module])) {
+	    // Looks like we have a multi-line entry where a module should be
+	    $entries['Core'][] = $module;
+        $module = 'Core';
+    }
+
+	// continued line
+	$c = count($entries[$module])-1;
+	$entries[$module][$c] = trim($entries[$module][$c] )." ".trim($ln);
 }
 
 if ($changelog) { ob_start(); }
@@ -70,7 +80,7 @@ foreach($entries as $module => $items) {
 		// convert bug numbers
 		$item = preg_replace(
 			array('/Fixed bug #([0-9]+)/', '/Fixed PECL bug #([0-9]+)/', '/Implemented FR #([0-9]+)/', '/GitHub PR #([0-9]+)/'),
-			array('<?php bugfix(\1); ?>', '<?php peclbugfix(\1); ?>', '<?php implemented(\1); ?>', '<?php githubissuel(\'php/php-src\',\1); ?>'),
+			array('<?php bugfix("$1"); ?>', '<?php peclbugfix("$1"); ?>', '<?php implemented("$1"); ?>', '<?php githubissuel(\'php/php-src\',"$1"); ?>'),
 			$item
 		);
 		echo "  <li>$item</li>\n";

--- a/license/index.php
+++ b/license/index.php
@@ -27,7 +27,7 @@ site_header("License Information", array("current" => "help"));
 
 <ul>
  <li>
-  PHP 4, PHP 5 and PHP 7 are distributed under the
+  Starting with PHP 4, versions of the PHP software are distributed under the
   <a href="http://www.php.net/license/3_01.txt">PHP License v3.01</a>, copyright (c) the <a href="/credits.php">PHP Group</a>.
   <ul>
    <li>


### PR DESCRIPTION
I am not sure this PR is valid because I only had one set of NEWS files to process.  But, maybe it is:

I needed a NEWS file to test bin/news2html and the only ones in the repo were /resources/NEWS_5_4_0_*.txt. Unfortunately, those had a few 'entries' that appeared to have no 'modules' and that caused the script to crash. So I added logic to recognize those and assign them to the 'Core' module and that allowed the script to work. As part of this, I unravelled the if..elseif..else logic to be a series of if..continue since the if statements were all in a loop and no code was run after the if..elseif..else statement.


