### PR TITLE
Change escaping function to build URL for searching

### DIFF
--- a/js/search.js
+++ b/js/search.js
@@ -360,7 +360,7 @@
 
                         dropdown.append(searchTemplate.render({
                             pattern: pattern,
-                            url: "/search.php?pattern=" + escape(pattern)
+                            url: "/search.php?pattern=" + pattern
                         }));
 
                         /* If the dropdown is hidden (because there are no

--- a/js/search.js
+++ b/js/search.js
@@ -360,7 +360,7 @@
 
                         dropdown.append(searchTemplate.render({
                             pattern: pattern,
-                            url: "/search.php?pattern=" + pattern
+                            url: "/search.php?pattern=" + encodeURIComponent(pattern)
                         }));
 
                         /* If the dropdown is hidden (because there are no


### PR DESCRIPTION
## Overview 

Fix #518

## Note

Search form submits raw-text to `/search.php`, but `search.js` build url with escaped text.
I think that it need not escape on JS too.

Ref: https://github.com/php/web-php/blob/master/include/header.inc#L127