### PR TITLE
Fix: Add type and return type declaration

### DIFF
--- a/include/branches.inc
+++ b/include/branches.inc
@@ -86,11 +86,13 @@ function format_interval($from, $to) {
 	return $eolPeriod;
 }
 
-function version_number_to_branch($version) {
+function version_number_to_branch(string $version): ?string {
 	$parts = explode('.', $version);
 	if (count($parts) > 1) {
 		return "$parts[0].$parts[1]";
 	}
+
+	return null;
 }
 
 function get_all_branches() {


### PR DESCRIPTION
This pull request

- [x] adds a type and return type declaration to `version_number_to_branch()`

💁‍♂️ See

- http://localhost:8080/eol.php
- http://localhost:8080/index.php
- http://localhost:8080/releases/active.php
- http://localhost:8080/releases/index.php
- http://localhost:8080/supported-versions.php
