### PR TITLE
Minor optimizations in CSS to shed some page size off

### DIFF
--- a/js/usernotes.js
+++ b/js/usernotes.js
@@ -26,13 +26,13 @@ $(document).ready(function() {
               if (data.msg != null) {
                 responsedata = data.msg;
               }
-              $("#V"+id).html("<div style=\"float: left; width: 16px; height: 16px; background-image: url(/images/notes-features.png); background-position:-32px 0px; margin-right: 8px; overflow: hidden;\" border=\"0\" alt=\"fail\" title=\"" + responsedata + "\"></div>");
+              $("#V"+id).html("<div style=\"float: left; width: 16px; height: 16px; background-image: url(/images/notes-features.png); background-position:-32px 0; margin-right: 8px; overflow: hidden;\" border=\"0\" alt=\"fail\" title=\"" + responsedata + "\"></div>");
             }
           });
           request.fail(function(jqXHR, textStatus) {
             $("#Vu"+id).show();
             $("#Vd"+id).show();
-            $("#V"+id).html("<div style=\"float: left; width: 16px; height: 16px; background-image: url(/images/notes-features.png); background-position:-32px 0px; margin-right: 8px; overflow: hidden;\" border=\"0\" alt=\"fail\" title=\"Error :(\"></div>");
+            $("#V"+id).html("<div style=\"float: left; width: 16px; height: 16px; background-image: url(/images/notes-features.png); background-position:-32px 0; margin-right: 8px; overflow: hidden;\" border=\"0\" alt=\"fail\" title=\"Error :(\"></div>");
           });
           request.always(function(data) {
             $("#V"+id).fadeIn(500, "linear");

--- a/styles/mirror.css
+++ b/styles/mirror.css
@@ -98,5 +98,5 @@ div#usernotes a.usernotes-voted:hover {
 
 #mirrors-container .mirrors-list img {
 	position: absolute;
-	right: 0px;
+	right: 0;
 }

--- a/styles/theme-base.css
+++ b/styles/theme-base.css
@@ -555,8 +555,7 @@ div.classsynopsisinfo_comment {
 
 pre.info {
     border: 1px solid;
-    margin: 1rem 2rem 1.3rem;
-    margin-right: 0.8rem;
+    margin: 1rem 0.8rem 1.3rem 2rem;
 }
 
 #langform {
@@ -686,7 +685,6 @@ table td {
 
 table.standard {
     border-collapse: collapse;
-    border-style: hidden;
     border:1px solid #d9d9d9;
 }
 
@@ -797,9 +795,8 @@ table.standard th.subr {
     width: 23.404%;
     margin-right: 2.762%;
     padding:.5rem .75rem;
-    border: 1px solid;
+    border: 1px solid #e0e0e0;
     background-color:#f2f2f2;
-    border-color: #e0e0e0;
     border-bottom-color:#d9d9d9;
     border-radius:2px;
     margin-top: 0;
@@ -1159,7 +1156,7 @@ fieldset {
 .content-box pre {
     background: white;
     border: solid 1px rgb(214, 214, 214);
-    margin: 0px;
+    margin: 0;
     padding: 0.75rem;
     overflow: auto;
     font: normal 0.875rem/1.5rem "Source Code Pro", monospace;
@@ -1483,8 +1480,8 @@ div.soft-deprecation-notice {
 }
 div.soft-deprecation-notice blockquote.sidebar {
     padding: 10px;
-    margin: 0px;
-    border: 0px solid;
+    margin: 0;
+    border: 0 solid;
 }
 
 #breadcrumbs {
@@ -1610,7 +1607,7 @@ div.soft-deprecation-notice blockquote.sidebar {
     float:left;
     clear: both;
     margin-top: 0;
-    padding: 0px 10px 10px 10px;
+    padding: 0 10px 10px 10px;
   }
 
   .navbar .nav {
@@ -1651,7 +1648,7 @@ div.soft-deprecation-notice blockquote.sidebar {
 
   .navbar-search {
     margin-top: 0;
-    padding: 0px 10px 10px;
+    padding: 0 10px 10px;
   }
 
   .navbar .brand img {
@@ -1690,7 +1687,7 @@ div.soft-deprecation-notice blockquote.sidebar {
   }
 
   #flash-message {
-    margin-top: 0px !important;
+    margin-top: 0 !important;
     top: 0;
   }
 
@@ -1735,7 +1732,7 @@ div.soft-deprecation-notice blockquote.sidebar {
   color: #E6E6E6;
 }
 #goto .search .results {
-  text-shadow: 0px 2px 3px #555;
+  text-shadow: 0 2px 3px #555;
   font-size: 2rem;
   line-height: 1;
 }
@@ -1745,7 +1742,7 @@ div.soft-deprecation-notice blockquote.sidebar {
 }
 #goto .search .text {
   color: #222;
-  text-shadow: 0px 2px 3px #555;
+  text-shadow: 0 2px 3px #555;
   font-size: 10rem;
   line-height: .7;
 }

--- a/styles/theme-medium.css
+++ b/styles/theme-medium.css
@@ -495,7 +495,7 @@ div.elephpants img:focus {
 }
 .mirror .title img {
 	position: absolute;
-	right: 0px;
+	right: 0;
 }
 .mirror .title {
 	font-size: 1.4em;


### PR DESCRIPTION
 - Removes `px` suffix from `0px`.
 - Combines CSS properties where they are immediately overridden in the same selector block, or can be combined without side effects.
This saves about 50 bytes off the CSS scripts. _it ain't much but it's honest work_