### PR TITLE
Mark Romanian as inactive

### DIFF
--- a/include/languages.inc
+++ b/include/languages.inc
@@ -77,6 +77,7 @@ $INACTIVE_ONLINE_LANGUAGES = array(
     'pl'    => 'Polish',
     'pt'    => 'Portuguese',
     'fa'    => 'Persian',
+    'ro'    => 'Romanian',
     'sr'    => 'Serbian',
     'sk'    => 'Slovak',
     'sl'    => 'Slovenian',


### PR DESCRIPTION
Relates [`#81545`](https://bugs.php.net/bug.php?id=81545).

Romanian translation has not been updated for a long time and the build is broken a few months.