### PR TITLE
Changelog: do not confuse GH-xxx with #xxx bugs

### DIFF
--- a/include/changelogs.inc
+++ b/include/changelogs.inc
@@ -24,7 +24,7 @@ function githubissue($repo, $number) {
 }
 
 function githubissuel($repo, $number) {
-    echo "<a href=\"https://github.com/$repo/issues/$number\">#$number</a>";
+    echo "<a href=\"https://github.com/$repo/issues/$number\">GH-$number</a>";
 }
 
 function release_date($in) {


### PR DESCRIPTION
E.g. in https://www.php.net/ChangeLog-8.php#8.1.6, excerpt generated from https://github.com/php/php-src/blob/php-8.1.8/NEWS#L140-L147 (i.e. https://github.com/php/web-php/blob/22ea1e2e6f6569e040ad92445c7a20749a2b0bd0/ChangeLog-8.php#L159-L165):
- before:
  ![image](https://user-images.githubusercontent.com/7404452/177984506-a41a9803-685f-401f-b89d-69588f1e3774.png)
- after:
  ![image](https://user-images.githubusercontent.com/7404452/177984525-0de4df43-3f9b-4555-b7f5-3d30d61aa298.png)
