### PR TITLE
`phpversion()` replacements and code branch collapsing for older PHP versions

### DIFF
--- a/include/ip-to-country.inc
+++ b/include/ip-to-country.inc
@@ -209,18 +209,9 @@ function i2c_realip()
             // Skip RFC 1918 IP's 10.0.0.0/8, 172.16.0.0/12 and
             // 192.168.0.0/16
             // Also skip RFC 6598 IP's
-            if (!preg_match('/^(?:10|100\.(?:6[4-9]|[7-9]\d|1[01]\d|12[0-7])|172\.(?:1[6-9]|2\d|3[01])|192\.168)\./', $ips[$i])) {
-                if (version_compare(phpversion(), "5.0.0", ">=")) {
-                    if (ip2long($ips[$i]) != false) {
-                        $ip = $ips[$i];
-                        break;
-                    }
-                } else {
-                    if (ip2long($ips[$i]) != -1) {
-                        $ip = $ips[$i];
-                        break;
-                    }
-                }
+            if (!preg_match('/^(?:10|100\.(?:6[4-9]|[7-9]\d|1[01]\d|12[0-7])|172\.(?:1[6-9]|2\d|3[01])|192\.168)\./', $ips[$i]) && ip2long($ips[$i])) {
+	            $ip = $ips[$i];
+	            break;
             }
         }
     }

--- a/mirror-info.php
+++ b/mirror-info.php
@@ -33,7 +33,7 @@ $exts = implode(',', get_loaded_extensions());
 
 echo implode('|', array(
     $MYSITE,            	// 0 : CNAME for mirror as accessed (CC, CC1, etc.)
-    phpversion(),       	// 1 : PHP version overview
+    PHP_VERSION,       	// 1 : PHP version overview
     $LAST_UPDATED,      	// 2 : Update problems
     $sqlite,            	// 3 : SQLite support?
     $mirror_stats,      	// 4 : Optional local stats support


### PR DESCRIPTION
 - Removes a `if` branch was PHP < 5, which should be safe now that we no longer support PHP 4. 
 - Replaces `phpversion()` function call with `PHP_VERSION` constant, both of which yield identical results, but the use of the constant is a micro-optimization. 