### PR TITLE
Fix: Remove commented out formats

### DIFF
--- a/download-docs.php
+++ b/download-docs.php
@@ -43,8 +43,6 @@ site_header("Download documentation", array("current" => "docs"));
 $formats = array(
     "Single HTML file" => "html.gz",
     "Many HTML files"  => "tar.gz",
-#   "Many PDF files"   => "pdf.tar.gz",
-#   "PDF"              => "pdf",
     "HTML Help file"   => "chm",
     "HTML Help file (with user notes)" => "chm",
 );


### PR DESCRIPTION
This pull request

- [x] removes commented out formats