### PR TITLE
improve fix of php bug #74493

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -335,7 +335,7 @@ $(document).ready(function() {
     {
       var id = $(this).text().replace(/^&?(\.\.\.)?\$?/g, '');
       var offsetTop = $('.parameters, .options').find('.parameter').filter(function() {
-          return $(this).text() === id; // https://bugs.php.net/bug.php?id=74493
+        return $(this).text().trim() === id; // https://bugs.php.net/bug.php?id=74493
       }).offset().top - 52;
       $.scrollTo({top: offsetTop, left: 0}, 400);
     });


### PR DESCRIPTION
improvement of 6cec58d9 (Use exact word for parameter scroll #74493,
2017-04-25). some options are rendered with surrounding white-space (e.g.
in front of "scale" for `bcdiv()`s' scale parameter [1].

fix is to not compare the word against surrounding spaces (UCS-0020) etc.
by removal through ECMAScript 5 15.5.4.20 String.prototype.trim(),
2009-12-03.

finally fix the lines' indent.

#74493: https://bugs.php.net/bug.php?id=74493
[1]: https://php.net/manual/en/function.bcdiv.php
ref: 6cec58d94b1357b907389e4b5123de85176bf635