### PR TITLE
Fix content layout on pages without sidebars for 768-979px viewport widths

### DIFF
--- a/styles/theme-base.css
+++ b/styles/theme-base.css
@@ -1574,7 +1574,7 @@ div.soft-deprecation-notice blockquote.sidebar {
         width: 30% !important;
     }
 
-    #layout-content {
+    #layout-content:not(:only-child) {
         width: 70% !important;
     }
 }


### PR DESCRIPTION
Per #500, pages without sidebar content (in an `aside` tag) are still pushed to the side at 70% width. I believe this is due to an over-eager selector (the one line changed in this PR).

The combination of `#layout-content` and `:only-child` is used in multiple places elsewhere in the site's CSS files, so I figured that was the safest option to minimize the amount of code being changed.