### PR TITLE
Fix: Do not use `vertical-align: middle` for table cells

### DIFF
--- a/styles/theme-base.css
+++ b/styles/theme-base.css
@@ -706,7 +706,6 @@ table.standard th {
 
 table.standard td {
     padding: 5px 10px;
-    vertical-align: middle;
 }
 
 table.standard tr:nth-child(even) td.subr,


### PR DESCRIPTION
This pull

- [x] stops overriding the default `vertical-align: top` with `vertical-align :middle` for table cells

Somewhat related to #499.

💁‍♂️ For reference, see https://github.com/php/web-php/blob/144acf6e9cf903bf694e531e84dd9201d520dee0/styles/theme-base.css#L683-L685

### Before

<img width="1604" alt="CleanShot 2022-06-27 at 15 27 48@2x" src="https://user-images.githubusercontent.com/605483/175953076-480cd8b4-6ecf-4c84-a56b-ebedef42daf4.png">

### After

<img width="1604" alt="CleanShot 2022-06-27 at 15 28 04@2x" src="https://user-images.githubusercontent.com/605483/175953132-ecd19db8-c4d1-4c5f-8900-20c084f70df9.png">

❗ This affects other tables using `class="standard"` as well.
