### PR TITLE
Enhancement: Enable `visibility_required` fixer

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -11,6 +11,7 @@ $finder = $config->getFinder()
 
 $config->setRules([
     'no_trailing_whitespace' => true,
+    'visibility_required' => true,
     'whitespace_after_comma_in_array' => true,
 ]);
 

--- a/src/News/Entry.php
+++ b/src/News/Entry.php
@@ -3,21 +3,21 @@
 namespace phpweb\News;
 
 class Entry {
-	const CATEGORIES = [
+	public const CATEGORIES = [
 		'frontpage'   => 'PHP.net frontpage news',
 		'releases'    => 'New PHP release',
 		'conferences' => 'Conference announcement',
 		'cfp'         => 'Call for Papers',
 	];
 
-	const WEBROOT = "https://www.php.net";
-	const PHPWEB = __DIR__ . '/../../';
-	const ARCHIVE_FILE_REL = 'archive/archive.xml';
-	const ARCHIVE_FILE_ABS = self::PHPWEB . self::ARCHIVE_FILE_REL;
-	const ARCHIVE_ENTRIES_REL = 'archive/entries/';
-	const ARCHIVE_ENTRIES_ABS = self::PHPWEB . self::ARCHIVE_ENTRIES_REL;
-	const IMAGE_PATH_REL = 'images/news/';
-	const IMAGE_PATH_ABS = self::PHPWEB . self::IMAGE_PATH_REL;
+	public const WEBROOT = "https://www.php.net";
+	public const PHPWEB = __DIR__ . '/../../';
+	public const ARCHIVE_FILE_REL = 'archive/archive.xml';
+	public const ARCHIVE_FILE_ABS = self::PHPWEB . self::ARCHIVE_FILE_REL;
+	public const ARCHIVE_ENTRIES_REL = 'archive/entries/';
+	public const ARCHIVE_ENTRIES_ABS = self::PHPWEB . self::ARCHIVE_ENTRIES_REL;
+	public const IMAGE_PATH_REL = 'images/news/';
+	public const IMAGE_PATH_ABS = self::PHPWEB . self::IMAGE_PATH_REL;
 
 
 	protected $title = '';

--- a/src/UserNotes/Sorter.php
+++ b/src/UserNotes/Sorter.php
@@ -15,7 +15,7 @@ class Sorter {
     private $ratingWeight = 60;
     private $ageWeight = 2;
 
-    function sort(array &$notes) {
+    public function sort(array &$notes) {
         // First we make a pass over the data to get the min and max values
         // for data normalization.
         $this->findMinMaxValues($notes);


### PR DESCRIPTION
This pull request

- [x] enables the `visibility_required` fixer
- [x] runs `make coding-standards`

Follows #559.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.4.0/doc/rules/class_notation/visibility_required.rst.