### PR TITLE
Fix: Remove unused references to a global variable

### DIFF
--- a/include/do-download.inc
+++ b/include/do-download.inc
@@ -25,8 +25,6 @@ function get_actual_download_file($file)
 // Download a file from a mirror site
 function download_file($mirror, $file)
 {
-    global $MYSITE;
-
     // Redirect to the particular file
     if (!headers_sent()) {
         status_header(302);

--- a/include/layout.inc
+++ b/include/layout.inc
@@ -524,7 +524,6 @@ function site_header($title = '', $config = array())
 }
 function site_footer($config = array())
 {
-    global $MYSITE;
     require __DIR__ . "/footer.inc";
 }
 


### PR DESCRIPTION
This pull request

- [x] removes unused references to the global variable `$MYSITE`