### PR TITLE
Enhancement: Enable `ordered_class_elements` fixer

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -8,7 +8,8 @@ $finder = $config->getFinder()
     ->ignoreDotFiles(false)
     ->in(__DIR__)
     ->exclude('manual/en/')
-    ->name(__FILE__);
+    ->name(__FILE__)
+    ->notPath('tests/run-tests.php');
 
 $config->setRules([
     'array_indentation' => true,

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -14,6 +14,7 @@ $config->setRules([
     'array_indentation' => true,
     'indentation_type' => true,
     'no_trailing_whitespace' => true,
+    'ordered_class_elements' => true,
     'single_space_after_construct' => true,
     'visibility_required' => true,
     'whitespace_after_comma_in_array' => true,

--- a/src/News/Entry.php
+++ b/src/News/Entry.php
@@ -22,12 +22,20 @@ class Entry {
 
     protected $title = '';
 
+    protected $categories = [];
+
+    protected $conf_time = 0;
+
+    protected $image = [];
+
+    protected $content = '';
+
+    protected $id = '';
+
     public function setTitle(string $title): self {
         $this->title = $title;
         return $this;
     }
-
-    protected $categories = [];
     public function setCategories(array $cats): self {
         foreach ($cats as $cat) {
             if (!isset(self::CATEGORIES[$cat])) {
@@ -50,14 +58,10 @@ class Entry {
     public function isConference(): bool {
         return (bool)array_intersect($this->categories, ['cfp', 'conferences']);
     }
-
-    protected $conf_time = 0;
     public function setConfTime(int $time): self {
         $this->conf_time = $time;
         return $this;
     }
-
-    protected $image = [];
     public function setImage(string $path, string $title, ?string $link): self {
         if (basename($path) !== $path) {
             throw new \Exception('path must be a simple file name under ' . self::IMAGE_PATH_REL);
@@ -72,27 +76,12 @@ class Entry {
         ];
         return $this;
     }
-
-    protected $content = '';
     public function setContent(string $content): self {
         if (empty($content)) {
             throw new \Exception('Content must not be empty');
         }
         $this->content = $content;
         return $this;
-    }
-
-    protected $id = '';
-    private static function selectNextId(): string {
-        $filename = date("Y-m-d", $_SERVER["REQUEST_TIME"]);
-        $count = 0;
-        do {
-            ++$count;
-            $id = $filename . "-" . $count;
-            $basename  = "{$id}.xml";
-        } while (file_exists(self::ARCHIVE_ENTRIES_ABS . $basename));
-
-        return $id;
     }
     public function getId(): string {
         return $this->id;
@@ -176,6 +165,17 @@ class Entry {
         $arch->save(self::ARCHIVE_FILE_ABS);
 
         return $this;
+    }
+    private static function selectNextId(): string {
+        $filename = date("Y-m-d", $_SERVER["REQUEST_TIME"]);
+        $count = 0;
+        do {
+            ++$count;
+            $id = $filename . "-" . $count;
+            $basename  = "{$id}.xml";
+        } while (file_exists(self::ARCHIVE_ENTRIES_ABS . $basename));
+
+        return $id;
     }
 
     private static function ce(\DOMDocument $d, string $name, $value, array $attrs = [], ?\DOMNode $to = null) {


### PR DESCRIPTION
This pull request

- [x] enables the `ordered_class_elements` fixer
- [x] excludes `tests/run-tests.php`
- [x] runs `make coding-standards`

Follows #559.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.4.0/doc/rules/class_notation/ordered_class_elements.rst.