### PR TITLE
Add PHPDoc to support linting via PhpStorm

### DIFF
--- a/ChangeLog-4.php
+++ b/ChangeLog-4.php
@@ -1,4 +1,4 @@
-<?php
+<?php /** @noinspection HtmlUnknownTarget  */
 $_SERVER['BASE_PAGE'] = 'ChangeLog-4.php';
 include_once __DIR__ . '/include/prepend.inc';
 include_once __DIR__ . '/include/changelogs.inc';

--- a/archive/2004.php
+++ b/archive/2004.php
@@ -1,8 +1,11 @@
-<?php
+<?php /** @noinspection HtmlUnknownTarget, HtmlUnknownAnchorTarget  */
 $_SERVER['BASE_PAGE'] = 'archive/2004.php';
 include_once __DIR__ . '/../include/prepend.inc';
 news_archive_sidebar();
 site_header("News Archive - 2004", array("cache" => true));
+/**
+ * @var string $SIDEBAR_DATA
+ */
 ?>
 
 <h1>News Archive - 2004</h1>

--- a/archive/2007.php
+++ b/archive/2007.php
@@ -1,8 +1,11 @@
-<?php
+<?php /** @noinspection HtmlUnknownTarget, HtmlUnknownAnchorTarget  */
 $_SERVER['BASE_PAGE'] = 'archive/2007.php';
 include_once __DIR__ . '/../include/prepend.inc';
 news_archive_sidebar();
 site_header("News Archive - 2007", array("cache" => true));
+/**
+ * @var string $SIDEBAR_DATA
+ */
 ?>
 
 <h1>News Archive - 2007</h1>

--- a/archive/2008.php
+++ b/archive/2008.php
@@ -1,8 +1,11 @@
-<?php
+<?php /** @noinspection HtmlUnknownTarget, HtmlUnknownAnchorTarget  */
 $_SERVER['BASE_PAGE'] = 'archive/2008.php';
 include_once __DIR__ . '/../include/prepend.inc';
 news_archive_sidebar();
 site_header("News Archive - 2008", array("cache" => true));
+/**
+ * @var string $SIDEBAR_DATA
+ */
 ?>
 
 <h1>News Archive - 2008</h1>

--- a/archive/2009.php
+++ b/archive/2009.php
@@ -1,8 +1,11 @@
-<?php
+<?php /** @noinspection HtmlUnknownTarget, HtmlUnknownAnchorTarget  */
 $_SERVER['BASE_PAGE'] = 'archive/2009.php';
 include_once __DIR__ . '/../include/prepend.inc';
 news_archive_sidebar();
 site_header("News Archive - 2009", array("cache" => true));
+/**
+ * @var string $SIDEBAR_DATA
+ */
 ?>
 
 <h1>News Archive - 2009</h1>

--- a/archive/2010.php
+++ b/archive/2010.php
@@ -1,8 +1,11 @@
-<?php
+<?php /** @noinspection HtmlUnknownTarget, HtmlUnknownAnchorTarget  */
 $_SERVER['BASE_PAGE'] = 'archive/2010.php';
 include_once __DIR__ . '/../include/prepend.inc';
 news_archive_sidebar();
 site_header("News Archive - 2010", array("cache" => true));
+/**
+ * @var string $SIDEBAR_DATA
+ */
 ?>
 
 <h1>News Archive - 2010</h1>

--- a/archive/2011.php
+++ b/archive/2011.php
@@ -1,8 +1,11 @@
-<?php
+<?php /** @noinspection HtmlUnknownTarget, HtmlUnknownAnchorTarget  */
 $_SERVER['BASE_PAGE'] = 'archive/2011.php';
 include_once __DIR__ . '/../include/prepend.inc';
 news_archive_sidebar();
 site_header("News Archive - 2011", array("cache" => true));
+/**
+ * @var string $SIDEBAR_DATA
+ */
 ?>
 
 <h1>News Archive - 2011</h1>

--- a/archive/2012.php
+++ b/archive/2012.php
@@ -1,8 +1,11 @@
-<?php
+<?php /** @noinspection HtmlUnknownAnchorTarget  */
 $_SERVER['BASE_PAGE'] = 'archive/2012.php';
 include_once __DIR__ . '/../include/prepend.inc';
 news_archive_sidebar();
 site_header("News Archive - 2012", array("cache" => true));
+/**
+ * @var string $SIDEBAR_DATA
+ */
 ?>
 
 <h1>News Archive - 2012</h1>

--- a/archive/2013.php
+++ b/archive/2013.php
@@ -1,10 +1,12 @@
 <?php
-
 $_SERVER['BASE_PAGE'] = 'archive/2013.php';
 include_once __DIR__ . '/../include/prepend.inc';
 include_once __DIR__ . '/../include/pregen-news.inc';
 news_archive_sidebar();
 site_header("News Archive - 2013", array("cache" => true));
+/**
+ * @var string $SIDEBAR_DATA
+ */
 ?>
 
 <h1>News Archive - 2013</h1>

--- a/archive/2014.php
+++ b/archive/2014.php
@@ -1,10 +1,12 @@
-<?php
-
+<?php /** @noinspection HtmlUnknownTarget, HtmlUnknownAnchorTarget  */
 $_SERVER['BASE_PAGE'] = 'archive/2014.php';
 include_once __DIR__ . '/../include/prepend.inc';
 include_once __DIR__ . '/../include/pregen-news.inc';
 news_archive_sidebar();
 site_header("News Archive - 2014", array("cache" => true));
+/**
+ * @var string $SIDEBAR_DATA
+ */
 ?>
 
 <h1>News Archive - 2014</h1>

--- a/archive/2015.php
+++ b/archive/2015.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * @var array $NEWS_ENTRIES
+ * @var string $SIDEBAR_DATA
+ */
 
 $_SERVER['BASE_PAGE'] = 'archive/2015.php';
 include_once __DIR__ . '/../include/prepend.inc';

--- a/archive/2016.php
+++ b/archive/2016.php
@@ -1,5 +1,8 @@
 <?php
-
+/**
+ * @var array $NEWS_ENTRIES
+ * @var string $SIDEBAR_DATA
+ */
 $_SERVER['BASE_PAGE'] = 'archive/2016.php';
 include_once __DIR__ . '/../include/prepend.inc';
 include_once __DIR__ . '/../include/pregen-news.inc';

--- a/archive/2017.php
+++ b/archive/2017.php
@@ -6,6 +6,10 @@ include_once __DIR__ . '/../include/pregen-news.inc';
 news_archive_sidebar();
 site_header("News Archive - 2017");
 //site_header("News Archive - 2017", array("cache" => true));
+/**
+ * @var array $NEWS_ENTRIES
+ * @var string $SIDEBAR_DATA
+ */
 ?>
 
 <h1>News Archive - 2017</h1>

--- a/archive/2018.php
+++ b/archive/2018.php
@@ -6,6 +6,10 @@ include_once __DIR__ . '/../include/pregen-news.inc';
 news_archive_sidebar();
 site_header("News Archive - 2018");
 //site_header("News Archive - 2018", array("cache" => true));
+/**
+ * @var array $NEWS_ENTRIES
+ * @var string $SIDEBAR_DATA
+ */
 ?>
 
 <h1>News Archive - 2018</h1>

--- a/archive/2019.php
+++ b/archive/2019.php
@@ -6,6 +6,10 @@ include_once __DIR__ . '/../include/pregen-news.inc';
 news_archive_sidebar();
 site_header("News Archive - 2019");
 //site_header("News Archive - 2019", array("cache" => true));
+/**
+ * @var array $NEWS_ENTRIES
+ * @var string $SIDEBAR_DATA
+ */
 ?>
 
 <h1>News Archive - 2019</h1>

--- a/archive/2020.php
+++ b/archive/2020.php
@@ -6,6 +6,10 @@ include_once __DIR__ . '/../include/pregen-news.inc';
 news_archive_sidebar();
 site_header("News Archive - 2020");
 //site_header("News Archive - 2020", array("cache" => true));
+/**
+ * @var array $NEWS_ENTRIES
+ * @var string $SIDEBAR_DATA
+ */
 ?>
 
 <h1>News Archive - 2020</h1>

--- a/archive/2021.php
+++ b/archive/2021.php
@@ -6,6 +6,10 @@ include_once __DIR__ . '/../include/pregen-news.inc';
 news_archive_sidebar();
 site_header("News Archive - 2021");
 //site_header("News Archive - 2021", array("cache" => true));
+/**
+ * @var array $NEWS_ENTRIES
+ * @var string $SIDEBAR_DATA
+ */
 ?>
 
 <h1>News Archive - 2021</h1>

--- a/conferences/index.php
+++ b/conferences/index.php
@@ -2,6 +2,10 @@
 $_SERVER['BASE_PAGE'] = 'conferences/index.php';
 include_once __DIR__ . '/../include/prepend.inc';
 include_once __DIR__ . '/../include/pregen-news.inc';
+/**
+ * @var string $MYSITE
+ * @var array $NEWS_ENTRIES
+ */
 
 
 mirror_setcookie("LAST_NEWS", $_SERVER["REQUEST_TIME"], 60*60*24*365);
@@ -37,7 +41,8 @@ foreach($frontpage as $entry) {
     $content .= '<div class="newsimage">';
 
     if (isset($entry["newsImage"])) {
-        $content .= sprintf('<a href="%s"><img src="/images/news/%s"></a>', $entry["newsImage"]["link"], $entry["newsImage"]["content"]);
+        /** @noinspection HtmlUnknownTarget */
+        $content .= sprintf('<a href="%s"><img src="/images/news/%s" alt="News"></a>', $entry["newsImage"]["link"], $entry["newsImage"]["content"]);
     }
 
     $content .= '</div>';
@@ -46,6 +51,7 @@ foreach($frontpage as $entry) {
     $content .= '</div>';
     $content .= '</div>';
 
+    /** @noinspection HtmlUnknownTarget */
     $panels .= sprintf('<p class="panel"><a href="%s">%s</a></p>', $entry["newsImage"]["link"], $entry["title"]);
 }
 $content .= "</div>";

--- a/copyright.php
+++ b/copyright.php
@@ -1,4 +1,4 @@
-<?php
+<?php /** @noinspection HtmlUnknownTarget  */
 $_SERVER['BASE_PAGE'] = 'copyright.php';
 include_once __DIR__ . '/include/prepend.inc';
 $SIDEBAR_DATA = '

--- a/include/layout.inc
+++ b/include/layout.inc
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @var string $MYSITE
+ */
 $_SERVER['STATIC_ROOT'] = $MYSITE;
 $_SERVER['MYSITE'] = $MYSITE;
 
@@ -81,6 +84,7 @@ function resize_image($img, $width = 1, $height = 1)
 }
 
 // Return an <img> tag for a given image file available on the server
+/** @noinspection PhpUnusedParameterInspection */
 function make_image($file, $alt = FALSE, $align = FALSE, $extras = FALSE,
                     $dir = '/images', $border = 0, $addsize = TRUE)
 {
@@ -105,7 +109,8 @@ function make_image($file, $alt = FALSE, $align = FALSE, $extras = FALSE,
     }
 
     // Return with image built up
-    return sprintf('<img src="%s/%s" alt="%s"%s%s%s>',
+    /** @noinspection HtmlUnknownTarget,HtmlUnknownAttribute */
+    return sprintf('<img src="%s/%s" alt="%s" %s%s%s>',
         $webdir,
         $file,
         ($alt    ? $alt : ''),
@@ -154,7 +159,8 @@ function make_submit($file, $alt = FALSE, $align = FALSE, $extras = FALSE,
 // Return a hiperlink to something within the site
 function make_link ($url, $linktext = FALSE, $target = FALSE, $extras = FALSE)
 {
-    return sprintf("<a href=\"%s\"%s%s>%s</a>",
+    /** @noinspection HtmlUnknownTarget,HtmlUnknownAttribute */
+    return sprintf("<a href=\"%s\" %s%s>%s</a>",
         $url,
         ($target   ? ' target="' . $target . '"' : ''),
         ($extras   ? ' ' . $extras               : ''),
@@ -172,7 +178,8 @@ function print_link($url, $linktext = FALSE, $target = FALSE, $extras = FALSE)
 // return a hyperlink to something, within the site, that pops up a new window
 //
 function make_popup_link ($url, $linktext=false, $target=false, $windowprops="", $extras=false) {
-    return sprintf("<a href=\"%s\" target=\"%s\" onclick=\"window.open('%s','%s','%s');return false;\"%s>%s</a>",
+    /** @noinspection HtmlUnknownTarget,HtmlUnknownAttribute */
+    return sprintf("<a href=\"%s\" target=\"%s\" onclick=\"window.open('%s','%s','%s');return false;\" %s>%s</a>",
         htmlspecialchars($url, ENT_QUOTES | ENT_IGNORE),
         ($target ? $target : "_new"),
         htmlspecialchars($url, ENT_QUOTES | ENT_IGNORE),
@@ -191,6 +198,7 @@ function print_popup_link($url, $linktext=false, $windowprops="", $target=false,
 }
 
 // Print a link for a downloadable file (including filesize)
+/** @noinspection PhpUnusedParameterInspection */
 function download_link($file, $title, $showsize = TRUE, $mirror = '')
 {
     $download_link = "/distributions/" . $file;
@@ -258,6 +266,7 @@ function clean_note($text)
     $text = highlight_php(trim($text), TRUE);
 
     // Turn urls into links
+    /** @noinspection HtmlUnknownTarget */
     $text = preg_replace(
         '!((mailto:|(https?|ftp|nntp|news):\/\/).*?)(\s|<|\)|"|\\\\|\'|$)!',
         '<a href="\1" rel="nofollow" target="_blank">\1</a>\4',
@@ -483,6 +492,7 @@ EOT;
 
 function site_header($title = '', $config = array())
 {
+    /** @noinspection PhpUnusedLocalVariableInspection */
     global $MYSITE;
 
     $defaults = array(
@@ -501,28 +511,38 @@ function site_header($title = '', $config = array())
 
     $config["headsup"] = get_news_changes();
 
-    $lang = language_convert($config["lang"]);
-    $curr = $config["current"];
+    /** @noinspection PhpUnusedLocalVariableInspection */
+    $lang    = language_convert($config["lang"]);
+
+    /** @noinspection PhpUnusedLocalVariableInspection */
+    $curr    = $config["current"];
+
     $classes = $config['classes'];
 
     if (isset($_COOKIE["MD"]) || isset($_GET["MD"])) {
+        /** @noinspection PhpUnusedLocalVariableInspection */
         $classes .= "markdown-content";
         $config["css_overwrite"] = array("/styles/i-love-markdown.css");
     }
 
     if (empty($title)) {
+        /** @noinspection PhpUnusedLocalVariableInspection */
         $title = "Hypertext Preprocessor";
     }
 
     // shorturl; http://wiki.snaplog.com/short_url
     if (isset($_SERVER['BASE_PAGE']) && $shortname = get_shortname($_SERVER["BASE_PAGE"])) {
+        /** @noinspection PhpUnusedLocalVariableInspection */
         $shorturl = "https://www.php.net/" . $shortname;
     }
 
     require __DIR__ ."/header.inc";
 }
+
+/** @noinspection PhpUnusedParameterInspection */
 function site_footer($config = array())
 {
+    /** @noinspection PhpUnusedLocalVariableInspection */
     global $MYSITE;
     require __DIR__ . "/footer.inc";
 }
@@ -530,6 +550,9 @@ function site_footer($config = array())
 function get_news_changes()
 {
     include __DIR__ . "/pregen-news.inc";
+    /**
+     * @var array $NEWS_ENTRIES;
+     */
     $date = date_create($NEWS_ENTRIES[0]["updated"]);
     if (isset($_COOKIE["LAST_NEWS"]) && $_COOKIE["LAST_NEWS"] >= $date->getTimestamp()) {
         return false;
@@ -553,6 +576,9 @@ function get_news_changes()
 
 function news_toc($sections = null) {
     include __DIR__ . "/pregen-news.inc";
+    /**
+     * @var array $NEWS_ENTRIES
+     */
     $items = array(
         "news" => array(
             "title" => "News",
@@ -585,9 +611,14 @@ function news_toc($sections = null) {
     }
 }
 function doc_toc($lang) {
+    /**
+     * @var array $TOC
+     */
     $file = __DIR__ . "/../manual/$lang/toc/index.inc";
     if (!file_exists($file)) {
         $lang = "en"; // Fallback on english if the translation doesn't exist
+
+        /** @noinspection PhpUnusedLocalVariableInspection */
         $file = __DIR__ . "/../manual/en/toc/index.inc";
     }
     require __DIR__ . "/../manual/$lang/toc/index.inc";
@@ -632,6 +663,9 @@ function doc_toc($lang) {
 
 }
 function doc_toc_list($lang, $index, $file) {
+    /**
+     * @var array $TOC
+     */
     include __DIR__ . "/../manual/$lang/toc/$file.inc";
 
     doc_toc_title($lang, $index, $file);

--- a/license/index.php
+++ b/license/index.php
@@ -2,6 +2,7 @@
 $_SERVER['BASE_PAGE'] = 'license/index.php';
 include_once __DIR__ . '/../include/prepend.inc';
 
+/** @noinspection HtmlUnknownAnchorTarget */
 $SIDEBAR_DATA = <<<EOF
 <aside>
   <h3>Contents</h3>

--- a/mailing-lists.php
+++ b/mailing-lists.php
@@ -3,6 +3,9 @@ $_SERVER['BASE_PAGE'] = 'mailing-lists.php';
 include_once __DIR__ . '/include/prepend.inc';
 include_once __DIR__ . '/include/posttohost.inc';
 include_once __DIR__ . '/include/email-validation.inc';
+/**
+ * @var string $MYSITE
+ */
 
 $SIDEBAR_DATA = '
 <h3>Would like to unsubscribe yourself?</h3>

--- a/security/index.php
+++ b/security/index.php
@@ -129,6 +129,7 @@ if(is_resource($fp)) {
         }
         $title = ucfirst(strtr($field, "-", " "));
         // Turn urls into links (stolen from master/manage/user-notes.php)
+        /** @noinspection HtmlUnknownTarget */
         $data = preg_replace(
             '!((mailto:|(http|ftp|nntp|news):\/\/).*?)(\s|<|\)|"|\\|\'|$)!',
             '<a href="\1" target="_blank">\1</a>\4',


### PR DESCRIPTION
Without these PHPDoc comments PhpStorm flags the variables, links and fragments as warnings or errors when using the Inspect Code feature. 

With these comments PhpStorm is able to recognize the purpose of the variables and to ignore the links and fragments it could not resolve so as to only flag items that might actually be real errors.