### PR TITLE
Replaced deprecated table attributes with css

### DIFF
--- a/archive/entries/2021-07-13-1.xml
+++ b/archive/entries/2021-07-13-1.xml
@@ -5,6 +5,7 @@
   <published>2021-07-13T16:45:56+00:00</published>
   <updated>2021-07-13T16:45:56+00:00</updated>
   <link href="https://www.php.net/conferences/index.php#id2021-07-13-1" rel="alternate" type="text/html"/>
+  <default:newsImage xmlns="http://php.net/ns/news" link="https://phpcon.php.gr.jp/2021/" title="PHP Conference Japan 2021 Online">phpconfjapan2021.png</default:newsImage>
   <link href="https://www.php.net/archive/2021.php#2021-07-13-1" rel="via" type="text/html"/>
   <default:finalTeaserDate xmlns="http://php.net/ns/news">2021-10-02</default:finalTeaserDate>
   <category term="conferences" label="Conference announcement"/>

--- a/include/layout.inc
+++ b/include/layout.inc
@@ -321,8 +321,8 @@ function display_event($event, $include_date = 1)
         $eday = (isset($event['end']) && !empty($event['end'])) ? strtotime($event['end']) : 0;
     }
 ?>
-<table border="0" cellspacing="0" cellpadding="3" width="100%" class="vevent">
- <tr bgcolor="#dddddd"><td>
+<table class="vevent">
+ <tr><td>
 <?php
 
     // Print out date if needed
@@ -367,7 +367,7 @@ function display_event($event, $include_date = 1)
     echo ' (<span class="location">' , $COUNTRIES[$event['country']] , '</span>)';
 ?>
  </td></tr>
- <tr bgcolor="#eeeeee" class="description"><td>
+ <tr class="description"><td>
 <?php
 
     // Print long description

--- a/license/index.php
+++ b/license/index.php
@@ -27,7 +27,7 @@ site_header("License Information", array("current" => "help"));
 
 <ul>
  <li>
-  PHP 4, PHP 5 and PHP 7 are distributed under the
+  Starting with PHP 4, versions of the PHP software are distributed under the
   <a href="http://www.php.net/license/3_01.txt">PHP License v3.01</a>, copyright (c) the <a href="/credits.php">PHP Group</a>.
   <ul>
    <li>

--- a/mailing-lists.php
+++ b/mailing-lists.php
@@ -345,7 +345,7 @@ function output_lists_table($mailing_lists)
 <?php output_lists_table($internals_mailing_lists); ?>
 
 <p class="center">
- <label for="email"><strong>Email:</strong>
+ <label><strong>Email:</strong>
      <input type="text" name="email" size="40" value="user@example.com">
  </label>
  <input type="submit" name="action" value="Subscribe">


### PR DESCRIPTION
HTML deprecated table element attributes @cellpadding, @cellspacing, @border, @align, etc. so this PR replaces them with CSS classes, selectors and style rules.  It also removed a CSS style rule that was being overwritten by the next line, it removes an invalid font rule (See https://stackoverflow.com/a/20641079/102699), it removes redundant `px` from `0px` and it sneaks in a <label> element to wrap an <input> element per PhpStorm's code inspection instructions.