### PR TITLE
usability: avoid gap between a wrapped link in aside bar

### DIFF
--- a/styles/theme-medium.css
+++ b/styles/theme-medium.css
@@ -407,11 +407,13 @@ aside.tips div.border {
 aside.tips h3 {
   color:#E6E6E6;
 }
+aside.tips li {
+  line-height: 1.2rem; /** avoid gaps in wrapped links **/
+  margin-bottom: 0.5rem; /** seperate each link item a little bit from eachother **/
+}
 aside.tips a {
   color:#ccc;
   border-bottom:1px dotted #666;
-  display:inline-block;
-  vertical-align:top;
 }
 aside.tips .panel > a:after,
 aside.tips .panel > span:after {

--- a/styles/theme-medium.css
+++ b/styles/theme-medium.css
@@ -410,6 +410,8 @@ aside.tips h3 {
 aside.tips a {
   color:#ccc;
   border-bottom:1px dotted #666;
+  display:inline-block;
+  vertical-align:top;
 }
 aside.tips .panel > a:after,
 aside.tips .panel > span:after {

--- a/styles/theme-medium.css
+++ b/styles/theme-medium.css
@@ -408,8 +408,8 @@ aside.tips h3 {
   color:#E6E6E6;
 }
 aside.tips li {
-  line-height: 1.2rem; /** avoid gaps in wrapped links **/
-  margin-bottom: 0.5rem; /** seperate each link item a little bit from eachother **/
+  line-height: 1.2rem; /* avoid gaps in wrapped links */
+  margin-bottom: 0.5rem; /* seperate each link item a little bit from eachother */
 }
 aside.tips a {
   color:#ccc;


### PR DESCRIPTION
The upcoming conference links are wrapped and clicking between should activate the link, not require the user to decide to click the upper or bottom line of the link.

![wrappedlinkgap](https://user-images.githubusercontent.com/1839154/131468577-bc706794-655e-4801-9513-f1077301d655.png)