### PR TITLE
No useless return

### DIFF
--- a/releases/8.0/common.php
+++ b/releases/8.0/common.php
@@ -6,7 +6,7 @@ include_once __DIR__ . '/../../include/prepend.inc';
 function language_redirect(string $currentLang): void {
     // We don't use the general language selection of php.net,
     // so soldier on with this one.
-    return;
+    
 }
 
 function common_header(string $description): void {

--- a/releases/8.1/common.php
+++ b/releases/8.1/common.php
@@ -7,7 +7,7 @@ include_once __DIR__ . '/../../include/prepend.inc';
 function language_redirect(string $currentLang): void {
     // We don't use the general language selection of php.net,
     // so soldier on with this one.
-    return;
+    
 }
 
 function common_header(string $description): void {

--- a/releases/8.1/common.php
+++ b/releases/8.1/common.php
@@ -7,7 +7,6 @@ include_once __DIR__ . '/../../include/prepend.inc';
 function language_redirect(string $currentLang): void {
     // We don't use the general language selection of php.net,
     // so soldier on with this one.
-    
 }
 
 function common_header(string $description): void {


### PR DESCRIPTION
There should not be an empty return statement at the end of a function.