### PR TITLE
Fix typo in PHP 8.1.2 release date

### DIFF
--- a/include/version.inc
+++ b/include/version.inc
@@ -21,7 +21,7 @@ $RELEASES = (function() {
     /* PHP 8.1 Release */
     $data['8.1'] = [
         'version' => '8.1.2',
-        'date'    => '20 Jan 2021',
+        'date'    => '20 Jan 2022',
         'tags'    => [], // Set to ['security'] for security releases.
         'sha256' => [
             'tar.gz'  => '9992409c0543e0c8e89914f7307e1485a08c057091146e4731565b59065f8bde',


### PR DESCRIPTION
The PHP website currently lists the release date of PHP 8.1.2 as 2021, this PR fixes the typo. At the time of writing the typo can be seen on this page https://www.php.net/downloads.php.

Commit where it happened 0d927c5d60da44536e5f532db33cf9fd8653c330