### PR TITLE
Enhancement: Trim trailing whitespace in all files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,15 +2,14 @@ root = true
 
 [*]
 insert_final_newline = true
+trim_trailing_whitespace = true
 
 [*.yaml]
 charset = utf-8
 indent_size = 2
 indent_style = space
-trim_trailing_whitespace = true
 
 [Makefile]
 charset = utf-8
 indent_size = 4
 indent_style = tab
-trim_trailing_whitespace = true


### PR DESCRIPTION
This pull request

- [x] adjusts `.editorconfig` to trim trailing whitespace in all (!) files

Similar to 620.

💁‍♂️ Perhaps we should apply this rule after merging #559 and after enabling the [`no_trailing_whitespace`](https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.4.0/doc/rules/whitespace/no_trailing_whitespace.rst) fixer.