### PR TITLE
Fix: Remove unused parameters

### DIFF
--- a/include/prepend.inc
+++ b/include/prepend.inc
@@ -188,10 +188,7 @@ function myphpnet_save()
 
 }
 
-// Default: Default search.
-// Lang: Not yet implemented (TODO: Compare google lang codes with ours. We did this for bing already, so maybe it's an easy fix)
-// TODO: Possible $default escaping issues
-function google_cse($default = '', $lang = 'en') {
+function google_cse() {
 ?>
 <noscript>
   php.net's search functionality requires JavaScript to operate. Please enable

--- a/results.php
+++ b/results.php
@@ -3,18 +3,6 @@ $_SERVER['BASE_PAGE'] = 'results.php';
 include __DIR__ . '/include/prepend.inc';
 include __DIR__ . '/include/results.inc';
 
-if (!isset($_GET['l']) || !is_string($_GET['l'])) {
-  $_GET['l'] = null;
-}
-
-$lang = isset($_GET["l"]) ? (string)$_GET["l"] : "en";
-$query = isset($_GET["q"]) ? (string)$_GET["q"] : '';
-
-if (!isset($LANGUAGES[$lang])) {
-    $lang = "en";
-}
-
-
 // HTTP status line is passed on, signifies an error
 site_header(
     'Search results',
@@ -27,6 +15,6 @@ site_header(
 
 echo '<h1>Search results</h1>';
 
-google_cse($query, $lang);
+google_cse();
 
 site_footer();


### PR DESCRIPTION
This pull request

- [x] removes more unused parameters

💁‍♂️ Affected pages include

### Search

See http://localhost:8080/search.php?q=foo&l=de

<img width="1822" alt="CleanShot 2022-06-28 at 15 05 51@2x" src="https://user-images.githubusercontent.com/605483/176185853-168263fb-ef09-40af-8dad-282fe19ef645.png">

### Results

See http://localhost:8080/results.php?q=foo&l=de:

<img width="1822" alt="CleanShot 2022-06-28 at 15 05 06@2x" src="https://user-images.githubusercontent.com/605483/176185764-42253f07-45fa-4dfd-84be-e021cbe854ce.png">

