### PR TITLE
Change invalid use of @alt on <a> anchor tags

### DIFF
--- a/archive/2008.xml
+++ b/archive/2008.xml
@@ -198,7 +198,7 @@
       <p>
 	Set in Paris, on December 8th and 9th 2008, by the
 	Association Française des Utilisateurs de PHP (French PHP User Group,
-	<a href="http://www.afup.org/" alt="AFUP">http://www.afup.org/</a>),
+	<a href="http://www.afup.org/" title="AFUP">http://www.afup.org/</a>),
 	the Forum PHP 2008 focuses on the themas of Professional Web Services,
 	and PHP large scale projects.
     </p>
@@ -358,7 +358,7 @@
       <div xmlns="http://www.w3.org/1999/xhtml">
         <h3>The premiere PHP Conference – Celebrate the 14th event with us!</h3>
         <p>
-       Today the ICP is <emphasis>the</emphasis> reference whenever substructures of existing technologies
+       Today the ICP is <em>the</em> reference whenever substructures of existing technologies
        should be extended or the basis for new developments should be created. Thus, you
        do not only profit from the concentrated know-how of worldwide acknowledged,
        international PHP-experts but also from the professional transfer of knowledge
@@ -995,11 +995,11 @@ visit the website: <a href="http://conf.phpquebec.com">http://conf.phpquebec.com
     <content type="xhtml">
       <div xmlns="http://www.w3.org/1999/xhtml">
         <p><abbr class="dtstart" title="2008-02-29">February 29th</abbr> (Leap Year Day). phplondon.org  announce their third
-            annual <a href="http://www.phpconference.co.uk" alt="phplondon.org community conference" class="url">community conference</a>
+            annual <a href="http://www.phpconference.co.uk" title="phplondon.org community conference" class="url">community conference</a>
             to be held at Inmarsat, Old Street, London.</p>
         <p>This year the conference will run two tracks and include speakers such as Derick Rethans, Wez Furlong, Scott MacVicar and Zoe Slattery.</p>
         <p>We will also be holding an extended presentation and discussion on frameworks for PHP.</p>
-        <p>Visit our <a href=" http://www.phpconference.co.uk" alt="phplondon.org community conference">conference site</a> to register. Early bird discount is available until 1st February 2008.</p>
+        <p>Visit our <a href=" http://www.phpconference.co.uk" title="phplondon.org community conference">conference site</a> to register. Early bird discount is available until 1st February 2008.</p>
       </div>
     </content>
   </entry>

--- a/archive/2009.php
+++ b/archive/2009.php
@@ -606,14 +606,14 @@ site_header("News Archive - 2009", array("cache" => true));
         <abbr class="published newsdate" title="2009-05-29T11:47:20+02:00">[29-May-2009]</abbr>
         <div>
       <p>
-      The <a href="http://www.afup.org/" alt="AFUP">AFUP</a> (Association française des utilisateurs PHP)
+      The <a href="http://www.afup.org/" title="AFUP">AFUP</a> (Association française des utilisateurs PHP)
       organizes on <abbr title="2009-11-11" class="dtstart">November 11th</abbr> and <abbr title="2009-11-12" class="dtstart">November 12th</abbr>
-      at the <a href="http://www.cite-sciences.fr/" alt="Cit&#xE9; des Sciences">Cité des Sciences</a> in Paris, France,
-      the <a href="" alt="Forum PHP">Forum PHP</a> for its 9th edition.
+      at the <a href="http://www.cite-sciences.fr/" title="Cit&#xE9; des Sciences">Cité des Sciences</a> in Paris, France,
+      the <a href="#" title="Forum PHP">Forum PHP</a> for its 9th edition.
       </p>
       <p>
        The PHP Forum 2009 will welcome as a partner alongside the AFUP,
-       the association <a href="http://www.lemug.fr/" alt="LeMug">LeMug.fr</a> (MySQL User Group).
+       the association <a href="http://www.lemug.fr/" title="LeMug">LeMug.fr</a> (MySQL User Group).
       </p>
       <p>
        On this occasion, AFUP decided to extend the pre-registration at preferential rates, and

--- a/license/index.php
+++ b/license/index.php
@@ -27,7 +27,7 @@ site_header("License Information", array("current" => "help"));
 
 <ul>
  <li>
-  PHP 4, PHP 5 and PHP 7 are distributed under the
+  Starting with PHP 4, versions of the PHP software are distributed under the
   <a href="http://www.php.net/license/3_01.txt">PHP License v3.01</a>, copyright (c) the <a href="/credits.php">PHP Group</a>.
   <ul>
    <li>


### PR DESCRIPTION
Changed from invalid @alt attribute on <a> anchor HTML elements to valid @title attribute using the same values used for @alt. 

Also fixed on invalid use of a non-existent <emphasis> element and replaced with <em>.
