### PR TITLE
Update documentations links at releases pages

### DIFF
--- a/releases/8.0/es.php
+++ b/releases/8.0/es.php
@@ -160,7 +160,7 @@ releases\php80\common_header(
     <h2 class="php8-h2" id="union-types">
       Tipos de unión
       <a class="php8-rfc" href="https://wiki.php.net/rfc/union_types_v2">RFC</a>
-      <a class="php8-rfc" href="/manual/en/language.types.declarations.php#language.types.declarations.union">Doc</a>
+      <a class="php8-rfc" href="/manual/en/language.types.declarations.php#language.types.declarations.composite.union">Doc</a>
     </h2>
     <div class="php8-compare__main">
       <div class="php8-compare__block example-contents">

--- a/releases/8.0/fr.php
+++ b/releases/8.0/fr.php
@@ -159,7 +159,7 @@ class User
   <div class="php8-compare">
     <h2 class="php8-h2" id="union-types">
       Types d'union
-      <a class="php8-rfc" href="https://wiki.php.net/rfc/union_types_v2">RFC</a> <a class="php8-rfc" href="/manual/fr/language.types.declarations.php#language.types.declarations.union">Doc</a>
+      <a class="php8-rfc" href="https://wiki.php.net/rfc/union_types_v2">RFC</a> <a class="php8-rfc" href="/manual/fr/language.types.declarations.php#language.types.declarations.composite.union">Doc</a>
     </h2>
     <div class="php8-compare__main">
       <div class="php8-compare__block example-contents">

--- a/releases/8.0/it.php
+++ b/releases/8.0/it.php
@@ -162,7 +162,7 @@ releases\php80\common_header(
   <div class="php8-compare">
     <h2 class="php8-h2" id="union-types">
       Tipi unione
-      <a class="php8-rfc" href="https://wiki.php.net/rfc/union_types_v2">RFC</a> <a class="php8-rfc" href="/manual/en/language.types.declarations.php#language.types.declarations.union">Doc</a>
+      <a class="php8-rfc" href="https://wiki.php.net/rfc/union_types_v2">RFC</a> <a class="php8-rfc" href="/manual/en/language.types.declarations.php#language.types.declarations.composite.union">Doc</a>
     </h2>
     <div class="php8-compare__main">
       <div class="php8-compare__block example-contents">

--- a/releases/8.0/ja.php
+++ b/releases/8.0/ja.php
@@ -159,7 +159,7 @@ releases\php80\common_header(
   <div class="php8-compare">
     <h2 class="php8-h2" id="union-types">
       Union 型
-      <a class="php8-rfc" href="https://wiki.php.net/rfc/union_types_v2">RFC</a> <a class="php8-rfc" href="/manual/ja/language.types.declarations.php#language.types.declarations.union">Doc</a>
+      <a class="php8-rfc" href="https://wiki.php.net/rfc/union_types_v2">RFC</a> <a class="php8-rfc" href="/manual/ja/language.types.declarations.php#language.types.declarations.composite.union">Doc</a>
     </h2>
     <div class="php8-compare__main">
       <div class="php8-compare__block example-contents">

--- a/releases/8.0/ka.php
+++ b/releases/8.0/ka.php
@@ -160,7 +160,7 @@ releases\php80\common_header(
   <div class="php8-compare">
     <h2 class="php8-h2" id="union-types">
       Union types
-      <a class="php8-rfc" href="https://wiki.php.net/rfc/union_types_v2">RFC</a> <a class="php8-rfc" href="/manual/en/language.types.declarations.php#language.types.declarations.union">დოკუმენტაცია</a>
+      <a class="php8-rfc" href="https://wiki.php.net/rfc/union_types_v2">RFC</a> <a class="php8-rfc" href="/manual/en/language.types.declarations.php#language.types.declarations.composite.union">დოკუმენტაცია</a>
     </h2>
     <div class="php8-compare__main">
       <div class="php8-compare__block example-contents">

--- a/releases/8.0/nl.php
+++ b/releases/8.0/nl.php
@@ -161,7 +161,7 @@ releases\php80\common_header(
   <div class="php8-compare">
     <h2 class="php8-h2" id="union-types">
       Unie types
-      <a class="php8-rfc" href="https://wiki.php.net/rfc/union_types_v2">RFC</a> <a class="php8-rfc" href="/manual/en/language.types.declarations.php#language.types.declarations.union">Doc</a>
+      <a class="php8-rfc" href="https://wiki.php.net/rfc/union_types_v2">RFC</a> <a class="php8-rfc" href="/manual/en/language.types.declarations.php#language.types.declarations.composite.union">Doc</a>
     </h2>
     <div class="php8-compare__main">
       <div class="php8-compare__block example-contents">

--- a/releases/8.0/pt_BR.php
+++ b/releases/8.0/pt_BR.php
@@ -159,7 +159,7 @@ releases\php80\common_header(
         <div class="php8-compare">
             <h2 class="php8-h2" id="union-types">
                 União de tipos
-                <a class="php8-rfc" href="https://wiki.php.net/rfc/union_types_v2">RFC</a> <a class="php8-rfc" href="/manual/pt_BR/language.types.declarations.php#language.types.declarations.union">Doc</a>
+                <a class="php8-rfc" href="https://wiki.php.net/rfc/union_types_v2">RFC</a> <a class="php8-rfc" href="/manual/pt_BR/language.types.declarations.php#language.types.declarations.composite.union">Doc</a>
             </h2>
             <div class="php8-compare__main">
                 <div class="php8-compare__block example-contents">

--- a/releases/8.0/ru.php
+++ b/releases/8.0/ru.php
@@ -158,7 +158,7 @@ releases\php80\common_header(
   <div class="php8-compare">
     <h2 class="php8-h2" id="union-types">
       Тип Union
-      <a class="php8-rfc" href="https://wiki.php.net/rfc/union_types_v2">RFC</a> <a class="php8-rfc" href="/manual/ru/language.types.declarations.php#language.types.declarations.union">Документация</a>
+      <a class="php8-rfc" href="https://wiki.php.net/rfc/union_types_v2">RFC</a> <a class="php8-rfc" href="/manual/ru/language.types.declarations.php#language.types.declarations.composite.union">Документация</a>
     </h2>
     <div class="php8-compare__main">
       <div class="php8-compare__block example-contents">

--- a/releases/8.0/tr.php
+++ b/releases/8.0/tr.php
@@ -158,7 +158,7 @@ releases\php80\common_header(
   <div class="php8-compare">
     <h2 class="php8-h2" id="union-types">
       Union types
-      <a class="php8-rfc" href="https://wiki.php.net/rfc/union_types_v2">RFC</a> <a class="php8-rfc" href="/manual/en/language.types.declarations.php#language.types.declarations.union">Doc</a>
+      <a class="php8-rfc" href="https://wiki.php.net/rfc/union_types_v2">RFC</a> <a class="php8-rfc" href="/manual/en/language.types.declarations.php#language.types.declarations.composite.union">Doc</a>
     </h2>
     <div class="php8-compare__main">
       <div class="php8-compare__block example-contents">

--- a/releases/8.0/zh.php
+++ b/releases/8.0/zh.php
@@ -156,7 +156,7 @@ releases\php80\common_header(
   <div class="php8-compare">
     <h2 class="php8-h2" id="union-types">
       联合类型
-      <a class="php8-rfc" href="https://wiki.php.net/rfc/union_types_v2">RFC</a> <a class="php8-rfc" href="/manual/zh/language.types.declarations.php#language.types.declarations.union">文档</a>
+      <a class="php8-rfc" href="https://wiki.php.net/rfc/union_types_v2">RFC</a> <a class="php8-rfc" href="/manual/zh/language.types.declarations.php#language.types.declarations.composite.union">文档</a>
     </h2>
     <div class="php8-compare__main">
       <div class="php8-compare__block example-contents">

--- a/releases/8.1/release.inc
+++ b/releases/8.1/release.inc
@@ -270,7 +270,7 @@ PHP
     <div class="php8-compare">
         <h2 class="php8-h2" id="pure_intersection_types">
             <?= message('pure_intersection_types_title', $lang) ?>
-            <a class="php8-rfc" href="https://wiki.php.net/rfc/pure-intersection-types">RFC</a>
+            <a class="php8-rfc" href="https://wiki.php.net/rfc/pure-intersection-types">RFC</a> <a class="php8-rfc" href="/manual/<?= $lang ?>/language.types.declarations.php#language.types.declarations.composite.intersection"><?= message('documentation', $lang) ?></a>
         </h2>
         <div class="php8-compare__main">
             <div class="php8-compare__block example-contents">


### PR DESCRIPTION
PHP 8.0
- Fix doc links to a union type

PHP 8.1
- Add doc link to an intersection type

Relates php/doc-en@7d9aa6352ebb52dd9703df3c7fd4d359ae09e614