### PR TITLE
Remove id prefix

### DIFF
--- a/src/News/Entry.php
+++ b/src/News/Entry.php
@@ -131,7 +131,7 @@ class Entry {
 		self::ce($dom, "id", $archive, [], $item);
 		self::ce($dom, "published", date(DATE_ATOM), [], $item);
 		self::ce($dom, "updated", date(DATE_ATOM), [], $item);
-		self::ce($dom, "link", null, ['href' => "{$href}#id{$this->id}", "rel"  => "alternate", "type" => "text/html"], $item);
+		self::ce($dom, "link", null, ['href' => "{$href}#{$this->id}", "rel"  => "alternate", "type" => "text/html"], $item);
 		self::ce($dom, "link", null, ['href' => $link, 'rel'  => 'via', 'type' => 'text/html'], $item);
 
 		if (!empty($this->conf_time)) {


### PR DESCRIPTION
We stopped adding the prefix in July 2019, but the links are still pointing to anchors with the prefix. 