### PR TITLE
improve local font support

### DIFF
--- a/fonts/Fira/fira.css
+++ b/fonts/Fira/fira.css
@@ -1,7 +1,8 @@
 @font-face{
     font-family: 'Fira Sans';
     src: url('/fonts/Fira/eot/FiraSans-Book.eot');
-    src: local('/fonts/Fira/Fira Sans Book'),
+    src: local('Fira Sans Book'),
+         local('/fonts/Fira/Fira Sans Book'),
          url('/fonts/Fira/eot/FiraSans-Book.eot') format('embedded-opentype'),
          url('/fonts/Fira/woff/FiraSans-Book.woff') format('woff'),
          url('/fonts/Fira/ttf/FiraSans-Book.ttf') format('truetype');
@@ -12,7 +13,8 @@
 @font-face{
     font-family: 'Fira Sans';
     src: url('/fonts/Fira/eot/FiraSans-BookItalic.eot');
-    src: local('/fonts/Fira/Fira Sans Book Italic'),
+    src: local('Fira Sans Book Italic'),
+         local('/fonts/Fira/Fira Sans Book Italic'),
          url('/fonts/Fira/eot/FiraSans-BookItalic.eot') format('embedded-opentype'),
          url('/fonts/Fira/woff/FiraSans-BookItalic.woff') format('woff'),
          url('/fonts/Fira/ttf/FiraSans-BookItalic.ttf') format('truetype');
@@ -23,7 +25,8 @@
 @font-face{
     font-family: 'Fira Sans';
     src: url('/fonts/Fira/eot/FiraSans-Medium.eot');
-    src: local('/fonts/Fira/Fira Sans Medium'),
+    src: local('Fira Sans Medium'),
+         local('/fonts/Fira/Fira Sans Medium'),
          url('/fonts/Fira/eot/FiraSans-Medium.eot') format('embedded-opentype'),
          url('/fonts/Fira/woff/FiraSans-Medium.woff') format('woff'),
          url('/fonts/Fira/ttf/FiraSans-Medium.ttf') format('truetype');
@@ -34,7 +37,8 @@
 @font-face{
     font-family: 'Fira Sans';
     src: url('/fonts/Fira/eot/FiraSans-MediumItalic.eot');
-    src: local('/fonts/Fira/Fira Sans Medium Italic'),
+    src: local('Fira Sans Medium Italic'),
+         local('/fonts/Fira/Fira Sans Medium Italic'),
          url('/fonts/Fira/eot/FiraSans-MediumItalic.eot') format('embedded-opentype'),
          url('/fonts/Fira/woff/FiraSans-MediumItalic.woff') format('woff'),
          url('/fonts/Fira/ttf/FiraSans-MediumItalic.ttf') format('truetype');
@@ -45,7 +49,8 @@
 @font-face{
     font-family: 'Fira Mono';
     src: url('/fonts/Fira/eot/FiraMono-Regular.eot');
-    src: local('/fonts/Fira/Fira Mono'),
+    src: local('Fira Mono'),
+         local('/fonts/Fira/Fira Mono'),
          url('/fonts/Fira/eot/FiraMono-Regular.eot') format('embedded-opentype'),
          url('/fonts/Fira/woff/FiraMono-Regular.woff') format('woff'),
          url('/fonts/Fira/ttf/FiraMono-Regular.ttf') format('truetype');
@@ -56,7 +61,8 @@
 @font-face{
     font-family: 'Fira Mono';
     src: url('/fonts/Fira/eot/FiraMono-Bold.eot');
-    src: local('/fonts/Fira/Fira Mono Bold'),
+    src: local('Fira Mono Bold'),
+         local('/fonts/Fira/Fira Mono Bold'),
          url('/fonts/Fira/eot/FiraMono-Bold.eot') format('embedded-opentype'),
          url('/fonts/Fira/woff/FiraMono-Bold.woff') format('woff'),
          url('/fonts/Fira/ttf/FiraMono-Bold.ttf') format('truetype');


### PR DESCRIPTION
previously local font support directs absolute paths while it is unknown to
me if paths of any kind are accepted for resolution of fonts with the CSS
`local()` function.

therefore adding the known parts that `local()` function resolves to font-
names on the local system (with preference over previous).

for me this is a great improvement as the fonts don't need to be loaded
via HTTP any longer but just work when they are locally installed using
a desktop computer.

as the Fira Sans and Fira Mono typefaces are in use on the PHP website and
my local system normally ships with these, the website loads much faster,
especially visually (fonts are used to display the text of the website).

this also reduces requests to the web-server hosting the PHP homepage
incl. the manual when the system already has the fonts.

NOTE: the circumstance that local() with absolute path-names has no effect
      is - if - not addressed in this change in so far that the original
      directives remain unchanged. this is done b/c I don't understand them
      well and might construe a flaw.