### PR TITLE
Simplify links

### DIFF
--- a/include/layout.inc
+++ b/include/layout.inc
@@ -152,20 +152,9 @@ function make_submit($file, $alt = false, $align = false, $extras = false,
 }
 
 // Return a hiperlink to something within the site
-function make_link ($url, $linktext = false, $target = false, $extras = false)
+function make_link (string $url, string $linktext = ''): string
 {
-    return sprintf("<a href=\"%s\"%s%s>%s</a>",
-        $url,
-        ($target   ? ' target="' . $target . '"' : ''),
-        ($extras   ? ' ' . $extras               : ''),
-        ($linktext ?: $url)
-    );
-}
-
-// Print a hyperlink to something, within the site
-function print_link($url, $linktext = false, $target = false, $extras = false)
-{
-    echo make_link($url, $linktext, $target, $extras);
+    return sprintf("<a href=\"%s\">%s</a>", $url, $linktext ?: $url);
 }
 
 // make_popup_link()
@@ -196,7 +185,7 @@ function download_link($file, $title)
     $download_link = "/distributions/" . $file;
 
     // Print out the download link
-    print_link($download_link, $title);
+    echo make_link($download_link, $title);
 
     // We have a full path or a relative to the distributions dir
     if ($tmp = strrchr($file, "/")) {
@@ -208,7 +197,7 @@ function download_link($file, $title)
     if (@file_exists($local_file . ".asc")) {
         echo " ";
         $sig_link = "/distributions/$file.asc";
-        print_link($sig_link, "(sig)");
+        echo make_link($sig_link, "(sig)");
     }
 
     // Try to get the size of the file

--- a/include/site.inc
+++ b/include/site.inc
@@ -15,9 +15,15 @@ const MIRROR_DOESNOTWORK = 3;
 
 $MIRRORS = [
     "https://www.php.net/" => [
-        "DEU", "MyraCloud", false,
-        "https://myracloud.com/en/", MIRROR_SPECIAL, true,
-        "en", MIRROR_OK],
+        "DEU",
+        "MyraCloud",
+        false,
+        "https://myracloud.com/en/",
+        MIRROR_SPECIAL,
+        true,
+        "en",
+        MIRROR_OK
+    ]
 ];
 
 /**

--- a/mirror.php
+++ b/mirror.php
@@ -66,14 +66,14 @@ site_header("Information About This PHP Mirror Site", ["current" => "community"]
 
 <ul>
  <li>This site is <?php echo is_official_mirror() ? "" : "not"; ?> an official PHP.net mirror site</li>
- <li>The mirror site's address is <?php print_link($MYSITE); ?></li>
+ <li>The mirror site's address is <?= make_link($MYSITE)?></li>
 </ul>
 
 <?php if (is_official_mirror()) { ?>
 <h2>Mirror Provider</h2>
 <ul>
  <li>
-  <p>The provider of this mirror is <?php print_link(mirror_provider_url(), mirror_provider()); ?></p>
+  <p>The provider of this mirror is <?= make_link(mirror_provider_url(), mirror_provider())?></p>
   <?php if ($MIRROR_IMAGE) { ?>
   <p><?php echo $MIRROR_IMAGE; ?></p>
   <?php } ?>


### PR DESCRIPTION
A function just to print the result of another function already exists in PHP, it's `echo`. So let's remove `print_link` and all unused parameters. Declare types to be string from bottom-up. Warning: it relies on type coercion from false to string just like it did before. 