### PR TITLE
Enhancement: Enable `array_indentation` fixer

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -7,6 +7,7 @@ $config = new PhpCsFixer\Config();
 $finder = $config->getFinder()
     ->ignoreDotFiles(false)
     ->in(__DIR__)
+    ->exclude('manual/en/')
     ->name(__FILE__);
 
 $config->setRules([

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -10,6 +10,7 @@ $finder = $config->getFinder()
     ->name(__FILE__);
 
 $config->setRules([
+    'array_indentation' => true,
     'indentation_type' => true,
     'no_trailing_whitespace' => true,
     'single_space_after_construct' => true,

--- a/git-php.php
+++ b/git-php.php
@@ -27,11 +27,11 @@ $SIDEBAR_DATA = '
 site_header("Using Git for PHP Development", array("current" => "community"));
 
 $groups = array(
-  "none" => "Choose One",
-  "php"  => "PHP Group",
-  "pear" => "PEAR Group",
-  "pecl" => "PECL Group",
-  "doc"  => "Doc Group",
+    "none" => "Choose One",
+    "php"  => "PHP Group",
+    "pear" => "PEAR Group",
+    "pecl" => "PECL Group",
+    "doc"  => "Doc Group",
 );
 
 ?>

--- a/mailing-lists.php
+++ b/mailing-lists.php
@@ -185,122 +185,122 @@ if (isset($_POST['action'])) {
   // array of lists (list, name, short desc., moderated, archive, digest, newsgroup)
   $general_mailing_lists = array(
 
-    'General mailing lists for PHP users',
-    array (
-      'php-announce', 'Announcements',
-      'Announcements of new PHP releases are sent to this very low-volume list',
-      TRUE, FALSE, FALSE, "php.announce"
-    ),
-    array (
-      'php-general', 'General user list',
-      'This is a high volume list for general PHP support; ask PHP questions here',
-      FALSE, TRUE, TRUE, "php.general"
-    ),
-    array (
-      'php-windows', 'Windows PHP users list',
-      'Using PHP on Microsoft Windows',
-      FALSE, TRUE, TRUE, "php.windows"
-    ),
+      'General mailing lists for PHP users',
+      array (
+          'php-announce', 'Announcements',
+          'Announcements of new PHP releases are sent to this very low-volume list',
+          TRUE, FALSE, FALSE, "php.announce"
+      ),
+      array (
+          'php-general', 'General user list',
+          'This is a high volume list for general PHP support; ask PHP questions here',
+          FALSE, TRUE, TRUE, "php.general"
+      ),
+      array (
+          'php-windows', 'Windows PHP users list',
+          'Using PHP on Microsoft Windows',
+          FALSE, TRUE, TRUE, "php.windows"
+      ),
 
-    'Subject specific lists for PHP users',
-    array (
-      'php-install', 'Installation issues and problems',
-      'How to install PHP with particular configurations and servers',
-      FALSE, TRUE, TRUE, "php.install"
-    ),
-    array (
-      'php-db', 'Databases and PHP',
-      'This list is for the discussion of PHP database topics',
-      FALSE, TRUE, TRUE, "php.db"
-    ),
-    array (
-      'php-i18n', 'Unicode and Internationalization',
-      'Unicode support, Internationalization (i18n) and localization (l10n) issues and features',
-      FALSE, TRUE, TRUE, "php.i18n"
-    ),
-    array (
-      'php-evangelism', 'PHP evangelism mailing list',
-      'A list for people interested in promoting PHP and learning good reasons to support PHP in the enterprise',
-      TRUE, TRUE, TRUE, "php.evangelism"
-    ),
-    array (
-      'soap', 'PHP SOAP list',
-      'List for the SOAP developers',
-      FALSE, FALSE, FALSE, 'php.soap'
-    ),
-    'Non-English language mailing lists',
-    array (
-      'php-es', 'Spanish PHP Mailing list',
-      'List for Spanish speaking people interested in PHP',
-      FALSE, FALSE, FALSE, 'php.general.es'
-    ),
+      'Subject specific lists for PHP users',
+      array (
+          'php-install', 'Installation issues and problems',
+          'How to install PHP with particular configurations and servers',
+          FALSE, TRUE, TRUE, "php.install"
+      ),
+      array (
+          'php-db', 'Databases and PHP',
+          'This list is for the discussion of PHP database topics',
+          FALSE, TRUE, TRUE, "php.db"
+      ),
+      array (
+          'php-i18n', 'Unicode and Internationalization',
+          'Unicode support, Internationalization (i18n) and localization (l10n) issues and features',
+          FALSE, TRUE, TRUE, "php.i18n"
+      ),
+      array (
+          'php-evangelism', 'PHP evangelism mailing list',
+          'A list for people interested in promoting PHP and learning good reasons to support PHP in the enterprise',
+          TRUE, TRUE, TRUE, "php.evangelism"
+      ),
+      array (
+          'soap', 'PHP SOAP list',
+          'List for the SOAP developers',
+          FALSE, FALSE, FALSE, 'php.soap'
+      ),
+      'Non-English language mailing lists',
+      array (
+          'php-es', 'Spanish PHP Mailing list',
+          'List for Spanish speaking people interested in PHP',
+          FALSE, FALSE, FALSE, 'php.general.es'
+      ),
 
   );
 
   // array of lists (list, name, short desc., moderated, archive, digest, newsgroup)
   $internals_mailing_lists = array(
 
-    'PHP and Zend Engine internals lists',
-    array (
-      'internals', 'Internals list',
-      'A medium volume list for those who want to help out with the development of PHP',
-      FALSE, 'php-internals', TRUE, "php.internals"
-    ),
-    array (
-      'internals-win', 'Windows Internals list',
-      'A low volume list for those who want to help out with the development of PHP on Windows',
-      FALSE, FALSE, TRUE, "php.internals.win"
-    ),
-    array (
-      'php-cvs', 'Git commit list',
-      'All commits to internals (php-src) and the Zend Engine are posted to this list automatically',
-      TRUE, TRUE, FALSE, "php.cvs"
-    ),
-    array (
-      'git-pulls', 'Git pull requests',
-      'Pull requests from Github',
-      FALSE, FALSE, FALSE, "php.git-pulls"
-    ),
-    array (
-      'php-qa', 'Quality Assurance list',
-      'List for the members of the PHP-QA Team',
-      FALSE, TRUE, FALSE, "php.qa"
-    ),
-    array (
-      'php-bugs', 'General bugs',
-      'General bug activity are posted here',
-      FALSE, FALSE, FALSE, "php.bugs"
-    ),
-    array (
-      'standards', 'PHP Standardization and interoperability list',
-      'Development of language standards',
-      FALSE, FALSE, FALSE, "php.standards"
-    ),
+      'PHP and Zend Engine internals lists',
+      array (
+          'internals', 'Internals list',
+          'A medium volume list for those who want to help out with the development of PHP',
+          FALSE, 'php-internals', TRUE, "php.internals"
+      ),
+      array (
+          'internals-win', 'Windows Internals list',
+          'A low volume list for those who want to help out with the development of PHP on Windows',
+          FALSE, FALSE, TRUE, "php.internals.win"
+      ),
+      array (
+          'php-cvs', 'Git commit list',
+          'All commits to internals (php-src) and the Zend Engine are posted to this list automatically',
+          TRUE, TRUE, FALSE, "php.cvs"
+      ),
+      array (
+          'git-pulls', 'Git pull requests',
+          'Pull requests from Github',
+          FALSE, FALSE, FALSE, "php.git-pulls"
+      ),
+      array (
+          'php-qa', 'Quality Assurance list',
+          'List for the members of the PHP-QA Team',
+          FALSE, TRUE, FALSE, "php.qa"
+      ),
+      array (
+          'php-bugs', 'General bugs',
+          'General bug activity are posted here',
+          FALSE, FALSE, FALSE, "php.bugs"
+      ),
+      array (
+          'standards', 'PHP Standardization and interoperability list',
+          'Development of language standards',
+          FALSE, FALSE, FALSE, "php.standards"
+      ),
 
-    'PHP internal website mailing lists',
-    array (
-      'php-webmaster', 'PHP php.net internal infrastructure discussion',
-      'List for discussing and maintaining the php.net web infrastructure.<br>
+      'PHP internal website mailing lists',
+      array (
+          'php-webmaster', 'PHP php.net internal infrastructure discussion',
+          'List for discussing and maintaining the php.net web infrastructure.<br>
        For general PHP support questions, see "General Mailing Lists" or the <a href="/support.php">support page</a>',
-      FALSE, FALSE, FALSE, "php.webmaster"
-    ),
+          FALSE, FALSE, FALSE, "php.webmaster"
+      ),
 
-    'PHP documentation mailing lists',
-    array (
-      'phpdoc', 'Documentation discussion',
-      'List for discussing the PHP documentation',
-      FALSE, TRUE, FALSE, "php.doc"
-    ),
-    array (
-      'doc-cvs', 'Documentation changes and commits',
-      'Changes to the documentation are posted here',
-      TRUE, "php-doc-cvs", FALSE, "php.doc.cvs"
-    ),
-    array (
-      'doc-bugs', 'Documentation bugs',
-      'Documentation bug activity (translations, sources, and build system) are posted here',
-      TRUE, 'php-doc-bugs', FALSE, "php.doc.bugs"
-    ),
+      'PHP documentation mailing lists',
+      array (
+          'phpdoc', 'Documentation discussion',
+          'List for discussing the PHP documentation',
+          FALSE, TRUE, FALSE, "php.doc"
+      ),
+      array (
+          'doc-cvs', 'Documentation changes and commits',
+          'Changes to the documentation are posted here',
+          TRUE, "php-doc-cvs", FALSE, "php.doc.cvs"
+      ),
+      array (
+          'doc-bugs', 'Documentation bugs',
+          'Documentation bug activity (translations, sources, and build system) are posted here',
+          TRUE, 'php-doc-bugs', FALSE, "php.doc.bugs"
+      ),
   );
 
 // Print out a table for a given list array

--- a/releases/8.0/common.php
+++ b/releases/8.0/common.php
@@ -11,9 +11,9 @@ function common_header(string $description): void {
     $meta_description = \htmlspecialchars($description);
 
     \site_header("PHP 8.0.0 Release Announcement", [
-            'current' => 'php8',
-            'css' => ['php8.css'],
-            'meta_tags' => <<<META
+        'current' => 'php8',
+        'css' => ['php8.css'],
+        'meta_tags' => <<<META
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:site" content="@official_php" />
 <meta name="twitter:title" content="PHP 8.0 Released" />
@@ -28,7 +28,7 @@ function common_header(string $description): void {
 <meta property="og:image" content="{$meta_image_path}" />
 <meta property="og:description" content="{$meta_description}" />
 META
-        ]);
+    ]);
 }
 
 function language_chooser(string $currentLang): void {

--- a/releases/8.1/common.php
+++ b/releases/8.1/common.php
@@ -12,9 +12,9 @@ function common_header(string $description): void {
     $meta_description = \htmlspecialchars($description);
 
     \site_header("PHP 8.1.0 Release Announcement", [
-            'current' => 'php8',
-            'css' => ['php8.css'],
-            'meta_tags' => <<<META
+        'current' => 'php8',
+        'css' => ['php8.css'],
+        'meta_tags' => <<<META
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:site" content="@official_php" />
 <meta name="twitter:title" content="PHP 8.1 Released" />
@@ -29,7 +29,7 @@ function common_header(string $description): void {
 <meta property="og:image" content="{$meta_image_path}" />
 <meta property="og:description" content="{$meta_description}" />
 META
-        ]);
+    ]);
 }
 
 function language_chooser(string $currentLang): void {

--- a/submit-event.php
+++ b/submit-event.php
@@ -160,10 +160,10 @@ for ($i = 1; $i <= 12; $i++) {
 
 // Possibilities to recur
 $re = array(
-     1 => 'First',
-     2 => 'Second',
-     3 => 'Third',
-     4 => 'Fourth',
+    1 => 'First',
+    2 => 'Second',
+    3 => 'Third',
+    4 => 'Fourth',
     -1 => 'Last',
     -2 => '2nd Last',
     -3 => '3rd Last'


### PR DESCRIPTION
This pull request

- [x] enables the `array_indentation` fixer
- [x] excludes `manual/en/`
- [x] runs `make coding-standards`

Follows #559.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.4.0/doc/rules/whitespace/array_indentation.rst.