### PR TITLE
Enhancement: Enable `no_trailing_whitespace` fixer

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -9,6 +9,8 @@ $finder = $config->getFinder()
     ->in(__DIR__)
     ->name(__FILE__);
 
-$config->setRules([]);
+$config->setRules([
+    'no_trailing_whitespace' => true,
+]);
 
 return $config;


### PR DESCRIPTION
This pull request

- [x] enables the `no_trailing_whitespace` fixer

Follows #559.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.4.0/doc/rules/whitespace/no_trailing_whitespace.rst.