### PR TITLE
Fopen flags

### DIFF
--- a/cal.php
+++ b/cal.php
@@ -257,7 +257,7 @@ function display_events_for_day($day, $events)
 function load_event($id)
 {
     // Open events CSV file, return on error
-    $fp = @fopen("backend/events.csv",'r');
+    $fp = @fopen("backend/events.csv",'rb');
     if (!$fp) { return FALSE; }
 
     // Read as we can, event by event
@@ -292,7 +292,7 @@ function load_events($from, $whole_month = FALSE)
     $events = $seen = array();
 
     // Try to open the events file for reading, return if unable to
-    $fp = @fopen("backend/events.csv",'r');
+    $fp = @fopen("backend/events.csv",'rb');
     if (!$fp) { return FALSE; }
 
     // For all events, read in the event and check it if fits our scope

--- a/security/index.php
+++ b/security/index.php
@@ -33,7 +33,7 @@ site_header("PHP Security center");
 echo "<h1>PHP Security Center</h1>\n";
 
 $dbfile = $_SERVER['DOCUMENT_ROOT'] . '/security/vulndb.txt';
-$fp = @fopen($dbfile, "rt");
+$fp = @fopen($dbfile, "rb");
 if(is_resource($fp)) {
     $RECORDS = array();
     $record_no = 1;


### PR DESCRIPTION
The flags in fopen calls must omit t, and b must be omitted or included consistently.