### PR TITLE
Enhancement: Enable `trim_array_spaces` fixer

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -17,6 +17,7 @@ $config->setRules([
     'no_trailing_whitespace' => true,
     'ordered_class_elements' => true,
     'single_space_after_construct' => true,
+    'trim_array_spaces' => true,
     'visibility_required' => true,
     'whitespace_after_comma_in_array' => true,
 ]);

--- a/manual/add-note.php
+++ b/manual/add-note.php
@@ -7,7 +7,7 @@ include_once __DIR__ . '/../include/posttohost.inc';
 include_once __DIR__ . '/../include/shared-manual.inc';
 include __DIR__ . '/spam_challenge.php';
 
-site_header("Add Manual Note", array( 'css' => 'add-note.css'));
+site_header("Add Manual Note", array('css' => 'add-note.css'));
 
 // Copy over "sect" and "redirect" from GET to POST
 if (empty($_POST['sect']) && isset($_GET['sect'])) {


### PR DESCRIPTION
This pull request

- [x] enables the `trim_array_spaces` fixer
- [x] runs `make coding-standards`

Follows #559.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.4.0/doc/rules/array_notation/trim_array_spaces.rst.