### PR TITLE
Fix: Remove useless function

### DIFF
--- a/include/shared-manual.inc
+++ b/include/shared-manual.inc
@@ -391,7 +391,6 @@ CHANGE_LANG;
     return trim($r);
 }
 
-function manual_header(){}
 function manual_footer() {
     global $USERNOTES, $__RELATED;
 

--- a/manual/en/book.var.php
+++ b/manual/en/book.var.php
@@ -48,7 +48,6 @@ $setup["toc"] = $TOC;
 $setup["parents"] = $PARENTS;
 manual_setup($setup);
 
-manual_header();
 ?>
 <div id="book.var" class="book">
 

--- a/manual/en/class.exception.php
+++ b/manual/en/class.exception.php
@@ -48,7 +48,6 @@ $setup["toc"] = $TOC;
 $setup["parents"] = $PARENTS;
 manual_setup($setup);
 
-manual_header();
 ?>
 <div id="class.exception" class="reference">
  <h1 class="title">Exception</h1>

--- a/manual/en/context.http.php
+++ b/manual/en/context.http.php
@@ -42,7 +42,6 @@ $setup["toc"] = $TOC;
 $setup["parents"] = $PARENTS;
 manual_setup($setup);
 
-manual_header();
 ?>
 <div id="context.http" class="refentry">
  <div class="refnamediv">

--- a/manual/en/funcref.php
+++ b/manual/en/funcref.php
@@ -48,7 +48,6 @@ $setup["toc"] = $TOC;
 $setup["parents"] = $PARENTS;
 manual_setup($setup);
 
-manual_header();
 ?>
 <div id="funcref" class="set">
   <h1 class="title">Function Reference</h1>

--- a/manual/en/function.strpos.php
+++ b/manual/en/function.strpos.php
@@ -42,7 +42,6 @@ $setup["toc"] = $TOC;
 $setup["parents"] = $PARENTS;
 manual_setup($setup);
 
-manual_header();
 ?>
 <div id="function.strpos" class="refentry">
  <div class="refnamediv">

--- a/manual/en/index.php
+++ b/manual/en/index.php
@@ -48,7 +48,6 @@ $setup["toc"] = $TOC;
 $setup["parents"] = $PARENTS;
 manual_setup($setup);
 
-manual_header();
 ?>
 <div id="index" class="set">
  <h1 class="title">PHP Manual</h1>

--- a/manual/en/language.exceptions.php
+++ b/manual/en/language.exceptions.php
@@ -48,7 +48,6 @@ $setup["toc"] = $TOC;
 $setup["parents"] = $PARENTS;
 manual_setup($setup);
 
-manual_header();
 ?>
 <div id="language.exceptions" class="chapter">
   <h1>Exceptions</h1>

--- a/manual/en/refs.basic.vartype.php
+++ b/manual/en/refs.basic.vartype.php
@@ -48,7 +48,6 @@ $setup["toc"] = $TOC;
 $setup["parents"] = $PARENTS;
 manual_setup($setup);
 
-manual_header();
 ?>
 <div id="refs.basic.vartype" class="set">
    <h1 class="title">Variable and Type Related Extensions</h1>


### PR DESCRIPTION
This pull request

- [x] removes the useless function `manual_header()`

Spotted in #594.