### PR TITLE
Fix: Use `include_once` instead of `include`

### DIFF
--- a/manual/add-note.php
+++ b/manual/add-note.php
@@ -5,7 +5,7 @@ $_SERVER['BASE_PAGE'] = 'manual/add-note.php';
 include_once __DIR__ . '/../include/prepend.inc';
 include_once __DIR__ . '/../include/posttohost.inc';
 include_once __DIR__ . '/../include/shared-manual.inc';
-include __DIR__ . '/spam_challenge.php';
+include_once __DIR__ . '/spam_challenge.php';
 
 site_header("Add Manual Note", array( 'css' => 'add-note.css'));
 


### PR DESCRIPTION
This pull request

- [x] uses `include_once` instead of `include`

Follows https://github.com/php/web-php/pull/640#discussion_r918767644.