### PR TITLE
Add returns to end of functions

### DIFF
--- a/include/layout.inc
+++ b/include/layout.inc
@@ -42,8 +42,10 @@ function highlight_php($code, $return = FALSE)
         $highlighted
     ) . '</div>';
 
-    if ($return) { return $highlighted; }
-    else { echo $highlighted; }
+    if (! $return) {
+        echo $highlighted;
+    }
+    return $highlighted;
 }
 
 // Same as highlight_php() but does not require '<?php' in $code
@@ -53,9 +55,10 @@ function highlight_php_trimmed($code, $return = false)
     $highlighted_code = highlight_php($code, true);
     $highlighted_code = preg_replace("/\&lt;\?php(\<br \/\>)+/", '', $highlighted_code, 1);
 
-    if ($return) { return $highlighted_code; }
-
-    echo $highlighted_code;
+    if (!$return) {
+        echo $highlighted_code;
+    }
+    return $highlighted_code;
 }
 
 // Stats pages still need this
@@ -321,8 +324,8 @@ function display_event($event, $include_date = 1)
         $eday = (isset($event['end']) && !empty($event['end'])) ? strtotime($event['end']) : 0;
     }
 ?>
-<table border="0" cellspacing="0" cellpadding="3" width="100%" class="vevent">
- <tr bgcolor="#dddddd"><td>
+<table class="vevent">
+ <tr><td>
 <?php
 
     // Print out date if needed
@@ -367,7 +370,7 @@ function display_event($event, $include_date = 1)
     echo ' (<span class="location">' , $COUNTRIES[$event['country']] , '</span>)';
 ?>
  </td></tr>
- <tr bgcolor="#eeeeee" class="description"><td>
+ <tr class="description"><td>
 <?php
 
     // Print long description
@@ -549,6 +552,7 @@ function get_news_changes()
         $title = $NEWS_ENTRIES[0]["title"];
         return "<a href='{$link}'>{$title}</a>";
     }
+    return false;
 }
 
 function news_toc($sections = null) {

--- a/include/layout.inc
+++ b/include/layout.inc
@@ -324,8 +324,8 @@ function display_event($event, $include_date = 1)
         $eday = (isset($event['end']) && !empty($event['end'])) ? strtotime($event['end']) : 0;
     }
 ?>
-<table class="vevent">
- <tr><td>
+<table border="0" cellspacing="0" cellpadding="3" width="100%" class="vevent">
+ <tr bgcolor="#dddddd"><td>
 <?php
 
     // Print out date if needed
@@ -370,7 +370,7 @@ function display_event($event, $include_date = 1)
     echo ' (<span class="location">' , $COUNTRIES[$event['country']] , '</span>)';
 ?>
  </td></tr>
- <tr class="description"><td>
+ <tr bgcolor="#eeeeee" class="description"><td>
 <?php
 
     // Print long description

--- a/include/layout.inc
+++ b/include/layout.inc
@@ -55,7 +55,7 @@ function highlight_php_trimmed($code, $return = false)
     $highlighted_code = preg_replace("/\&lt;\?php(\<br \/\>)+/", '', $highlighted_code, 1);
 
     if ($return) { return $highlighted_code; }
-    else { echo $highlighted_code; }
+    echo $highlighted_code;
     return null;
 }
 

--- a/include/layout.inc
+++ b/include/layout.inc
@@ -43,7 +43,7 @@ function highlight_php($code, $return = FALSE)
     ) . '</div>';
 
     if ($return) { return $highlighted; }
-    else { echo $highlighted; }
+    echo $highlighted;
     return null;
 }
 

--- a/include/layout.inc
+++ b/include/layout.inc
@@ -42,10 +42,9 @@ function highlight_php($code, $return = FALSE)
         $highlighted
     ) . '</div>';
 
-    if (! $return) {
-        echo $highlighted;
-    }
-    return $highlighted;
+    if ($return) { return $highlighted; }
+    else { echo $highlighted; }
+    return null;
 }
 
 // Same as highlight_php() but does not require '<?php' in $code
@@ -55,10 +54,9 @@ function highlight_php_trimmed($code, $return = false)
     $highlighted_code = highlight_php($code, true);
     $highlighted_code = preg_replace("/\&lt;\?php(\<br \/\>)+/", '', $highlighted_code, 1);
 
-    if (!$return) {
-        echo $highlighted_code;
-    }
-    return $highlighted_code;
+    if ($return) { return $highlighted_code; }
+    else { echo $highlighted_code; }
+    return null;
 }
 
 // Stats pages still need this


### PR DESCRIPTION
PhpStorm flags functions that don't have returns at the end so this PR rearranges code so that the returns are always at the end, or in one case adds one that was missing.