### PR TITLE
Fix mismatched <p> tags

### DIFF
--- a/archive/2007.php
+++ b/archive/2007.php
@@ -90,10 +90,16 @@ using <a href="/my.php">my.php</a>.
     <div>
   <span class="newsdate">[21-Sep-2007]</span>
   <p>
-November 7th - 9th, Join us at the 2nd Annual DC PHP Conference. The event will take place at George Washington University's Cafritz Conference Center in the heart of Washington DC. The three day conference begins November 7th and 8th with general sessions, and ends November 9th with tutorials. This year's conference will host some of the PHP Community's top speakers and developers and focus on three primary tracks:
-<ul><li>Scalability</li><li>Security</li><li>The Art of PHP</li></ul>
-Please see <a href="http://www.dcphpconference.com ">the website</a> for more details and to register. Early registration is available until mid-October.
-	</p>
+   November 7th - 9th, Join us at the 2nd Annual DC PHP Conference. The event will take place at George Washington University's Cafritz Conference Center in the heart of Washington DC. The three day conference begins November 7th and 8th with general sessions, and ends November 9th with tutorials. This year's conference will host some of the PHP Community's top speakers and developers and focus on three primary tracks:
+  </p>
+  <ul>
+   <li>Scalability</li>
+   <li>Security</li>
+   <li>The Art of PHP</li>
+  </ul>
+  <p>
+   Please see <a href="http://www.dcphpconference.com ">the website</a> for more details and to register. Early registration is available until mid-October.
+  </p>
 
 </div>
 </div>

--- a/archive/2009.php
+++ b/archive/2009.php
@@ -579,17 +579,16 @@ site_header("News Archive - 2009", array("cache" => true));
         <div>
      <p>CodeWorks 2009 is a series of <em>two-day conferences for PHP developers</em> and IT managers organized and run by the publishers of <a href="http://phparch.com/">php|architect Magazine</a>.</p>
      <p>CodeWorks will travel to <a href="http://cw.mtacon.com/main/s/about/locations">seven locations</a> across the United States between <abbr title="2009-09-22" class="dtstart">September 22nd</abbr> and <abbr title="2009-10-06" class="dtend">October 5th</abbr> included. Each two-day event includes a day of <em>in-depth tutorials</em>  and a day of <em>conference talks</em> arranged across three different tracks, all presented by the <em>best experts</em> in the business.</p>
-     <p>These locations include:
-      <ul>
-       <li>San Francisco, CA (9/22-9/23)</li>
-       <li>Los Angeles, CA (9/24-9/25)</li>
-       <li>Dallas, TX (9/26-9/27)</li>
-       <li>Atlanta, GA (9/28-9/29)</li>
-       <li>Miami, FL (9/30-10/1)</li>
-       <li>Washington, DC/Baltimore Area (10/2-10/3)</li>
-       <li>New York, NY (10/4-10/5)</li>
-      </ul>
-     </p>
+     <p>These locations include:</p>
+     <ul>
+      <li>San Francisco, CA (9/22-9/23)</li>
+      <li>Los Angeles, CA (9/24-9/25)</li>
+      <li>Dallas, TX (9/26-9/27)</li>
+      <li>Atlanta, GA (9/28-9/29)</li>
+      <li>Miami, FL (9/30-10/1)</li>
+      <li>Washington, DC/Baltimore Area (10/2-10/3)</li>
+      <li>New York, NY (10/4-10/5)</li>
+     </ul>
      <p>If PHP is your work, your passion or your hobby, CodeWorks is a great way to learn and connect with the greatest community of professionals in the world—and with <a href="http://cw.mtacon.com/signup/index">prices as low as $99</a> and a generous <a href="http://cw.mtacon.com/signup/s/discounts">discount program</a>, a uniquely affordable opportunity for everyone.</p>
      <p>Remember, each event is <em>limited to 300 attendees</em> and prices increase the closer we get to each event. <a href="http://cw.mtacon.com/signup/index">Get your tickets today</a> before we run out or the price goes up!</p>
      <p>For more information, visit <a href="http://cw.mtacon.com/">http://cw.mtacon.com</a>.</p>
@@ -721,12 +720,12 @@ site_header("News Archive - 2009", array("cache" => true));
      </p>
      <p>
       The phpDay will have three channels:
-      <ul>
-       <li>Developers: development approach and techniques</li>
-       <li>Community: focus on open source software and frameworks</li>
-       <li>Enterprise: real case studies for business and enterprises</li>
-      </ul>
      </p>
+     <ul>
+      <li>Developers: development approach and techniques</li>
+      <li>Community: focus on open source software and frameworks</li>
+      <li>Enterprise: real case studies for business and enterprises</li>
+     </ul>
      <p>
       For the benefit of our international visitors, there will be an
       entiretrack in english, so come and join us in the beautiful city of

--- a/archive/2010.php
+++ b/archive/2010.php
@@ -555,19 +555,18 @@ class Bar {<br>
     <li>Open Source Trainer/ Educationist</li>
    </ul>
    <p><strong>We invite you to submit a proposal on one of the topics below:</strong></p>
-   <p>
-    <ul>
-     <li>Cloud Computing: Tools and Platforms, Cloudnomics, Cloud for
-      Dummies &amp; Others</li>
-     <li>PHP: PHP 5 &amp; 6, PHP Security, Frameworks, Architecture / QA &amp; Best
-      Practices</li>
-     <li>Drupal: Best Practices, Module Development, Theme Development,
-      Scaling/ Management/ Performance &amp; Others</li>
-     <li>Databases: MySQL, NoSQL, CouchDB, PostgreSQL, Ingres, SQLite &amp; Others</li>
-     <li>Java Script</li>
-     <li>Developer / Tools &amp; Techniques</li>
-    </ul>
-   </p>
+   <ul>
+    <li>Cloud Computing: Tools and Platforms, Cloudnomics, Cloud for
+     Dummies &amp; Others</li>
+    <li>PHP: PHP 5 &amp; 6, PHP Security, Frameworks, Architecture / QA &amp; Best
+     Practices</li>
+    <li>Drupal: Best Practices, Module Development, Theme Development,
+     Scaling/ Management/ Performance &amp; Others</li>
+    <li>Databases: MySQL, NoSQL, CouchDB, PostgreSQL, Ingres, SQLite &amp; Others</li>
+    <li>Java Script</li>
+    <li>Developer / Tools &amp; Techniques</li>
+   </ul>
+
    <p><strong>Types of Presentation</strong></p>
    <ul>
     <li>45 minute Session</li>
@@ -576,18 +575,16 @@ class Bar {<br>
     <li>Full Day tutorial / workshop</li>
    </ul>
    <p><strong>Your proposals Should</strong></p>
-   <p>
-    <ul>
-     <li>be Free of Marketing talks / self promotion / company promotion:
-      Please speak about ideas/ technology/ business and not about
-      yourself or your company. Talk about Open Source Projects/
-      Products and not strictly commercial closed source products.</li>
-     <li>Clearly identify your target audience and what are the
-      pre-requisites while submitting the proposal</li>
-     <li>Have a clear title and limit the scope of your proposal to
-      something specific rather than trying to cover too much</li>
-    </ul>
-   </p>
+   <ul>
+    <li>be Free of Marketing talks / self promotion / company promotion:
+     Please speak about ideas/ technology/ business and not about
+     yourself or your company. Talk about Open Source Projects/
+     Products and not strictly commercial closed source products.</li>
+    <li>Clearly identify your target audience and what are the
+     pre-requisites while submitting the proposal</li>
+    <li>Have a clear title and limit the scope of your proposal to
+     something specific rather than trying to cover too much</li>
+   </ul>
    <p><strong>Speaker Benefits</strong></p>
    <p>OSI Days offers its speakers tremendous opportunities for exposure and
     recognition as an industry leader. Your session will attract many

--- a/archive/2011.php
+++ b/archive/2011.php
@@ -332,6 +332,7 @@ site_header("News Archive - 2011", array("cache" => true));
      </p>
      <p>
      Conference Tickets:
+     </p>
      <ul>
      <li>1-day: € 399,– plus vat/tax before 7th of September 2011
      (later booking € 499,– plus vat/tax)</li>
@@ -341,7 +342,6 @@ site_header("News Archive - 2011", array("cache" => true));
      (later booking € 1.099,– plus vat/tax)
      </li>
      </ul>
-     </p>
      <p>
      Information and booking via the website: <a href="http://www.web-devcon.de">http://www.web-devcon.de</a>
      </p>
@@ -527,13 +527,12 @@ site_header("News Archive - 2011", array("cache" => true));
      The Zend PHP Conference (ZendCon) is the largest gathering of the PHP Community and brings together PHP developers and IT managers from around the world to discuss PHP best practices and explore new technologies.
      </p>
 
-     <p>This year’s conference will be held on October 17-20, 2011 at the Convention Center in Santa Clara, California. The conference will include a variety of technical sessions and in-depth tutorials in the following areas:
+     <p>This year’s conference will be held on October 17-20, 2011 at the Convention Center in Santa Clara, California. The conference will include a variety of technical sessions and in-depth tutorials in the following areas:</p>
      <ul>
      <li>Cloud Computing - build applications, not infrastructure.<br>Learn about the latest developments in PHP Cloud infrastructure, management and application services</li>
      <li>Mobile and User Experience - go beyond the browser<br>Learn how to build engaging mobile apps with the latest PHP technologies and tools</li>
      <li>Enterprise and Professional PHP - master your craft<br>Explore PHP best practices, new technologies and practical tips with industry experts</li>
      </ul>
-     </p>
      <p>
      For more details and to register for ZendCon, visit the website at: http://www.zendcon.com/
      </p>
@@ -607,7 +606,7 @@ site_header("News Archive - 2011", array("cache" => true));
      anymore. All users are strongly encouraged to upgrade to PHP 5.3.7.</p>
     </div>
 
-    <p xmlns="http://www.w3.org/2005/Atom">For a full list of changes in PHP 5.3.7, see the
+    <p>For a full list of changes in PHP 5.3.7, see the
      <a href="/ChangeLog-5.php#5.3.7">ChangeLog</a>. For source downloads
      please visit our <a href="/downloads.php">downloads page</a>, Windows
      binaries can be found on <a href="http://windows.php.net/download/">windows.php.net/download/</a>.</p>

--- a/archive/2012.php
+++ b/archive/2012.php
@@ -459,7 +459,6 @@ site_header("News Archive - 2012", array("cache" => true));
      <p>
      This year promises to be the best ZendCon ever! We are planning a fun new exhibit hall, some great parties including a hackathon and, of course, oodles of excellent PHP content!
      </p>
-     <p>
      <ul>
      <li>Learn PHP best practices for architecture, design and development</li>
      <li>Discover new advances in the PHP language and how to best harness them</li>
@@ -468,21 +467,13 @@ site_header("News Archive - 2012", array("cache" => true));
      <li>Discover how to deploy and scale large PHP applications</li>
      <li>Explore new technologies like NoSQL and Cloud Computing</li>
      </ul>
-     </p>
-     <p>
-     <ul>
-     <li>What: PHP 2012 (ZendCon)
-     </li>
-     <li>When: Mon Oct 22- Thurs Oct 25
-     </li>
-     <li>Where: Santa Clara, CA
-     </li>
-     <li>Tickets: Early reg discount until Sept 8
-     </li>
-     </ul>
-     </p>
-    </div>
 
+     <ul>
+     <li>What: PHP 2012 (ZendCon)</li>
+     <li>When: Mon Oct 22- Thurs Oct 25</li>
+     <li>Where: Santa Clara, CA</li>
+     <li>Tickets: Early reg discount until Sept 8</li>
+     </ul>
     </div>
 </div>
 <div class="newsItem hentry">
@@ -584,14 +575,12 @@ site_header("News Archive - 2012", array("cache" => true));
      <p>
          Check out the <a href="http://www.northeastphp.org/">Northeast PHP website</a> for a listing of the talks and speakers lined up.
      </p>
-     <p>
-         <ul>
-             <li><strong>What:</strong> Northeast PHP Conference</li>
-             <li><strong>When:</strong> Sat-Sun August 11-12, 2012 8am-5pm</li>
-             <li><strong>*Where:</strong> Microsoft NERD</li>
-             <li><strong>*Tickets:</strong> Tickets go on sale June 28th!</li>
-         </ul>
-     </p>
+     <ul>
+         <li><strong>What:</strong> Northeast PHP Conference</li>
+         <li><strong>When:</strong> Sat-Sun August 11-12, 2012 8am-5pm</li>
+         <li><strong>*Where:</strong> Microsoft NERD</li>
+         <li><strong>*Tickets:</strong> Tickets go on sale June 28th!</li>
+     </ul>
     </div>
 
     </div>
@@ -656,9 +645,8 @@ site_header("News Archive - 2012", array("cache" => true));
     instead of <strong>"$@"</strong> to pass parameters to php-cgi which causes a number of
     issues. Again, people using mod_php or php-fpm are not affected.</p>
 
-    <p>
-    One way to address these CGI issues is to reject the request if the query string
-    contains a '-' and no '='. It can be done using Apache's mod_rewrite like this:
+    <p>One way to address these CGI issues is to reject the request if the query string
+    contains a '-' and no '='. It can be done using Apache's mod_rewrite like this:</p>
 
     <pre>
     RewriteCond %{QUERY_STRING} ^[^=]*$
@@ -666,7 +654,7 @@ site_header("News Archive - 2012", array("cache" => true));
     RewriteRule .? - [F,L]
     </pre>
 
-    Note that this will block otherwise safe requests like ?top-40 so if you
+    <p>Note that this will block otherwise safe requests like ?top-40 so if you
     have query parameters that look like that, adjust your regex accordingly.</p>
 
     <p>Another set of releases are planned for Tuesday, May, 8th. These

--- a/archive/2013.php
+++ b/archive/2013.php
@@ -353,11 +353,11 @@ site_header("News Archive - 2013", array("cache" => true));
   <h2 class="summary entry-title"><a name="id2013-08-22-1" id="id2013-08-22-1" href="http://php.net/archive/2013.php#id2013-08-22-1" rel="bookmark" class="bookmark">PHP 5.4.19 and PHP 5.5.3 Released!</a></h2>
   <div class="entry-content description">
     <abbr class="published newsdate" title="2013-08-22T16:06:05-07:00">22-Aug-2013</abbr>
-    <p xmlns="http://www.w3.org/2005/Atom">The PHP development team announces the immediate availability of PHP
+    <p>The PHP development team announces the immediate availability of PHP
     5.4.19 and PHP 5.5.3. These releases fix a bug in the patch for CVE-2013-4248 in OpenSSL module and
     compile failure with ZTS enabled in PHP 5.4. All PHP users are encouraged to upgrade to either PHP 5.5.3 or PHP 5.4.19.</p>
 
-    <p xmlns="http://www.w3.org/2005/Atom">For source downloads of PHP 5.4.19 and PHP 5.5.3 please visit our <a href="http://www.php.net/downloads.php">downloads page</a>,
+    <p>For source downloads of PHP 5.4.19 and PHP 5.5.3 please visit our <a href="http://www.php.net/downloads.php">downloads page</a>,
     Windows binaries can be found on <a href="http://windows.php.net/download/">windows.php.net/download/</a>.
     The list of changes is recorded in the <a href="http://www.php.net/ChangeLog-5.php#5.4.19">ChangeLog</a>.
     </p>

--- a/archive/2014.php
+++ b/archive/2014.php
@@ -1306,27 +1306,27 @@ The list of changes is recorded in the <a href="http://www.php.net/ChangeLog-5.p
   </header>
   <time class="newsdate" datetime="2014-05-29T03:11:15+02:00">29 May 2014</time>
   <div class="newscontent">
-    <p xmlns="http://www.w3.org/2005/Atom">We’re pleased to announce the 10th annual ZendCon which will be held October 27-30th, 2014 in Santa Clara, CA. ZendCon 2014 has a long history of being one of the “must attend” PHP conferences as community members from around the world have come together to learn and share information about the latest trends and technologies in professional PHP development. Our main topics this year are:</p>
+    <p>We’re pleased to announce the 10th annual ZendCon which will be held October 27-30th, 2014 in Santa Clara, CA. ZendCon 2014 has a long history of being one of the “must attend” PHP conferences as community members from around the world have come together to learn and share information about the latest trends and technologies in professional PHP development. Our main topics this year are:</p>
 
-     <ul xmlns="http://www.w3.org/2005/Atom">
+     <ul>
         <li>PHP Best Practices and Tooling</li>
         <li>Continuous Delivery and DevOps</li>
         <li>Application Architecture - APIs, Mobile, Cloud Services</li>
     </ul>
 
-    <p xmlns="http://www.w3.org/2005/Atom">
+    <p>
         We would welcome submission of any talk included in the wide variety of
         topics related to PHP and tools commonly used by PHP developers. We are
         looking for submissions for:
     </p>
 
-    <ul xmlns="http://www.w3.org/2005/Atom">
+    <ul>
         <li>Pre-conference tutorials on October 27 - 3 hour intensive session</li>
         <li>Breakout sessions on October 28, 29 and 30 - 1 hour sessions including Q&amp;A</li>
         <li>Keynote sessions on October 28-30 – 1 hour sessions with topics appealing to the entire audience</li>
     </ul>
 
-    <p xmlns="http://www.w3.org/2005/Atom">
+    <p>
         For those interested in speaking, please head out to
         <a href="http://cfp.zendcon.com">http://cfp.zendcon.com</a> to
         submit on or before June 16th, 2014.
@@ -1629,6 +1629,7 @@ The list of changes is recorded in the <a href="http://www.php.net/ChangeLog-5.p
       </p>
       <p>
         Conference numbers
+      </p>
         <ul>
           <li>Expecting more than 700 attendees</li>
           <li>Full exclusivity of a highly recognized venue in Buenos Aires, giving us
@@ -1637,8 +1638,9 @@ The list of changes is recorded in the <a href="http://www.php.net/ChangeLog-5.p
             day at a farm (called the "Gaucho day") to improve networking opportunities.</li>
           <li>Organized social activities for both conference days.</li>
         </ul>
-        More info: <a href="http://www.phpconference.com.ar">www.phpconference.com.ar</a>
-      </p>
+        <p>
+         More info: <a href="http://www.phpconference.com.ar">www.phpconference.com.ar</a>
+        </p>
     </div>
 
   </div>

--- a/contact.php
+++ b/contact.php
@@ -26,6 +26,7 @@ site_header("Contact", array("current" => "community"));
  For security related issues (in PHP or our websites) please contact
  <a href="mailto:security@php.net">security@php.net</a>.
  Please note that the following are <b>NOT</b> security issues:
+</p>
  <ul>
   <li><b>Requests for help with using PHP.</b> Please use the
       <a href="mailto:php-general@lists.php.net">PHP General</a> mailing list.</li>
@@ -38,7 +39,6 @@ site_header("Contact", array("current" => "community"));
       The servers are donated hardware and bandwidth.
       Your bug reports and patches are appreciated, but we can not pay you for them.</li>
  </ul>
-</p>
 <p>
  If you have problems setting up PHP or using some functionality,
  or especially a program written in PHP, please ask your question on a


### PR DESCRIPTION
When inspecting the code with PhpStorm is reported that the usage of the <p> tags that were modified in this commit were invalid. Mostly the <p> tags were enclosing <ul>..</ul> tags which is not valid HTML. This commit fixes the HTML to be valid and includes