### PR TITLE
Fix: Move class into `src/`

### DIFF
--- a/bin/createNewsEntry
+++ b/bin/createNewsEntry
@@ -2,8 +2,9 @@
 <?php
 PHP_SAPI == 'cli' or die("Please run this script using the cli sapi");
 
-require(__DIR__ . '/../include/news_entry.inc');
-use phpweb\news\Entry;
+require_once __DIR__ . '/../src/News/Entry.php';
+
+use phpweb\News\Entry;
 
 $imageRestriction = [
 	'width' => 400,

--- a/bin/createReleaseEntry
+++ b/bin/createReleaseEntry
@@ -2,8 +2,9 @@
 <?php
 PHP_SAPI == 'cli' or die("Please run this script using the cli sapi");
 
-require(__DIR__ . '/../include/news_entry.inc');
-use phpweb\news\Entry;
+require_once __DIR__ . '/../src/News/Entry.php';
+
+use phpweb\News\Entry;
 
 if (!file_exists(Entry::ARCHIVE_FILE_ABS)) {
 	fwrite(STDERR, "Can't find " . Entry::ARCHIVE_FILE_REL . ", are you sure you are in phpweb/?\n");

--- a/src/News/Entry.php
+++ b/src/News/Entry.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace phpweb\news;
+namespace phpweb\News;
 
 class Entry {
 	const CATEGORIES = [
@@ -11,7 +11,7 @@ class Entry {
 	];
 
 	const WEBROOT = "https://www.php.net";
-	const PHPWEB = __DIR__ . '/../';
+	const PHPWEB = __DIR__ . '/../../';
 	const ARCHIVE_FILE_REL = 'archive/archive.xml';
 	const ARCHIVE_FILE_ABS = self::PHPWEB . self::ARCHIVE_FILE_REL;
 	const ARCHIVE_ENTRIES_REL = 'archive/entries/';


### PR DESCRIPTION
This pull request

- [x] moves a previously introduced class into `src/`

💁‍♂️ Given #579, it could make sense to start moving (and extracting additional) classes into `src/`. 

Sooner or later we could even add auto-loading, instead of relying on `require` statements. 

Examples of PSR-4 autoloader implementations can be found [here](https://www.php-fig.org/psr/psr-4/examples/).