### PR TITLE
Combine EOL date and period columns

### DIFF
--- a/eol.php
+++ b/eol.php
@@ -37,7 +37,7 @@ site_header('Unsupported Branches');
 	<thead>
 		<tr>
 			<th>Branch</th>
-			<th colspan="2">Date</th>
+			<th>Date</th>
 			<th>Last Release</th>
 			<th>Notes</th>
 		</tr>
@@ -51,9 +51,8 @@ site_header('Unsupported Branches');
 						<td><?php echo htmlspecialchars($branch); ?></td>
 						<td>
 							<?php echo $eolDate->format('j M Y') ?>
-						</td>
-						<td>
-							<em><?php echo $eolPeriod ?></em>
+							<br/>
+							<em>(<?php echo $eolPeriod ?>)</em>
 						</td>
 						<td>
 							<a href="<?php echo htmlspecialchars($detail['link']); ?>">


### PR DESCRIPTION
This PR proposes a fix for #498 by combining the EOL date and period columns, placing the period on a new line below the date and enclosed in parentheses.

The amended layout reduces the page's minimum non-breaking viewport width from 408px to 352px, which should account for the vast majority of modern smartphones (manufactured 2016 or later).