### PR TITLE
Improve local font-names

### DIFF
--- a/fonts/Fira/fira.css
+++ b/fonts/Fira/fira.css
@@ -2,7 +2,7 @@
     font-family: 'Fira Sans';
     src: url('/fonts/Fira/eot/FiraSans-Book.eot');
     src: local('Fira Sans Book'),
-         local('/fonts/Fira/Fira Sans Book'),
+         local('FiraSans-Book'),
          url('/fonts/Fira/eot/FiraSans-Book.eot') format('embedded-opentype'),
          url('/fonts/Fira/woff/FiraSans-Book.woff') format('woff'),
          url('/fonts/Fira/ttf/FiraSans-Book.ttf') format('truetype');
@@ -14,7 +14,7 @@
     font-family: 'Fira Sans';
     src: url('/fonts/Fira/eot/FiraSans-BookItalic.eot');
     src: local('Fira Sans Book Italic'),
-         local('/fonts/Fira/Fira Sans Book Italic'),
+         local('FiraSans-BookItalic'),
          url('/fonts/Fira/eot/FiraSans-BookItalic.eot') format('embedded-opentype'),
          url('/fonts/Fira/woff/FiraSans-BookItalic.woff') format('woff'),
          url('/fonts/Fira/ttf/FiraSans-BookItalic.ttf') format('truetype');
@@ -26,7 +26,7 @@
     font-family: 'Fira Sans';
     src: url('/fonts/Fira/eot/FiraSans-Medium.eot');
     src: local('Fira Sans Medium'),
-         local('/fonts/Fira/Fira Sans Medium'),
+         local('FiraSans-Medium'),
          url('/fonts/Fira/eot/FiraSans-Medium.eot') format('embedded-opentype'),
          url('/fonts/Fira/woff/FiraSans-Medium.woff') format('woff'),
          url('/fonts/Fira/ttf/FiraSans-Medium.ttf') format('truetype');
@@ -38,7 +38,7 @@
     font-family: 'Fira Sans';
     src: url('/fonts/Fira/eot/FiraSans-MediumItalic.eot');
     src: local('Fira Sans Medium Italic'),
-         local('/fonts/Fira/Fira Sans Medium Italic'),
+         local('FiraSans-MediumItalic'),
          url('/fonts/Fira/eot/FiraSans-MediumItalic.eot') format('embedded-opentype'),
          url('/fonts/Fira/woff/FiraSans-MediumItalic.woff') format('woff'),
          url('/fonts/Fira/ttf/FiraSans-MediumItalic.ttf') format('truetype');
@@ -50,7 +50,7 @@
     font-family: 'Fira Mono';
     src: url('/fonts/Fira/eot/FiraMono-Regular.eot');
     src: local('Fira Mono'),
-         local('/fonts/Fira/Fira Mono'),
+         local('FiraMono-Regular'),
          url('/fonts/Fira/eot/FiraMono-Regular.eot') format('embedded-opentype'),
          url('/fonts/Fira/woff/FiraMono-Regular.woff') format('woff'),
          url('/fonts/Fira/ttf/FiraMono-Regular.ttf') format('truetype');
@@ -62,7 +62,7 @@
     font-family: 'Fira Mono';
     src: url('/fonts/Fira/eot/FiraMono-Bold.eot');
     src: local('Fira Mono Bold'),
-         local('/fonts/Fira/Fira Mono Bold'),
+         local('FiraMono-Bold'),
          url('/fonts/Fira/eot/FiraMono-Bold.eot') format('embedded-opentype'),
          url('/fonts/Fira/woff/FiraMono-Bold.woff') format('woff'),
          url('/fonts/Fira/ttf/FiraMono-Bold.ttf') format('truetype');


### PR DESCRIPTION
In 2ceaff53 (Improve fonts support, 2021-11-26) local font names were
added but it was still missing a closer review on the previous local
/fonts/ prefixed font names which were retained while annotated to be
potentially wrong. [#462]

Now after review of the [@font-face rule] in the CSS Fonts Module
Level 3 W3C Recommendation 20 September 2018 in regard to `local()`, the
following two educated guesses are made:

1. /fonts/ prefixed local() font-names were introduced in the 2014
   transition in error and can be removed as those are ineffective, ref
   78286b7a (Font URLs are now relative to root; cached.php was breaking
   the relative URLs., 2014-05-27)

2. local() should have the Postscript name as well as it is "the
   commonly used key for all fonts on OSX and for Postscript CFF fonts
   under Windows". [ibid.]

Postscript names were obtained with FontForge (20190801), Element ->
Font Info... (Ctrl+Shift+F): PS Names -> Fontname.

Replace /fonts/Fira/* font-names with their Postscript name.

[#462]: https://github.com/php/web-php/pull/462
[@font-face rule]: https://www.w3.org/TR/css-fonts-3/#at-font-face-rule