### PR TITLE
Fix: Remove unused `private` property

### DIFF
--- a/include/shared-manual.inc
+++ b/include/shared-manual.inc
@@ -31,7 +31,6 @@ class ManualNotesSorter {
     private $minAge;
 
     private $voteFactor;
-    private $ratingFactor;
     private $ageFactor;
 
     private $voteWeight = 38;


### PR DESCRIPTION
This pull request

- [x] removes an unused `private` property

💁‍♂️ Running

```shell
git grep -i ratingFactor
```

on current `master` yields

```
include/shared-manual.inc:34:    private $ratingFactor;
```