### PR TITLE
Micro Optimizations - Round #2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 backend/mirror.gif
 backend/mirror.png
 backend/mirror.jpg
-backend/mirror.jpg
 backend/GeoIP.dat
 .idea
 .DS_Store

--- a/.router.php
+++ b/.router.php
@@ -1,7 +1,7 @@
 <?php
 $_SERVER["SERVER_ADDR"] = $_SERVER["HTTP_HOST"];
 
-$filename = isset($_SERVER["PATH_INFO"]) ? $_SERVER["PATH_INFO"] : $_SERVER["SCRIPT_NAME"];
+$filename = $_SERVER["PATH_INFO"] ?? $_SERVER["SCRIPT_NAME"];
 
 if (file_exists($_SERVER["DOCUMENT_ROOT"] . $filename)) {
     /* This could be an image or whatever, so don't try to compress it */

--- a/images/logo.php
+++ b/images/logo.php
@@ -1,6 +1,6 @@
 <?php
 
-$refresh = isset($_GET['refresh']) ? true : false;
+$refresh = isset($_GET['refresh']);
 
 // Be 100% sure the timezone is set
 if (ini_get('date.timezone') === '' && function_exists('date_default_timezone_set')) {

--- a/include/prepend.inc
+++ b/include/prepend.inc
@@ -131,9 +131,9 @@ function myphpnet_language($langcode = FALSE)
     return false;
 }
 
-define("MYPHPNET_URL_NONE", FALSE);
-define("MYPHPNET_URL_FUNC", 'quickref');
-define("MYPHPNET_URL_MANUAL", 'manual');
+const MYPHPNET_URL_NONE = false;
+const MYPHPNET_URL_FUNC = 'quickref';
+const MYPHPNET_URL_MANUAL = 'manual';
 
 // Set URL search fallback preference
 function myphpnet_urlsearch($type = FALSE)

--- a/include/site.inc
+++ b/include/site.inc
@@ -2,16 +2,16 @@
 
 // Define some constants, and $MIRRORS array
 // Mirror type constants
-define('MIRROR_DOWNLOAD', 0);
-define('MIRROR_STANDARD', 1);
-define('MIRROR_SPECIAL',  2);
-define('MIRROR_VIRTUAL',  3);
+const MIRROR_DOWNLOAD = 0;
+const MIRROR_STANDARD = 1;
+const MIRROR_SPECIAL = 2;
+const MIRROR_VIRTUAL = 3;
 
 // Mirror status constants
-define('MIRROR_OK',          0);
-define('MIRROR_NOTACTIVE',   1);
-define('MIRROR_OUTDATED',    2);
-define('MIRROR_DOESNOTWORK', 3);
+const MIRROR_OK = 0;
+const MIRROR_NOTACTIVE = 1;
+const MIRROR_OUTDATED = 2;
+const MIRROR_DOESNOTWORK = 3;
 
 $MIRRORS = array(
     "https://www.php.net/" => array(


### PR DESCRIPTION
Follow-up to #603, includes a few more optimizations. 
 - [.gitignore: Remove redundant entry](https://github.com/php/web-php/commit/9c77a3cf1293651356ef1e68233d2ace3d2b76d2)
 - [Minor optimizations with ternary operators](https://github.com/php/web-php/commit/24406af9c96edac1fd48cb7cdbd933cf7214a1bd)
 - [Use const instead of define() where appropriate](https://github.com/php/web-php/commit/4b337aea819119792e4e5c889c2a0614620a693e)
    `const` is quite faster because of the compile-time optimizations. Because the replaced statements are not declaring constant conditionally, it's safe to use `const` in all of these places.

Thank you.