### PR TITLE
Removes use of get_magic_quotes_gpc()

### DIFF
--- a/include/layout.inc
+++ b/include/layout.inc
@@ -248,7 +248,7 @@ function sect_to_file($string) {
 }
 
 function clean($var) {
-  return htmlspecialchars( $var, ENT_QUOTES);
+  return htmlspecialchars($var, ENT_QUOTES);
 }
 
 // Clean out the content of one user note for printing to HTML

--- a/include/layout.inc
+++ b/include/layout.inc
@@ -248,7 +248,7 @@ function sect_to_file($string) {
 }
 
 function clean($var) {
-  return htmlspecialchars(get_magic_quotes_gpc() ? stripslashes($var) : $var, ENT_QUOTES);
+  return htmlspecialchars( $var, ENT_QUOTES);
 }
 
 // Clean out the content of one user note for printing to HTML


### PR DESCRIPTION
As `get_magic_quotes_gpc()` has been removed in PHP 8.0, this PR removes it from the `clean()` function in `layout.inc.`

Hopefully its removal is valid, or at least how it was removed it valid.