### PR TITLE
Fix: Remove unused parameter

### DIFF
--- a/include/layout.inc
+++ b/include/layout.inc
@@ -192,7 +192,7 @@ function print_popup_link($url, $linktext=false, $windowprops="", $target=false,
 }
 
 // Print a link for a downloadable file (including filesize)
-function download_link($file, $title, $showsize = TRUE, $mirror = '')
+function download_link($file, $title, $showsize = TRUE)
 {
     $download_link = "/distributions/" . $file;
 


### PR DESCRIPTION
This pull request

- [x] removes an unused parameter `$mirror`

💁‍♂️ Running

```shell
git grep download_link`
```

on current `master` yields

```
downloads.php:60:          <?php download_link($rel['filename'], $rel['filename']); ?>
gpg-keys.php:23:  <?php download_link('php-keyring.gpg', 'php-keyring.gpg'); ?>
include/layout.inc:195:function download_link($file, $title, $showsize = TRUE, $mirror = '')
include/layout.inc:197:    $download_link = "/distributions/" . $file;
include/layout.inc:200:    print_link($download_link, $title);
releases/index.php:218:				download_link($src["filename"], $src["name"]); echo "<br>\n";
```