### PR TITLE
Enhancement: Enable `trailing_comma_in_multiline` fixer

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -51,6 +51,12 @@ $config
         ],
         'strict_param' => true,
         'switch_case_space' => true,
+        'trailing_comma_in_multiline' => [
+            'elements' => [
+                'arguments',
+                'arrays',
+            ],
+        ],
         'trim_array_spaces' => true,
         'unary_operator_spaces' => true,
         'visibility_required' => true,

--- a/credits.php
+++ b/credits.php
@@ -16,7 +16,7 @@ $credits = preg_replace('!<style.*?>.*</style>!ims', '', $m[1]);
 $credits = str_replace(
     ["</center>", "& "],
     ["</div>", "&amp; "],
-    $credits
+    $credits,
 );
 
 // If there is something left, print it out

--- a/download-docs.php
+++ b/download-docs.php
@@ -123,7 +123,7 @@ foreach ($LANGUAGES as $langcode => $language) {
                     $link_to,
                     (int) ($size / 1024),
                     date("j M Y", $changed),
-                    $extension
+                    $extension,
                 ];
                 $found_formats[$formatname] = 1;
             }

--- a/downloads.php
+++ b/downloads.php
@@ -32,11 +32,11 @@ site_header("Downloads",
                 "rel" => "alternate",
                 "type" => "application/atom+xml",
                 "href" => $MYSITE . "releases/feed.php",
-                "title" => "PHP Release feed"
+                "title" => "PHP Release feed",
             ],
         ],
         "current" => "downloads",
-    ]
+    ],
 );
 ?>
 <?php $i = 0; foreach ($RELEASES as $MAJOR => $major_releases): /* major releases loop start */

--- a/elephpant.php
+++ b/elephpant.php
@@ -36,5 +36,5 @@ site_header("ElePHPant", ["current" => "footer"]);
 <?php
 // Print the common footer.
 site_footer([
-    'elephpants' => true
+    'elephpants' => true,
 ]);

--- a/error.php
+++ b/error.php
@@ -711,7 +711,7 @@ if (strpos($URI, "manual/") === 0) {
 $fallback = (myphpnet_urlsearch() === MYPHPNET_URL_MANUAL ? "404manual" : "404quickref");
 mirror_redirect(
     '/search.php?show=' . $fallback . '&lang=' . urlencode($LANG) .
-    '&pattern=' . substr($_SERVER['REQUEST_URI'], 1)
+    '&pattern=' . substr($_SERVER['REQUEST_URI'], 1),
 );
 /*
  * vim: set et ts=4 sw=4 ft=php: :

--- a/git-php.php
+++ b/git-php.php
@@ -86,7 +86,7 @@ if (count($_POST) && (!isset($_POST['purpose']) || !is_array($_POST['purpose']) 
                 "note" => $_POST['realpurpose'],
                 "yesno" => $_POST['yesno'],
                 "group" => $_POST['group'],
-            ]
+            ],
         );
         // Error while posting
         if ($error) {

--- a/images/elephpants.php
+++ b/images/elephpants.php
@@ -39,7 +39,7 @@ if (isset($_REQUEST['count'])) {
 } else {
     header('HTTP/1.1 400', true, 400);
     echo json_encode([
-        'error' => "Specify how many elephpants to serve via 'count'."
+        'error' => "Specify how many elephpants to serve via 'count'.",
     ]);
     exit;
 }
@@ -53,7 +53,7 @@ $photos = json_decode($json, true);
 if (!$photos || !is_array($photos)) {
     header('HTTP/1.1 500', true, 500);
     echo json_encode([
-        'error' => "No elephpant metadata available."
+        'error' => "No elephpant metadata available.",
     ]);
     exit;
 }
@@ -79,7 +79,7 @@ foreach ($photos as $photo) {
     $elephpants[] = [
         'title' => $photo['title'],
         'url' => "http://flickr.com/photos/" . $photo['owner'] . "/" . $photo['id'],
-        'data' => base64_encode(file_get_contents($path . '/' . $photo['filename']))
+        'data' => base64_encode(file_get_contents($path . '/' . $photo['filename'])),
     ];
 }
 

--- a/include/branches.inc
+++ b/include/branches.inc
@@ -68,8 +68,8 @@ function format_interval($from, DateTime $to) {
                                                 return "$t[0] $t[1]" .
                                                         ($t[0] != 1 ? 's' : '');
                                             },
-                                            $times
-                                        )
+                                            $times,
+                                        ),
                                 );
 
             if ($diff->invert) {
@@ -378,7 +378,7 @@ function version_array(string $version, ?int $length = null)
 {
     $versionArray = array_map(
         'intval',
-        explode('.', $version)
+        explode('.', $version),
     );
 
     if (is_int($length)) {
@@ -387,7 +387,7 @@ function version_array(string $version, ?int $length = null)
             : array_slice(
                 $versionArray,
                 0,
-                $length
+                $length,
             );
     }
 

--- a/include/get-download.inc
+++ b/include/get-download.inc
@@ -12,7 +12,7 @@ $possible_files = [$df, "manual/$df"];
 
 $site_config = [
     'current' => 'downloads',
-    'css' => ['mirror.css']
+    'css' => ['mirror.css'],
 ];
 
 // Find out what is the exact file requested

--- a/include/ip-to-country.inc
+++ b/include/ip-to-country.inc
@@ -89,7 +89,7 @@ function i2c_search_in_index($ip)
     // Open the index file for reading
     $dbidx = fopen(
         __DIR__ . "/../backend/ip-to-country.idx",
-        "r"
+        "r",
     );
     if (!$dbidx) { return false; }
 
@@ -133,7 +133,7 @@ function i2c_search_in_db($ip, $idx)
     // Open DB for reading
     $ipdb = fopen(
         $_SERVER['DOCUMENT_ROOT'] . "/backend/ip-to-country.db",
-        "r"
+        "r",
     );
 
     // Return with "NA" in case of we cannot open the db

--- a/include/langchooser.inc
+++ b/include/langchooser.inc
@@ -68,7 +68,7 @@ function language_choose_code()
 
         // Drop out langauge specification from URL, as this is already handled
         $_SERVER['STRIPPED_URI'] = preg_replace(
-            "!^/$flang[1]/!", "/", htmlspecialchars($_SERVER['REQUEST_URI'], ENT_QUOTES, 'UTF-8')
+            "!^/$flang[1]/!", "/", htmlspecialchars($_SERVER['REQUEST_URI'], ENT_QUOTES, 'UTF-8'),
         );
 
     }

--- a/include/layout.inc
+++ b/include/layout.inc
@@ -64,7 +64,7 @@ function resize_image($img, $width = 1, $height = 1)
     return preg_replace(
         '!/?>$!',
         sprintf(' height="%s" width="%s">', $height, $width),
-        $str
+        $str,
     );
 }
 
@@ -99,7 +99,7 @@ function make_image($file, $alt = false, $align = false, $extras = false,
         ($alt ?: ''),
         $sizeparams,
         $align,
-        ($extras ? ' ' . $extras              : '')
+        ($extras ? ' ' . $extras              : ''),
     );
 }
 
@@ -132,7 +132,7 @@ function make_submit($file, $alt = false, $align = false, $extras = false,
     $img = str_replace(
         "border=\"$border\"",
         "style=\"border: {$border}px;\"",
-        $img
+        $img,
     );
 
     // Return with ready input image
@@ -156,7 +156,7 @@ function make_popup_link($url, $linktext = false, $target = false, $windowprops 
         ($target ?: "_new"),
                 $windowprops,
         ($extras ? ' ' . $extras : ''),
-        ($linktext ?: $url)
+        ($linktext ?: $url),
     );
 }
 
@@ -232,7 +232,7 @@ function clean_note($text)
     return preg_replace(
         '!((mailto:|(https?|ftp|nntp|news)://).*?)(\s|<|\)|"|\\\\|\'|$)!',
         '<a href="\1" rel="nofollow" target="_blank">\1</a>\4',
-        $text
+        $text,
     );
 }
 
@@ -275,7 +275,7 @@ function display_event($event, $include_date = 1): void
         4 => 'Fourth',
         -1 => 'Last',
         -2 => '2nd Last',
-        -3 => '3rd Last'
+        -3 => '3rd Last',
     ];
 
     if (!isset($event['start']) && isset($event['sday'])) {

--- a/include/results.inc
+++ b/include/results.inc
@@ -26,7 +26,7 @@ function search_results($res, $q, $profile = 'all', $per_page = 10, $s = 0, $l =
         'php' => '<img src="' . $php_img_dir . '/logos/php-icon-white.gif" height="32" width="32" style="float:left; margin-left:-40px;"/>',
         'doc' => '<img src="' . $php_img_dir . '/logos/php-icon-white.gif" height="32" width="32" style="float:left; margin-left:-40px;"/>',
         'bugs' => '<img src="' . $php_img_dir . '/php_bug.gif" height="32" width="32" style="float:left; margin-left:-40px;"/>',
-        'gtk' => '<img src="' . $php_img_dir . '/logos/php-gtk-white.gif" height="26" width="32" style="float:left; margin-left:-40px;"/>'
+        'gtk' => '<img src="' . $php_img_dir . '/logos/php-gtk-white.gif" height="26" width="32" style="float:left; margin-left:-40px;"/>',
     ];
 
     foreach($res['ResultSet']['Result'] as $i => $hit) {

--- a/include/shared-manual.inc
+++ b/include/shared-manual.inc
@@ -50,7 +50,7 @@ function manual_notes($notes):void {
                    '&amp;redirect=' . $_SERVER['BASE_HREF'];
     $addnotesnippet = make_link(
         $addnotelink,
-        "＋<small>add a note</small>"
+        "＋<small>add a note</small>",
     );
 
     $num_notes = count($notes);
@@ -165,21 +165,21 @@ VOTEDIV;
             'https://main.php.net/manage/user-notes.php?action=edit+' . $note->id,
             '<img src="/images/notes-edit@2x.png" height="12" width="12" alt="edit note">',
             'admin',
-            'scrollbars=yes,width=650,height=400'
+            'scrollbars=yes,width=650,height=400',
         ) . "\n   " .
 
         make_popup_link(
             'https://main.php.net/manage/user-notes.php?action=reject+' . $note->id,
             '<img src="/images/notes-reject@2x.png" height="12" width="12" alt="reject note">',
             'admin',
-            'scrollbars=no,width=300,height=200'
+            'scrollbars=no,width=300,height=200',
         ) . "\n   " .
 
         make_popup_link(
             'https://main.php.net/manage/user-notes.php?action=delete+' . $note->id,
             '<img src="/images/notes-delete@2x.png" height="12" width="12" alt="delete note">',
             'admin',
-            'scrollbars=no,width=300,height=200'
+            'scrollbars=no,width=300,height=200',
         ) . "\n  </span>";
 
     } else {
@@ -387,7 +387,7 @@ function manual_footer(): void {
     manual_notes($USERNOTES);
     site_footer([
         'related_menu' => $__RELATED['toc'],
-        'related_menu_deprecated' => $__RELATED['toc_deprecated']
+        'related_menu_deprecated' => $__RELATED['toc_deprecated'],
     ]);
 }
 

--- a/include/site.inc
+++ b/include/site.inc
@@ -22,8 +22,8 @@ $MIRRORS = [
         MIRROR_SPECIAL,
         true,
         "en",
-        MIRROR_OK
-    ]
+        MIRROR_OK,
+    ],
 ];
 
 /**

--- a/index.php
+++ b/index.php
@@ -129,20 +129,20 @@ site_header("Hypertext Preprocessor",
             '<script>',
             "function okc(f){var c=[38,38,40,40,37,39,37,39,66,65,13],x=function(){x.c=x.c||Array.apply({},c);x.r=function(){x.c=null};return x.c},h=function(e){if(x()[0]==(e||window.event).keyCode){x().shift();if(!x().length){x.r();f()}}else{x.r()}};window.addEventListener?window.addEventListener('keydown',h,false):document.attachEvent('onkeydown',h)}",
             "okc(function(){if(document.getElementById){i=document.getElementById('phplogo');i.src='" . $MYSITE . "images/php_konami.gif'}});",
-            '</script>'
+            '</script>',
         ],
         'link' => [
             [
                 "rel" => "search",
                 "type" => "application/opensearchdescription+xml",
                 "href" => $MYSITE . "phpnetimprovedsearch.src",
-                "title" => "Add PHP.net search"
+                "title" => "Add PHP.net search",
             ],
             [
                 "rel" => "alternate",
                 "type" => "application/atom+xml",
                 "href" => $MYSITE . "releases/feed.php",
-                "title" => "PHP Release feed"
+                "title" => "PHP Release feed",
             ],
 
         ],
@@ -167,7 +167,7 @@ site_header("Hypertext Preprocessor",
 
 <link href="https://fosstodon.org/@php" rel="me" />
 META
-    ]
+    ],
 );
 
 // Print body of home page.
@@ -228,5 +228,5 @@ SIDEBAR_DATA;
 site_footer([
     "atom" => "/feed.atom", // Add a link to the feed at the bottom
     'elephpants' => true,
-    'sidebar' => $SIDEBAR
+    'sidebar' => $SIDEBAR,
 ]);

--- a/mailing-lists.php
+++ b/mailing-lists.php
@@ -78,8 +78,8 @@ if (isset($_POST['action'])) {
                 "email" => $_POST['email'],
                 "maillist" => $_POST['maillist'],
                 "remoteip" => $remote_addr,
-                "referer" => $MYSITE . "mailing-lists.php"
-            ]
+                "referer" => $MYSITE . "mailing-lists.php",
+            ],
         );
 
         // Provide error if unable to [un]subscribe
@@ -189,50 +189,50 @@ if (isset($_POST['action'])) {
       [
           'php-announce', 'Announcements',
           'Announcements of new PHP releases are sent to this very low-volume list',
-          true, false, false, "php.announce"
+          true, false, false, "php.announce",
       ],
       [
           'php-general', 'General user list',
           'This is a high volume list for general PHP support; ask PHP questions here',
-          false, true, true, "php.general"
+          false, true, true, "php.general",
       ],
       [
           'php-windows', 'Windows PHP users list',
           'Using PHP on Microsoft Windows',
-          false, true, true, "php.windows"
+          false, true, true, "php.windows",
       ],
 
       'Subject specific lists for PHP users',
       [
           'php-install', 'Installation issues and problems',
           'How to install PHP with particular configurations and servers',
-          false, true, true, "php.install"
+          false, true, true, "php.install",
       ],
       [
           'php-db', 'Databases and PHP',
           'This list is for the discussion of PHP database topics',
-          false, true, true, "php.db"
+          false, true, true, "php.db",
       ],
       [
           'php-i18n', 'Unicode and Internationalization',
           'Unicode support, Internationalization (i18n) and localization (l10n) issues and features',
-          false, true, true, "php.i18n"
+          false, true, true, "php.i18n",
       ],
       [
           'php-evangelism', 'PHP evangelism mailing list',
           'A list for people interested in promoting PHP and learning good reasons to support PHP in the enterprise',
-          true, true, true, "php.evangelism"
+          true, true, true, "php.evangelism",
       ],
       [
           'soap', 'PHP SOAP list',
           'List for the SOAP developers',
-          false, false, false, 'php.soap'
+          false, false, false, 'php.soap',
       ],
       'Non-English language mailing lists',
       [
           'php-es', 'Spanish PHP Mailing list',
           'List for Spanish speaking people interested in PHP',
-          false, false, false, 'php.general.es'
+          false, false, false, 'php.general.es',
       ],
 
   ];
@@ -244,37 +244,37 @@ if (isset($_POST['action'])) {
       [
           'internals', 'Internals list',
           'A medium volume list for those who want to help out with the development of PHP',
-          false, 'php-internals', true, "php.internals"
+          false, 'php-internals', true, "php.internals",
       ],
       [
           'internals-win', 'Windows Internals list',
           'A low volume list for those who want to help out with the development of PHP on Windows',
-          false, false, true, "php.internals.win"
+          false, false, true, "php.internals.win",
       ],
       [
           'php-cvs', 'Git commit list',
           'All commits to internals (php-src) and the Zend Engine are posted to this list automatically',
-          true, true, false, "php.cvs"
+          true, true, false, "php.cvs",
       ],
       [
           'git-pulls', 'Git pull requests',
           'Pull requests from Github',
-          false, false, false, "php.git-pulls"
+          false, false, false, "php.git-pulls",
       ],
       [
           'php-qa', 'Quality Assurance list',
           'List for the members of the PHP-QA Team',
-          false, true, false, "php.qa"
+          false, true, false, "php.qa",
       ],
       [
           'php-bugs', 'General bugs',
           'General bug activity are posted here',
-          false, false, false, "php.bugs"
+          false, false, false, "php.bugs",
       ],
       [
           'standards', 'PHP Standardization and interoperability list',
           'Development of language standards',
-          false, false, false, "php.standards"
+          false, false, false, "php.standards",
       ],
 
       'PHP internal website mailing lists',
@@ -282,24 +282,24 @@ if (isset($_POST['action'])) {
           'php-webmaster', 'PHP php.net internal infrastructure discussion',
           'List for discussing and maintaining the php.net web infrastructure.<br>
        For general PHP support questions, see "General Mailing Lists" or the <a href="/support.php">support page</a>',
-          false, false, false, "php.webmaster"
+          false, false, false, "php.webmaster",
       ],
 
       'PHP documentation mailing lists',
       [
           'phpdoc', 'Documentation discussion',
           'List for discussing the PHP documentation',
-          false, true, false, "php.doc"
+          false, true, false, "php.doc",
       ],
       [
           'doc-cvs', 'Documentation changes and commits',
           'Changes to the documentation are posted here',
-          true, "php-doc-cvs", false, "php.doc.cvs"
+          true, "php-doc-cvs", false, "php.doc.cvs",
       ],
       [
           'doc-bugs', 'Documentation bugs',
           'Documentation bug activity (translations, sources, and build system) are posted here',
-          true, 'php-doc-bugs', false, "php.doc.bugs"
+          true, 'php-doc-bugs', false, "php.doc.bugs",
       ],
   ];
 

--- a/manual/add-note.php
+++ b/manual/add-note.php
@@ -100,8 +100,8 @@ if ($process) {
                 'note' => $note,
                 'sect' => $_POST['sect'],
                 'ip' => $_SERVER['REMOTE_ADDR'],
-                'redirip' => $redirip
-            ]
+                'redirip' => $redirip,
+            ],
         );
 
         // If there is any non-header result, then it is an error

--- a/manual/vote-note.php
+++ b/manual/vote-note.php
@@ -28,7 +28,7 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
           "noteid" => $_REQUEST['id'],
           "sect" => $_REQUEST['page'],
           "vote" => $_REQUEST['vote'],
-          "ip" => $_SERVER['REMOTE_ADDR']
+          "ip" => $_SERVER['REMOTE_ADDR'],
       ];
       if (($r = posttohost($master_url, $data)) === null || strpos($r,"failed to open socket to") !== false) {
         $response["success"] = false;

--- a/mirror.php
+++ b/mirror.php
@@ -33,7 +33,7 @@ if (is_official_mirror()) {
                 htmlspecialchars(mirror_provider()),
                 false,
                 false,
-                'backend'
+                'backend',
             );
 
             // Add size information depending on mirror type

--- a/mirroring.php
+++ b/mirroring.php
@@ -24,7 +24,7 @@ site_header(
     [
         'current' => 'community',
         'layout_span' => 12,
-    ]
+    ],
 );
 
 ?>

--- a/mod.php
+++ b/mod.php
@@ -47,7 +47,7 @@ else {
         "confirm@" . $sites[$site],
         "confirm",
         "[confirm: $token $sender]",
-        "From: $sender"
+        "From: $sender",
     );
 
     echo <<<THANKS

--- a/my.php
+++ b/my.php
@@ -118,7 +118,7 @@ $langinfo = [
     "The mirror's default language" =>
     default_language(),
 
-    "Default" => "en"
+    "Default" => "en",
 ];
 
 // Write a row for all settings

--- a/releases/8.0/de.php
+++ b/releases/8.0/de.php
@@ -44,7 +44,7 @@ releases\php80\common_header(
         <div class="php8-compare__label">PHP 7</div>
         <div class="php8-code phpcode">
             <?php highlight_php_trimmed(
-                'htmlspecialchars($string, ENT_COMPAT | ENT_HTML401, \'UTF-8\', false);'
+                'htmlspecialchars($string, ENT_COMPAT | ENT_HTML401, \'UTF-8\', false);',
             );?>
         </div>
       </div>
@@ -53,7 +53,7 @@ releases\php80\common_header(
         <div class="php8-compare__label php8-compare__label_new">PHP 8</div>
         <div class="php8-code phpcode">
             <?php highlight_php_trimmed(
-                'htmlspecialchars($string, double_encode: false);'
+                'htmlspecialchars($string, double_encode: false);',
             );?>
         </div>
       </div>
@@ -82,7 +82,7 @@ releases\php80\common_header(
      * @Route("/api/posts/{id}", methods={"GET"})
      */
     public function get($id) { /* ... */ }
-}'
+}',
             );?>
         </div>
       </div>
@@ -95,7 +95,7 @@ releases\php80\common_header(
 {
     #[Route("/api/posts/{id}", methods: ["GET"])]
     public function get($id) { /* ... */ }
-}'
+}',
             );?>
         </div>
       </div>
@@ -129,7 +129,7 @@ releases\php80\common_header(
     $this->y = $y;
     $this->z = $z;
   }
-}'
+}',
             );?>
         </div>
       </div>
@@ -144,7 +144,7 @@ releases\php80\common_header(
     public float $y = 0.0,
     public float $z = 0.0,
   ) {}
-}'
+}',
             );?>
         </div>
       </div>
@@ -176,7 +176,7 @@ releases\php80\common_header(
   }
 }
 
-new Number(\'NaN\'); // Ok'
+new Number(\'NaN\'); // Ok',
             );?>
         </div>
       </div>
@@ -191,7 +191,7 @@ new Number(\'NaN\'); // Ok'
   ) {}
 }
 
-new Number(\'NaN\'); // TypeError'
+new Number(\'NaN\'); // TypeError',
             );?>
         </div>
       </div>
@@ -221,7 +221,7 @@ new Number(\'NaN\'); // TypeError'
     break;
 }
 echo $result;
-//> Oh nein!'
+//> Oh nein!',
             );?>
         </div>
       </div>
@@ -234,7 +234,7 @@ echo $result;
   \'8.0\' => "Oh nein!",
   8.0 => "Das hatte ich erwartet",
 };
-//> Das hatte ich erwartet'
+//> Das hatte ich erwartet',
             );?>
         </div>
       </div>
@@ -271,7 +271,7 @@ if ($session !== null) {
       $country = $address->country;
     }
   }
-}'
+}',
             );?>
         </div>
       </div>
@@ -280,7 +280,7 @@ if ($session !== null) {
         <div class="php8-compare__label php8-compare__label_new">PHP 8</div>
         <div class="php8-code phpcode">
             <?php highlight_php_trimmed(
-                '$country = $session?->user?->getAddress()?->country;'
+                '$country = $session?->user?->getAddress()?->country;',
             );?>
         </div>
       </div>
@@ -302,7 +302,7 @@ if ($session !== null) {
         <div class="php8-compare__label">PHP 7</div>
         <div class="php8-code phpcode">
             <?php highlight_php_trimmed(
-                '0 == \'foobar\' // true'
+                '0 == \'foobar\' // true',
             );?>
         </div>
       </div>
@@ -311,7 +311,7 @@ if ($session !== null) {
         <div class="php8-compare__label php8-compare__label_new">PHP 8</div>
         <div class="php8-code phpcode">
             <?php highlight_php_trimmed(
-                '0 == \'foobar\' // false'
+                '0 == \'foobar\' // false',
             );?>
         </div>
       </div>
@@ -334,7 +334,7 @@ if ($session !== null) {
             <?php highlight_php_trimmed(
                 'strlen([]); // Warning: strlen() expects parameter 1 to be string, array given
 
-array_chunk([], -1); // Warning: array_chunk(): Size parameter expected to be greater than 0'
+array_chunk([], -1); // Warning: array_chunk(): Size parameter expected to be greater than 0',
             );?>
         </div>
       </div>
@@ -345,7 +345,7 @@ array_chunk([], -1); // Warning: array_chunk(): Size parameter expected to be gr
             <?php highlight_php_trimmed(
                 'strlen([]); // TypeError: strlen(): Argument #1 ($str) must be of type string, array given
 
-array_chunk([], -1); // ValueError: array_chunk(): Argument #2 ($length) must be greater than 0'
+array_chunk([], -1); // ValueError: array_chunk(): Argument #2 ($length) must be greater than 0',
             );?>
         </div>
       </div>

--- a/releases/8.0/en.php
+++ b/releases/8.0/en.php
@@ -43,7 +43,7 @@ releases\php80\common_header(
         <div class="php8-compare__label">PHP 7</div>
         <div class="php8-code phpcode">
             <?php highlight_php_trimmed(
-                'htmlspecialchars($string, ENT_COMPAT | ENT_HTML401, \'UTF-8\', false);'
+                'htmlspecialchars($string, ENT_COMPAT | ENT_HTML401, \'UTF-8\', false);',
             );?>
         </div>
 
@@ -54,7 +54,7 @@ releases\php80\common_header(
         <div class="php8-compare__label php8-compare__label_new">PHP 8</div>
         <div class="php8-code phpcode">
             <?php highlight_php_trimmed(
-                'htmlspecialchars($string, double_encode: false);'
+                'htmlspecialchars($string, double_encode: false);',
             );?>
         </div>
       </div>
@@ -83,7 +83,7 @@ releases\php80\common_header(
      * @Route("/api/posts/{id}", methods={"GET"})
      */
     public function get($id) { /* ... */ }
-}'
+}',
             );?>
         </div>
       </div>
@@ -96,7 +96,7 @@ releases\php80\common_header(
 {
     #[Route("/api/posts/{id}", methods: ["GET"])]
     public function get($id) { /* ... */ }
-}'
+}',
             );?>
         </div>
       </div>
@@ -130,7 +130,7 @@ releases\php80\common_header(
     $this->y = $y;
     $this->z = $z;
   }
-}'
+}',
             );?>
         </div>
       </div>
@@ -145,7 +145,7 @@ releases\php80\common_header(
     public float $y = 0.0,
     public float $z = 0.0,
   ) {}
-}'
+}',
             );?>
         </div>
       </div>
@@ -177,7 +177,7 @@ releases\php80\common_header(
   }
 }
 
-new Number(\'NaN\'); // Ok'
+new Number(\'NaN\'); // Ok',
             );?>
         </div>
       </div>
@@ -192,7 +192,7 @@ new Number(\'NaN\'); // Ok'
   ) {}
 }
 
-new Number(\'NaN\'); // TypeError'
+new Number(\'NaN\'); // TypeError',
             );?>
         </div>
       </div>
@@ -222,7 +222,7 @@ new Number(\'NaN\'); // TypeError'
     break;
 }
 echo $result;
-//> Oh no!'
+//> Oh no!',
             );?>
         </div>
       </div>
@@ -235,7 +235,7 @@ echo $result;
   \'8.0\' => "Oh no!",
   8.0 => "This is what I expected",
 };
-//> This is what I expected'
+//> This is what I expected',
             );?>
         </div>
       </div>
@@ -272,7 +272,7 @@ if ($session !== null) {
       $country = $address->country;
     }
   }
-}'
+}',
             );?>
         </div>
       </div>
@@ -281,7 +281,7 @@ if ($session !== null) {
         <div class="php8-compare__label php8-compare__label_new">PHP 8</div>
         <div class="php8-code phpcode">
             <?php highlight_php_trimmed(
-                '$country = $session?->user?->getAddress()?->country;'
+                '$country = $session?->user?->getAddress()?->country;',
             );?>
         </div>
       </div>
@@ -303,7 +303,7 @@ if ($session !== null) {
         <div class="php8-compare__label">PHP 7</div>
         <div class="php8-code phpcode">
             <?php highlight_php_trimmed(
-                '0 == \'foobar\' // true'
+                '0 == \'foobar\' // true',
             );?>
         </div>
       </div>
@@ -312,7 +312,7 @@ if ($session !== null) {
         <div class="php8-compare__label php8-compare__label_new">PHP 8</div>
         <div class="php8-code phpcode">
             <?php highlight_php_trimmed(
-                '0 == \'foobar\' // false'
+                '0 == \'foobar\' // false',
             );?>
         </div>
       </div>
@@ -335,7 +335,7 @@ if ($session !== null) {
             <?php highlight_php_trimmed(
                 'strlen([]); // Warning: strlen() expects parameter 1 to be string, array given
 
-array_chunk([], -1); // Warning: array_chunk(): Size parameter expected to be greater than 0'
+array_chunk([], -1); // Warning: array_chunk(): Size parameter expected to be greater than 0',
             );?>
         </div>
       </div>
@@ -346,7 +346,7 @@ array_chunk([], -1); // Warning: array_chunk(): Size parameter expected to be gr
             <?php highlight_php_trimmed(
                 'strlen([]); // TypeError: strlen(): Argument #1 ($str) must be of type string, array given
 
-array_chunk([], -1); // ValueError: array_chunk(): Argument #2 ($length) must be greater than 0'
+array_chunk([], -1); // ValueError: array_chunk(): Argument #2 ($length) must be greater than 0',
             );?>
         </div>
       </div>

--- a/releases/8.0/es.php
+++ b/releases/8.0/es.php
@@ -42,7 +42,7 @@ releases\php80\common_header(
         <div class="php8-compare__label">PHP 7</div>
         <div class="php8-code phpcode">
             <?php highlight_php_trimmed(
-                'htmlspecialchars($string, ENT_COMPAT | ENT_HTML401, \'UTF-8\', false);'
+                'htmlspecialchars($string, ENT_COMPAT | ENT_HTML401, \'UTF-8\', false);',
             );?>
         </div>
 
@@ -53,7 +53,7 @@ releases\php80\common_header(
         <div class="php8-compare__label php8-compare__label_new">PHP 8</div>
         <div class="php8-code phpcode">
             <?php highlight_php_trimmed(
-                'htmlspecialchars($string, double_encode: false);'
+                'htmlspecialchars($string, double_encode: false);',
             );?>
         </div>
       </div>
@@ -82,7 +82,7 @@ releases\php80\common_header(
      * @Route("/api/posts/{id}", methods={"GET"})
      */
     public function get($id) { /* ... */ }
-}'
+}',
             );?>
         </div>
       </div>
@@ -95,7 +95,7 @@ releases\php80\common_header(
 {
     #[Route("/api/posts/{id}", methods: ["GET"])]
     public function get($id) { /* ... */ }
-}'
+}',
             );?>
         </div>
       </div>
@@ -129,7 +129,7 @@ releases\php80\common_header(
     $this->y = $y;
     $this->z = $z;
   }
-}'
+}',
             );?>
         </div>
       </div>
@@ -144,7 +144,7 @@ releases\php80\common_header(
     public float $y = 0.0,
     public float $z = 0.0,
   ) {}
-}'
+}',
             );?>
         </div>
       </div>
@@ -177,7 +177,7 @@ releases\php80\common_header(
   }
 }
 
-new Number(\'NaN\'); // Ok'
+new Number(\'NaN\'); // Ok',
             );?>
         </div>
       </div>
@@ -192,7 +192,7 @@ new Number(\'NaN\'); // Ok'
   ) {}
 }
 
-new Number(\'NaN\'); // TypeError'
+new Number(\'NaN\'); // TypeError',
             );?>
         </div>
       </div>
@@ -221,7 +221,7 @@ new Number(\'NaN\'); // TypeError'
     break;
 }
 echo $result;
-//> Oh no!'
+//> Oh no!',
             );?>
         </div>
       </div>
@@ -234,7 +234,7 @@ echo $result;
   \'8.0\' => "Oh no!",
   8.0 => "This is what I expected",
 };
-//> This is what I expected'
+//> This is what I expected',
             );?>
         </div>
       </div>
@@ -272,7 +272,7 @@ if ($session !== null) {
       $country = $address->country;
     }
   }
-}'
+}',
             );?>
         </div>
       </div>
@@ -281,7 +281,7 @@ if ($session !== null) {
         <div class="php8-compare__label php8-compare__label_new">PHP 8</div>
         <div class="php8-code phpcode">
             <?php highlight_php_trimmed(
-                '$country = $session?->user?->getAddress()?->country;'
+                '$country = $session?->user?->getAddress()?->country;',
             );?>
         </div>
       </div>
@@ -302,7 +302,7 @@ if ($session !== null) {
         <div class="php8-compare__label">PHP 7</div>
         <div class="php8-code phpcode">
             <?php highlight_php_trimmed(
-                '0 == \'foobar\' // true'
+                '0 == \'foobar\' // true',
             );?>
         </div>
       </div>
@@ -311,7 +311,7 @@ if ($session !== null) {
         <div class="php8-compare__label php8-compare__label_new">PHP 8</div>
         <div class="php8-code phpcode">
             <?php highlight_php_trimmed(
-                '0 == \'foobar\' // false'
+                '0 == \'foobar\' // false',
             );?>
         </div>
       </div>
@@ -334,7 +334,7 @@ if ($session !== null) {
             <?php highlight_php_trimmed(
                 'strlen([]); // Warning: strlen() expects parameter 1 to be string, array given
 
-array_chunk([], -1); // Warning: array_chunk(): Size parameter expected to be greater than 0'
+array_chunk([], -1); // Warning: array_chunk(): Size parameter expected to be greater than 0',
             );?>
         </div>
       </div>
@@ -345,7 +345,7 @@ array_chunk([], -1); // Warning: array_chunk(): Size parameter expected to be gr
             <?php highlight_php_trimmed(
                 'strlen([]); // TypeError: strlen(): Argument #1 ($str) must be of type string, array given
 
-array_chunk([], -1); // ValueError: array_chunk(): Argument #2 ($length) must be greater than 0'
+array_chunk([], -1); // ValueError: array_chunk(): Argument #2 ($length) must be greater than 0',
             );?>
         </div>
       </div>

--- a/releases/8.0/fr.php
+++ b/releases/8.0/fr.php
@@ -47,7 +47,7 @@ releases\php80\common_header(
         <div class="php8-compare__label">PHP 7</div>
         <div class="php8-code phpcode">
             <?php highlight_php_trimmed(
-                'htmlspecialchars($string, ENT_COMPAT | ENT_HTML401, \'UTF-8\', false);'
+                'htmlspecialchars($string, ENT_COMPAT | ENT_HTML401, \'UTF-8\', false);',
             );?>
         </div>
 
@@ -58,7 +58,7 @@ releases\php80\common_header(
         <div class="php8-compare__label php8-compare__label_new">PHP 8</div>
         <div class="php8-code phpcode">
             <?php highlight_php_trimmed(
-                'htmlspecialchars($string, double_encode: false);'
+                'htmlspecialchars($string, double_encode: false);',
             );?>
         </div>
       </div>
@@ -85,7 +85,7 @@ releases\php80\common_header(
 * @Route("/api/posts/{id}", methods={"GET", "HEAD"})
 */
 class User
-{'
+{',
             );?>
         </div>
       </div>
@@ -96,7 +96,7 @@ class User
             <?php highlight_php_trimmed(
                 '#[Route("/api/posts/{id}", methods: ["GET", "HEAD"])]
 class User
-{'
+{',
             );?>
         </div>
       </div>
@@ -130,7 +130,7 @@ class User
     $this->y = $y;
     $this->z = $z;
   }
-}'
+}',
             );?>
         </div>
       </div>
@@ -145,7 +145,7 @@ class User
     public float $y = 0.0,
     public float $z = 0.0,
   ) {}
-}'
+}',
             );?>
         </div>
       </div>
@@ -177,7 +177,7 @@ class User
   }
 }
 
-new Number(\'NaN\'); // Ok'
+new Number(\'NaN\'); // Ok',
             );?>
         </div>
       </div>
@@ -192,7 +192,7 @@ new Number(\'NaN\'); // Ok'
   ) {}
 }
 
-new Number(\'NaN\'); // TypeError'
+new Number(\'NaN\'); // TypeError',
             );?>
         </div>
       </div>
@@ -224,7 +224,7 @@ new Number(\'NaN\'); // TypeError'
     break;
 }
 echo $result;
-//> Oh no!'
+//> Oh no!',
             );?>
         </div>
       </div>
@@ -237,7 +237,7 @@ echo $result;
   \'8.0\' => "Oh no!",
   8.0 => "This is what I expected",
 };
-//> This is what I expected'
+//> This is what I expected',
             );?>
         </div>
       </div>
@@ -274,7 +274,7 @@ if ($session !== null) {
       $country = $address->country;
     }
   }
-}'
+}',
             );?>
         </div>
       </div>
@@ -283,7 +283,7 @@ if ($session !== null) {
         <div class="php8-compare__label php8-compare__label_new">PHP 8</div>
         <div class="php8-code phpcode">
             <?php highlight_php_trimmed(
-                '$country = $session?->user?->getAddress()?->country;'
+                '$country = $session?->user?->getAddress()?->country;',
             );?>
         </div>
       </div>
@@ -307,7 +307,7 @@ if ($session !== null) {
         <div class="php8-compare__label">PHP 7</div>
         <div class="php8-code phpcode">
             <?php highlight_php_trimmed(
-                '0 == \'foobar\' // true'
+                '0 == \'foobar\' // true',
             );?>
         </div>
       </div>
@@ -316,7 +316,7 @@ if ($session !== null) {
         <div class="php8-compare__label php8-compare__label_new">PHP 8</div>
         <div class="php8-code phpcode">
             <?php highlight_php_trimmed(
-                '0 == \'foobar\' // false'
+                '0 == \'foobar\' // false',
             );?>
         </div>
       </div>
@@ -341,7 +341,7 @@ if ($session !== null) {
             <?php highlight_php_trimmed(
                 'strlen([]); // Warning: strlen() expects parameter 1 to be string, array given
 
-array_chunk([], -1); // Warning: array_chunk(): Size parameter expected to be greater than 0'
+array_chunk([], -1); // Warning: array_chunk(): Size parameter expected to be greater than 0',
             );?>
         </div>
       </div>
@@ -352,7 +352,7 @@ array_chunk([], -1); // Warning: array_chunk(): Size parameter expected to be gr
             <?php highlight_php_trimmed(
                 'strlen([]); // TypeError: strlen(): Argument #1 ($str) must be of type string, array given
 
-array_chunk([], -1); // ValueError: array_chunk(): Argument #2 ($length) must be greater than 0'
+array_chunk([], -1); // ValueError: array_chunk(): Argument #2 ($length) must be greater than 0',
             );?>
         </div>
       </div>

--- a/releases/8.0/it.php
+++ b/releases/8.0/it.php
@@ -45,7 +45,7 @@ releases\php80\common_header(
         <div class="php8-compare__label">PHP 7</div>
         <div class="php8-code phpcode">
             <?php highlight_php_trimmed(
-                'htmlspecialchars($string, ENT_COMPAT | ENT_HTML401, \'UTF-8\', false);'
+                'htmlspecialchars($string, ENT_COMPAT | ENT_HTML401, \'UTF-8\', false);',
             );?>
         </div>
 
@@ -56,7 +56,7 @@ releases\php80\common_header(
         <div class="php8-compare__label php8-compare__label_new">PHP 8</div>
         <div class="php8-code phpcode">
             <?php highlight_php_trimmed(
-                'htmlspecialchars($string, double_encode: false);'
+                'htmlspecialchars($string, double_encode: false);',
             );?>
         </div>
       </div>
@@ -85,7 +85,7 @@ releases\php80\common_header(
      * @Route("/api/posts/{id}", methods={"GET"})
      */
     public function get($id) { /* ... */ }
-}'
+}',
             );?>
         </div>
       </div>
@@ -98,7 +98,7 @@ releases\php80\common_header(
 {
     #[Route("/api/posts/{id}", methods: ["GET"])]
     public function get($id) { /* ... */ }
-}'
+}',
             );?>
         </div>
       </div>
@@ -132,7 +132,7 @@ releases\php80\common_header(
     $this->y = $y;
     $this->z = $z;
   }
-}'
+}',
             );?>
         </div>
       </div>
@@ -147,7 +147,7 @@ releases\php80\common_header(
     public float $y = 0.0,
     public float $z = 0.0,
   ) {}
-}'
+}',
             );?>
         </div>
       </div>
@@ -179,7 +179,7 @@ releases\php80\common_header(
   }
 }
 
-new Number(\'NaN\'); // Ok'
+new Number(\'NaN\'); // Ok',
             );?>
         </div>
       </div>
@@ -194,7 +194,7 @@ new Number(\'NaN\'); // Ok'
   ) {}
 }
 
-new Number(\'NaN\'); // TypeError'
+new Number(\'NaN\'); // TypeError',
             );?>
         </div>
       </div>
@@ -224,7 +224,7 @@ new Number(\'NaN\'); // TypeError'
     break;
 }
 echo $result;
-//> Oh no!'
+//> Oh no!',
             );?>
         </div>
       </div>
@@ -237,7 +237,7 @@ echo $result;
   \'8.0\' => "Oh no!",
   8.0 => "This is what I expected",
 };
-//> This is what I expected'
+//> This is what I expected',
             );?>
         </div>
       </div>
@@ -274,7 +274,7 @@ if ($session !== null) {
       $country = $address->country;
     }
   }
-}'
+}',
             );?>
         </div>
       </div>
@@ -283,7 +283,7 @@ if ($session !== null) {
         <div class="php8-compare__label php8-compare__label_new">PHP 8</div>
         <div class="php8-code phpcode">
             <?php highlight_php_trimmed(
-                '$country = $session?->user?->getAddress()?->country;'
+                '$country = $session?->user?->getAddress()?->country;',
             );?>
         </div>
       </div>
@@ -305,7 +305,7 @@ if ($session !== null) {
         <div class="php8-compare__label">PHP 7</div>
         <div class="php8-code phpcode">
             <?php highlight_php_trimmed(
-                '0 == \'foobar\' // true'
+                '0 == \'foobar\' // true',
             );?>
         </div>
       </div>
@@ -314,7 +314,7 @@ if ($session !== null) {
         <div class="php8-compare__label php8-compare__label_new">PHP 8</div>
         <div class="php8-code phpcode">
             <?php highlight_php_trimmed(
-                '0 == \'foobar\' // false'
+                '0 == \'foobar\' // false',
             );?>
         </div>
       </div>
@@ -337,7 +337,7 @@ if ($session !== null) {
             <?php highlight_php_trimmed(
                 'strlen([]); // Warning: strlen() expects parameter 1 to be string, array given
 
-array_chunk([], -1); // Warning: array_chunk(): Size parameter expected to be greater than 0'
+array_chunk([], -1); // Warning: array_chunk(): Size parameter expected to be greater than 0',
             );?>
         </div>
       </div>
@@ -348,7 +348,7 @@ array_chunk([], -1); // Warning: array_chunk(): Size parameter expected to be gr
             <?php highlight_php_trimmed(
                 'strlen([]); // TypeError: strlen(): Argument #1 ($str) must be of type string, array given
 
-array_chunk([], -1); // ValueError: array_chunk(): Argument #2 ($length) must be greater than 0'
+array_chunk([], -1); // ValueError: array_chunk(): Argument #2 ($length) must be greater than 0',
             );?>
         </div>
       </div>

--- a/releases/8.0/ja.php
+++ b/releases/8.0/ja.php
@@ -42,7 +42,7 @@ releases\php80\common_header(
         <div class="php8-compare__label">PHP 7</div>
         <div class="php8-code phpcode">
             <?php highlight_php_trimmed(
-                'htmlspecialchars($string, ENT_COMPAT | ENT_HTML401, \'UTF-8\', false);'
+                'htmlspecialchars($string, ENT_COMPAT | ENT_HTML401, \'UTF-8\', false);',
             );?>
         </div>
 
@@ -53,7 +53,7 @@ releases\php80\common_header(
         <div class="php8-compare__label php8-compare__label_new">PHP 8</div>
         <div class="php8-code phpcode">
             <?php highlight_php_trimmed(
-                'htmlspecialchars($string, double_encode: false);'
+                'htmlspecialchars($string, double_encode: false);',
             );?>
         </div>
       </div>
@@ -82,7 +82,7 @@ releases\php80\common_header(
      * @Route("/api/posts/{id}", methods={"GET"})
      */
     public function get($id) { /* ... */ }
-}'
+}',
             );?>
         </div>
       </div>
@@ -95,7 +95,7 @@ releases\php80\common_header(
 {
     #[Route("/api/posts/{id}", methods: ["GET"])]
     public function get($id) { /* ... */ }
-}'
+}',
             );?>
         </div>
       </div>
@@ -129,7 +129,7 @@ releases\php80\common_header(
     $this->y = $y;
     $this->z = $z;
   }
-}'
+}',
             );?>
         </div>
       </div>
@@ -144,7 +144,7 @@ releases\php80\common_header(
     public float $y = 0.0,
     public float $z = 0.0,
   ) {}
-}'
+}',
             );?>
         </div>
       </div>
@@ -176,7 +176,7 @@ releases\php80\common_header(
   }
 }
 
-new Number(\'NaN\'); // Ok'
+new Number(\'NaN\'); // Ok',
             );?>
         </div>
       </div>
@@ -191,7 +191,7 @@ new Number(\'NaN\'); // Ok'
   ) {}
 }
 
-new Number(\'NaN\'); // TypeError'
+new Number(\'NaN\'); // TypeError',
             );?>
         </div>
       </div>
@@ -220,7 +220,7 @@ new Number(\'NaN\'); // TypeError'
     break;
 }
 echo $result;
-//> Oh no!'
+//> Oh no!',
             );?>
         </div>
       </div>
@@ -233,7 +233,7 @@ echo $result;
   \'8.0\' => "Oh no!",
   8.0 => "This is what I expected",
 };
-//> This is what I expected'
+//> This is what I expected',
             );?>
         </div>
       </div>
@@ -270,7 +270,7 @@ if ($session !== null) {
       $country = $address->country;
     }
   }
-}'
+}',
             );?>
         </div>
       </div>
@@ -279,7 +279,7 @@ if ($session !== null) {
         <div class="php8-compare__label php8-compare__label_new">PHP 8</div>
         <div class="php8-code phpcode">
             <?php highlight_php_trimmed(
-                '$country = $session?->user?->getAddress()?->country;'
+                '$country = $session?->user?->getAddress()?->country;',
             );?>
         </div>
       </div>
@@ -299,7 +299,7 @@ if ($session !== null) {
         <div class="php8-compare__label">PHP 7</div>
         <div class="php8-code phpcode">
             <?php highlight_php_trimmed(
-                '0 == \'foobar\' // true'
+                '0 == \'foobar\' // true',
             );?>
         </div>
       </div>
@@ -308,7 +308,7 @@ if ($session !== null) {
         <div class="php8-compare__label php8-compare__label_new">PHP 8</div>
         <div class="php8-code phpcode">
             <?php highlight_php_trimmed(
-                '0 == \'foobar\' // false'
+                '0 == \'foobar\' // false',
             );?>
         </div>
       </div>
@@ -331,7 +331,7 @@ if ($session !== null) {
             <?php highlight_php_trimmed(
                 'strlen([]); // Warning: strlen() expects parameter 1 to be string, array given
 
-array_chunk([], -1); // Warning: array_chunk(): Size parameter expected to be greater than 0'
+array_chunk([], -1); // Warning: array_chunk(): Size parameter expected to be greater than 0',
             );?>
         </div>
       </div>
@@ -342,7 +342,7 @@ array_chunk([], -1); // Warning: array_chunk(): Size parameter expected to be gr
             <?php highlight_php_trimmed(
                 'strlen([]); // TypeError: strlen(): Argument #1 ($str) must be of type string, array given
 
-array_chunk([], -1); // ValueError: array_chunk(): Argument #2 ($length) must be greater than 0'
+array_chunk([], -1); // ValueError: array_chunk(): Argument #2 ($length) must be greater than 0',
             );?>
         </div>
       </div>

--- a/releases/8.0/ka.php
+++ b/releases/8.0/ka.php
@@ -44,7 +44,7 @@ releases\php80\common_header(
         <div class="php8-compare__label">PHP 7</div>
         <div class="php8-code phpcode">
             <?php highlight_php_trimmed(
-                'htmlspecialchars($string, ENT_COMPAT | ENT_HTML401, \'UTF-8\', false);'
+                'htmlspecialchars($string, ENT_COMPAT | ENT_HTML401, \'UTF-8\', false);',
             );?>
         </div>
 
@@ -55,7 +55,7 @@ releases\php80\common_header(
         <div class="php8-compare__label php8-compare__label_new">PHP 8</div>
         <div class="php8-code phpcode">
             <?php highlight_php_trimmed(
-                'htmlspecialchars($string, double_encode: false);'
+                'htmlspecialchars($string, double_encode: false);',
             );?>
         </div>
       </div>
@@ -84,7 +84,7 @@ releases\php80\common_header(
      * @Route("/api/posts/{id}", methods={"GET"})
      */
     public function get($id) { /* ... */ }
-}'
+}',
             );?>
         </div>
       </div>
@@ -97,7 +97,7 @@ releases\php80\common_header(
 {
     #[Route("/api/posts/{id}", methods: ["GET"])]
     public function get($id) { /* ... */ }
-}'
+}',
             );?>
         </div>
       </div>
@@ -131,7 +131,7 @@ releases\php80\common_header(
     $this->y = $y;
     $this->z = $z;
   }
-}'
+}',
             );?>
         </div>
       </div>
@@ -146,7 +146,7 @@ releases\php80\common_header(
     public float $y = 0.0,
     public float $z = 0.0,
   ) {}
-}'
+}',
             );?>
         </div>
       </div>
@@ -178,7 +178,7 @@ releases\php80\common_header(
   }
 }
 
-new Number(\'NaN\'); // შეცდომები არაა'
+new Number(\'NaN\'); // შეცდომები არაა',
             );?>
         </div>
       </div>
@@ -193,7 +193,7 @@ new Number(\'NaN\'); // შეცდომები არაა'
   ) {}
 }
 
-new Number(\'NaN\'); // TypeError'
+new Number(\'NaN\'); // TypeError',
             );?>
         </div>
       </div>
@@ -223,7 +223,7 @@ new Number(\'NaN\'); // TypeError'
     break;
 }
 echo $result;
-//> ოოო არა!'
+//> ოოო არა!',
             );?>
         </div>
       </div>
@@ -236,7 +236,7 @@ echo $result;
   \'8.0\' => "Oh no!",
   8.0 => "ის, რასაც მე ველოდი",
 };
-//> ის, რასაც მე ველოდი'
+//> ის, რასაც მე ველოდი',
             );?>
         </div>
       </div>
@@ -273,7 +273,7 @@ if ($session !== null) {
       $country = $address->country;
     }
   }
-}'
+}',
             );?>
         </div>
       </div>
@@ -282,7 +282,7 @@ if ($session !== null) {
         <div class="php8-compare__label php8-compare__label_new">PHP 8</div>
         <div class="php8-code phpcode">
             <?php highlight_php_trimmed(
-                '$country = $session?->user?->getAddress()?->country;'
+                '$country = $session?->user?->getAddress()?->country;',
             );?>
         </div>
       </div>
@@ -303,7 +303,7 @@ if ($session !== null) {
         <div class="php8-compare__label">PHP 7</div>
         <div class="php8-code phpcode">
             <?php highlight_php_trimmed(
-                '0 == \'foobar\' // true'
+                '0 == \'foobar\' // true',
             );?>
         </div>
       </div>
@@ -312,7 +312,7 @@ if ($session !== null) {
         <div class="php8-compare__label php8-compare__label_new">PHP 8</div>
         <div class="php8-code phpcode">
             <?php highlight_php_trimmed(
-                '0 == \'foobar\' // false'
+                '0 == \'foobar\' // false',
             );?>
         </div>
       </div>
@@ -335,7 +335,7 @@ if ($session !== null) {
             <?php highlight_php_trimmed(
                 'strlen([]); // Warning: strlen() expects parameter 1 to be string, array given
 
-array_chunk([], -1); // Warning: array_chunk(): Size parameter expected to be greater than 0'
+array_chunk([], -1); // Warning: array_chunk(): Size parameter expected to be greater than 0',
             );?>
         </div>
       </div>
@@ -346,7 +346,7 @@ array_chunk([], -1); // Warning: array_chunk(): Size parameter expected to be gr
             <?php highlight_php_trimmed(
                 'strlen([]); // TypeError: strlen(): Argument #1 ($str) must be of type string, array given
 
-array_chunk([], -1); // ValueError: array_chunk(): Argument #2 ($length) must be greater than 0'
+array_chunk([], -1); // ValueError: array_chunk(): Argument #2 ($length) must be greater than 0',
             );?>
         </div>
       </div>

--- a/releases/8.0/nl.php
+++ b/releases/8.0/nl.php
@@ -44,7 +44,7 @@ releases\php80\common_header(
         <div class="php8-compare__label">PHP 7</div>
         <div class="php8-code phpcode">
             <?php highlight_php_trimmed(
-                'htmlspecialchars($string, ENT_COMPAT | ENT_HTML401, \'UTF-8\', false);'
+                'htmlspecialchars($string, ENT_COMPAT | ENT_HTML401, \'UTF-8\', false);',
             );?>
         </div>
 
@@ -55,7 +55,7 @@ releases\php80\common_header(
         <div class="php8-compare__label php8-compare__label_new">PHP 8</div>
         <div class="php8-code phpcode">
             <?php highlight_php_trimmed(
-                'htmlspecialchars($string, double_encode: false);'
+                'htmlspecialchars($string, double_encode: false);',
             );?>
         </div>
       </div>
@@ -84,7 +84,7 @@ releases\php80\common_header(
      * @Route("/api/posts/{id}", methods={"GET"})
      */
     public function get($id) { /* ... */ }
-}'
+}',
             );?>
         </div>
       </div>
@@ -97,7 +97,7 @@ releases\php80\common_header(
 {
     #[Route("/api/posts/{id}", methods: ["GET"])]
     public function get($id) { /* ... */ }
-}'
+}',
             );?>
         </div>
       </div>
@@ -131,7 +131,7 @@ releases\php80\common_header(
     $this->y = $y;
     $this->z = $z;
   }
-}'
+}',
             );?>
         </div>
       </div>
@@ -146,7 +146,7 @@ releases\php80\common_header(
     public float $y = 0.0,
     public float $z = 0.0,
   ) {}
-}'
+}',
             );?>
         </div>
       </div>
@@ -178,7 +178,7 @@ releases\php80\common_header(
   }
 }
 
-new Number(\'NaN\'); // Ok'
+new Number(\'NaN\'); // Ok',
             );?>
         </div>
       </div>
@@ -193,7 +193,7 @@ new Number(\'NaN\'); // Ok'
   ) {}
 }
 
-new Number(\'NaN\'); // TypeError'
+new Number(\'NaN\'); // TypeError',
             );?>
         </div>
       </div>
@@ -223,7 +223,7 @@ new Number(\'NaN\'); // TypeError'
     break;
 }
 echo $result;
-//> Oh no!'
+//> Oh no!',
             );?>
         </div>
       </div>
@@ -236,7 +236,7 @@ echo $result;
   \'8.0\' => "Oh no!",
   8.0 => "This is what I expected",
 };
-//> This is what I expected'
+//> This is what I expected',
             );?>
         </div>
       </div>
@@ -273,7 +273,7 @@ if ($session !== null) {
       $country = $address->country;
     }
   }
-}'
+}',
             );?>
         </div>
       </div>
@@ -282,7 +282,7 @@ if ($session !== null) {
         <div class="php8-compare__label php8-compare__label_new">PHP 8</div>
         <div class="php8-code phpcode">
             <?php highlight_php_trimmed(
-                '$country = $session?->user?->getAddress()?->country;'
+                '$country = $session?->user?->getAddress()?->country;',
             );?>
         </div>
       </div>
@@ -304,7 +304,7 @@ if ($session !== null) {
         <div class="php8-compare__label">PHP 7</div>
         <div class="php8-code phpcode">
             <?php highlight_php_trimmed(
-                '0 == \'foobar\' // true'
+                '0 == \'foobar\' // true',
             );?>
         </div>
       </div>
@@ -313,7 +313,7 @@ if ($session !== null) {
         <div class="php8-compare__label php8-compare__label_new">PHP 8</div>
         <div class="php8-code phpcode">
             <?php highlight_php_trimmed(
-                '0 == \'foobar\' // false'
+                '0 == \'foobar\' // false',
             );?>
         </div>
       </div>
@@ -336,7 +336,7 @@ if ($session !== null) {
             <?php highlight_php_trimmed(
                 'strlen([]); // Warning: strlen() expects parameter 1 to be string, array given
 
-array_chunk([], -1); // Warning: array_chunk(): Size parameter expected to be greater than 0'
+array_chunk([], -1); // Warning: array_chunk(): Size parameter expected to be greater than 0',
             );?>
         </div>
       </div>
@@ -347,7 +347,7 @@ array_chunk([], -1); // Warning: array_chunk(): Size parameter expected to be gr
             <?php highlight_php_trimmed(
                 'strlen([]); // TypeError: strlen(): Argument #1 ($str) must be of type string, array given
 
-array_chunk([], -1); // ValueError: array_chunk(): Argument #2 ($length) must be greater than 0'
+array_chunk([], -1); // ValueError: array_chunk(): Argument #2 ($length) must be greater than 0',
             );?>
         </div>
       </div>

--- a/releases/8.0/pt_BR.php
+++ b/releases/8.0/pt_BR.php
@@ -45,7 +45,7 @@ releases\php80\common_header(
                     <div class="php8-compare__label">PHP 7</div>
                     <div class="php8-code phpcode">
                         <?php highlight_php_trimmed(
-                            'htmlspecialchars($string, ENT_COMPAT | ENT_HTML401, \'UTF-8\', false);'
+                            'htmlspecialchars($string, ENT_COMPAT | ENT_HTML401, \'UTF-8\', false);',
                         );?>
                     </div>
                 </div>
@@ -54,7 +54,7 @@ releases\php80\common_header(
                     <div class="php8-compare__label php8-compare__label_new">PHP 8</div>
                     <div class="php8-code phpcode">
                         <?php highlight_php_trimmed(
-                            'htmlspecialchars($string, double_encode: false);'
+                            'htmlspecialchars($string, double_encode: false);',
                         );?>
                     </div>
                 </div>
@@ -83,7 +83,7 @@ releases\php80\common_header(
      * @Route("/api/posts/{id}", methods={"GET"})
      */
     public function get($id) { /* ... */ }
-}'
+}',
                         );?>
                     </div>
                 </div>
@@ -96,7 +96,7 @@ releases\php80\common_header(
 {
     #[Route("/api/posts/{id}", methods: ["GET"])]
     public function get($id) { /* ... */ }
-}'
+}',
                         );?>
                     </div>
                 </div>
@@ -130,7 +130,7 @@ releases\php80\common_header(
     $this->y = $y;
     $this->z = $z;
   }
-}'
+}',
                         );?>
                     </div>
                 </div>
@@ -145,7 +145,7 @@ releases\php80\common_header(
     public float $y = 0.0,
     public float $z = 0.0,
   ) {}
-}'
+}',
                         );?>
                     </div>
                 </div>
@@ -177,7 +177,7 @@ releases\php80\common_header(
   }
 }
 
-new Number(\'NaN\'); // Ok'
+new Number(\'NaN\'); // Ok',
                         );?>
                     </div>
                 </div>
@@ -192,7 +192,7 @@ new Number(\'NaN\'); // Ok'
   ) {}
 }
 
-new Number(\'NaN\'); // TypeError'
+new Number(\'NaN\'); // TypeError',
                         );?>
                     </div>
                 </div>
@@ -222,7 +222,7 @@ new Number(\'NaN\'); // TypeError'
     break;
 }
 echo $result;
-//> Oh no!'
+//> Oh no!',
                         );?>
                     </div>
                 </div>
@@ -235,7 +235,7 @@ echo $result;
   \'8.0\' => "Oh no!",
   8.0 => "This is what I expected",
 };
-//> This is what I expected'
+//> This is what I expected',
                         );?>
                     </div>
                 </div>
@@ -273,7 +273,7 @@ if ($session !== null) {
       $country = $address->country;
     }
   }
-}'
+}',
                         );?>
                     </div>
                 </div>
@@ -282,7 +282,7 @@ if ($session !== null) {
                     <div class="php8-compare__label php8-compare__label_new">PHP 8</div>
                     <div class="php8-code phpcode">
                         <?php highlight_php_trimmed(
-                            '$country = $session?->user?->getAddress()?->country;'
+                            '$country = $session?->user?->getAddress()?->country;',
                         );?>
                     </div>
                 </div>
@@ -304,7 +304,7 @@ if ($session !== null) {
                     <div class="php8-compare__label">PHP 7</div>
                     <div class="php8-code phpcode">
                         <?php highlight_php_trimmed(
-                            '0 == \'foobar\' // true'
+                            '0 == \'foobar\' // true',
                         );?>
                     </div>
                 </div>
@@ -313,7 +313,7 @@ if ($session !== null) {
                     <div class="php8-compare__label php8-compare__label_new">PHP 8</div>
                     <div class="php8-code phpcode">
                         <?php highlight_php_trimmed(
-                            '0 == \'foobar\' // false'
+                            '0 == \'foobar\' // false',
                         );?>
                     </div>
                 </div>
@@ -336,7 +336,7 @@ if ($session !== null) {
                         <?php highlight_php_trimmed(
                             'strlen([]); // Warning: strlen() expects parameter 1 to be string, array given
 
-array_chunk([], -1); // Warning: array_chunk(): Size parameter expected to be greater than 0'
+array_chunk([], -1); // Warning: array_chunk(): Size parameter expected to be greater than 0',
                         );?>
                     </div>
                 </div>
@@ -347,7 +347,7 @@ array_chunk([], -1); // Warning: array_chunk(): Size parameter expected to be gr
                         <?php highlight_php_trimmed(
                             'strlen([]); // TypeError: strlen(): Argument #1 ($str) must be of type string, array given
 
-array_chunk([], -1); // ValueError: array_chunk(): Argument #2 ($length) must be greater than 0'
+array_chunk([], -1); // ValueError: array_chunk(): Argument #2 ($length) must be greater than 0',
                         );?>
                     </div>
                 </div>

--- a/releases/8.0/ru.php
+++ b/releases/8.0/ru.php
@@ -44,7 +44,7 @@ releases\php80\common_header(
         <div class="php8-compare__label">PHP 7</div>
         <div class="php8-code phpcode">
             <?php highlight_php_trimmed(
-                'htmlspecialchars($string, ENT_COMPAT | ENT_HTML401, \'UTF-8\', false);'
+                'htmlspecialchars($string, ENT_COMPAT | ENT_HTML401, \'UTF-8\', false);',
             );?>
         </div>
       </div>
@@ -53,7 +53,7 @@ releases\php80\common_header(
         <div class="php8-compare__label php8-compare__label_new">PHP 8</div>
         <div class="php8-code phpcode">
             <?php highlight_php_trimmed(
-                'htmlspecialchars($string, double_encode: false);'
+                'htmlspecialchars($string, double_encode: false);',
             );?>
         </div>
       </div>
@@ -82,7 +82,7 @@ releases\php80\common_header(
      * @Route("/api/posts/{id}", methods={"GET"})
      */
     public function get($id) { /* ... */ }
-}'
+}',
             );?>
         </div>
       </div>
@@ -95,7 +95,7 @@ releases\php80\common_header(
 {
     #[Route("/api/posts/{id}", methods: ["GET"])]
     public function get($id) { /* ... */ }
-}'
+}',
             );?>
         </div>
       </div>
@@ -129,7 +129,7 @@ releases\php80\common_header(
     $this->y = $y;
     $this->z = $z;
   }
-}'
+}',
             );?>
         </div>
       </div>
@@ -144,7 +144,7 @@ releases\php80\common_header(
     public float $y = 0.0,
     public float $z = 0.0,
   ) {}
-}'
+}',
             );?>
         </div>
       </div>
@@ -176,7 +176,7 @@ releases\php80\common_header(
   }
 }
 
-new Number(\'NaN\'); // Нет ошибки'
+new Number(\'NaN\'); // Нет ошибки',
             );?>
         </div>
       </div>
@@ -191,7 +191,7 @@ new Number(\'NaN\'); // Нет ошибки'
   ) {}
 }
 
-new Number(\'NaN\'); // TypeError'
+new Number(\'NaN\'); // TypeError',
             );?>
         </div>
       </div>
@@ -221,7 +221,7 @@ new Number(\'NaN\'); // TypeError'
     break;
 }
 echo $result;
-//> О нет!'
+//> О нет!',
             );?>
         </div>
       </div>
@@ -234,7 +234,7 @@ echo $result;
   \'8.0\' => "О нет!",
   8.0 => "То, что я и ожидал",
 };
-//> То, что я и ожидал'
+//> То, что я и ожидал',
             );?>
         </div>
       </div>
@@ -271,7 +271,7 @@ if ($session !== null) {
       $country = $address->country;
     }
   }
-}'
+}',
             );?>
         </div>
       </div>
@@ -280,7 +280,7 @@ if ($session !== null) {
         <div class="php8-compare__label php8-compare__label_new">PHP 8</div>
         <div class="php8-code phpcode">
             <?php highlight_php_trimmed(
-                '$country = $session?->user?->getAddress()?->country;'
+                '$country = $session?->user?->getAddress()?->country;',
             );?>
         </div>
       </div>
@@ -302,7 +302,7 @@ if ($session !== null) {
         <div class="php8-compare__label">PHP 7</div>
         <div class="php8-code phpcode">
             <?php highlight_php_trimmed(
-                '0 == \'foobar\' // true'
+                '0 == \'foobar\' // true',
             );?>
         </div>
       </div>
@@ -311,7 +311,7 @@ if ($session !== null) {
         <div class="php8-compare__label php8-compare__label_new">PHP 8</div>
         <div class="php8-code phpcode">
             <?php highlight_php_trimmed(
-                '0 == \'foobar\' // false'
+                '0 == \'foobar\' // false',
             );?>
         </div>
       </div>
@@ -334,7 +334,7 @@ if ($session !== null) {
             <?php highlight_php_trimmed(
                 'strlen([]); // Warning: strlen() expects parameter 1 to be string, array given
 
-array_chunk([], -1); // Warning: array_chunk(): Size parameter expected to be greater than 0'
+array_chunk([], -1); // Warning: array_chunk(): Size parameter expected to be greater than 0',
             );?>
         </div>
       </div>
@@ -345,7 +345,7 @@ array_chunk([], -1); // Warning: array_chunk(): Size parameter expected to be gr
             <?php highlight_php_trimmed(
                 'strlen([]); // TypeError: strlen(): Argument #1 ($str) must be of type string, array given
 
-array_chunk([], -1); // ValueError: array_chunk(): Argument #2 ($length) must be greater than 0'
+array_chunk([], -1); // ValueError: array_chunk(): Argument #2 ($length) must be greater than 0',
             );?>
         </div>
       </div>

--- a/releases/8.0/tr.php
+++ b/releases/8.0/tr.php
@@ -41,7 +41,7 @@ releases\php80\common_header(
         <div class="php8-compare__label">PHP 7</div>
         <div class="php8-code phpcode">
             <?php highlight_php_trimmed(
-                'htmlspecialchars($string, ENT_COMPAT | ENT_HTML401, \'UTF-8\', false);'
+                'htmlspecialchars($string, ENT_COMPAT | ENT_HTML401, \'UTF-8\', false);',
             );?>
         </div>
 
@@ -52,7 +52,7 @@ releases\php80\common_header(
         <div class="php8-compare__label php8-compare__label_new">PHP 8</div>
         <div class="php8-code phpcode">
             <?php highlight_php_trimmed(
-                'htmlspecialchars($string, double_encode: false);'
+                'htmlspecialchars($string, double_encode: false);',
             );?>
         </div>
       </div>
@@ -81,7 +81,7 @@ releases\php80\common_header(
      * @Route("/api/posts/{id}", methods={"GET"})
      */
     public function get($id) { /* ... */ }
-}'
+}',
             );?>
         </div>
       </div>
@@ -94,7 +94,7 @@ releases\php80\common_header(
 {
     #[Route("/api/posts/{id}", methods: ["GET"])]
     public function get($id) { /* ... */ }
-}'
+}',
             );?>
         </div>
       </div>
@@ -128,7 +128,7 @@ releases\php80\common_header(
     $this->y = $y;
     $this->z = $z;
   }
-}'
+}',
             );?>
         </div>
       </div>
@@ -143,7 +143,7 @@ releases\php80\common_header(
     public float $y = 0.0,
     public float $z = 0.0,
   ) {}
-}'
+}',
             );?>
         </div>
       </div>
@@ -175,7 +175,7 @@ releases\php80\common_header(
   }
 }
 
-new Number(\'NaN\'); // Ok'
+new Number(\'NaN\'); // Ok',
             );?>
         </div>
       </div>
@@ -190,7 +190,7 @@ new Number(\'NaN\'); // Ok'
   ) {}
 }
 
-new Number(\'NaN\'); // TypeError'
+new Number(\'NaN\'); // TypeError',
             );?>
         </div>
       </div>
@@ -220,7 +220,7 @@ new Number(\'NaN\'); // TypeError'
     break;
 }
 echo $result;
-//> Oh no!'
+//> Oh no!',
             );?>
         </div>
       </div>
@@ -233,7 +233,7 @@ echo $result;
   \'8.0\' => "Oh no!",
   8.0 => "This is what I expected",
 };
-//> This is what I expected'
+//> This is what I expected',
             );?>
         </div>
       </div>
@@ -270,7 +270,7 @@ if ($session !== null) {
       $country = $address->country;
     }
   }
-}'
+}',
             );?>
         </div>
       </div>
@@ -279,7 +279,7 @@ if ($session !== null) {
         <div class="php8-compare__label php8-compare__label_new">PHP 8</div>
         <div class="php8-code phpcode">
             <?php highlight_php_trimmed(
-                '$country = $session?->user?->getAddress()?->country;'
+                '$country = $session?->user?->getAddress()?->country;',
             );?>
         </div>
       </div>
@@ -301,7 +301,7 @@ if ($session !== null) {
         <div class="php8-compare__label">PHP 7</div>
         <div class="php8-code phpcode">
             <?php highlight_php_trimmed(
-                '0 == \'foobar\' // true'
+                '0 == \'foobar\' // true',
             );?>
         </div>
       </div>
@@ -310,7 +310,7 @@ if ($session !== null) {
         <div class="php8-compare__label php8-compare__label_new">PHP 8</div>
         <div class="php8-code phpcode">
             <?php highlight_php_trimmed(
-                '0 == \'foobar\' // false'
+                '0 == \'foobar\' // false',
             );?>
         </div>
       </div>
@@ -333,7 +333,7 @@ if ($session !== null) {
             <?php highlight_php_trimmed(
                 'strlen([]); // Warning: strlen() expects parameter 1 to be string, array given
 
-array_chunk([], -1); // Warning: array_chunk(): Size parameter expected to be greater than 0'
+array_chunk([], -1); // Warning: array_chunk(): Size parameter expected to be greater than 0',
             );?>
         </div>
       </div>
@@ -344,7 +344,7 @@ array_chunk([], -1); // Warning: array_chunk(): Size parameter expected to be gr
             <?php highlight_php_trimmed(
                 'strlen([]); // TypeError: strlen(): Argument #1 ($str) must be of type string, array given
 
-array_chunk([], -1); // ValueError: array_chunk(): Argument #2 ($length) must be greater than 0'
+array_chunk([], -1); // ValueError: array_chunk(): Argument #2 ($length) must be greater than 0',
             );?>
         </div>
       </div>

--- a/releases/8.0/zh.php
+++ b/releases/8.0/zh.php
@@ -41,7 +41,7 @@ releases\php80\common_header(
         <div class="php8-compare__label">PHP 7</div>
         <div class="php8-code phpcode">
             <?php highlight_php_trimmed(
-                'htmlspecialchars($string, ENT_COMPAT | ENT_HTML401, \'UTF-8\', false);'
+                'htmlspecialchars($string, ENT_COMPAT | ENT_HTML401, \'UTF-8\', false);',
             );?>
         </div>
 
@@ -52,7 +52,7 @@ releases\php80\common_header(
         <div class="php8-compare__label php8-compare__label_new">PHP 8</div>
         <div class="php8-code phpcode">
             <?php highlight_php_trimmed(
-                'htmlspecialchars($string, double_encode: false);'
+                'htmlspecialchars($string, double_encode: false);',
             );?>
         </div>
       </div>
@@ -81,7 +81,7 @@ releases\php80\common_header(
      * @Route("/api/posts/{id}", methods={"GET"})
      */
     public function get($id) { /* ... */ }
-}'
+}',
             );?>
         </div>
       </div>
@@ -94,7 +94,7 @@ releases\php80\common_header(
 {
     #[Route("/api/posts/{id}", methods: ["GET"])]
     public function get($id) { /* ... */ }
-}'
+}',
             );?>
         </div>
       </div>
@@ -127,7 +127,7 @@ releases\php80\common_header(
     $this->y = $y;
     $this->z = $z;
   }
-}'
+}',
             );?>
         </div>
       </div>
@@ -142,7 +142,7 @@ releases\php80\common_header(
     public float $y = 0.0,
     public float $z = 0.0,
   ) {}
-}'
+}',
             );?>
         </div>
       </div>
@@ -172,7 +172,7 @@ releases\php80\common_header(
     $this->number = $number;
   }
 }
-new Number(\'NaN\'); // Ok'
+new Number(\'NaN\'); // Ok',
             );?>
         </div>
       </div>
@@ -186,7 +186,7 @@ new Number(\'NaN\'); // Ok'
     private int|float $number
   ) {}
 }
-new Number(\'NaN\'); // TypeError'
+new Number(\'NaN\'); // TypeError',
             );?>
         </div>
       </div>
@@ -216,7 +216,7 @@ new Number(\'NaN\'); // TypeError'
     break;
 }
 echo $result;
-//> Oh no!'
+//> Oh no!',
             );?>
         </div>
       </div>
@@ -229,7 +229,7 @@ echo $result;
   \'8.0\' => "Oh no!",
   8.0 => "This is what I expected",
 };
-//> This is what I expected'
+//> This is what I expected',
             );?>
         </div>
       </div>
@@ -264,7 +264,7 @@ if ($session !== null) {
       $country = $address->country;
     }
   }
-}'
+}',
             );?>
         </div>
       </div>
@@ -273,7 +273,7 @@ if ($session !== null) {
         <div class="php8-compare__label php8-compare__label_new">PHP 8</div>
         <div class="php8-code phpcode">
             <?php highlight_php_trimmed(
-                '$country = $session?->user?->getAddress()?->country;'
+                '$country = $session?->user?->getAddress()?->country;',
             );?>
         </div>
       </div>
@@ -294,7 +294,7 @@ if ($session !== null) {
         <div class="php8-compare__label">PHP 7</div>
         <div class="php8-code phpcode">
             <?php highlight_php_trimmed(
-                '0 == \'foobar\' // true'
+                '0 == \'foobar\' // true',
             );?>
         </div>
       </div>
@@ -303,7 +303,7 @@ if ($session !== null) {
         <div class="php8-compare__label php8-compare__label_new">PHP 8</div>
         <div class="php8-code phpcode">
             <?php highlight_php_trimmed(
-                '0 == \'foobar\' // false'
+                '0 == \'foobar\' // false',
             );?>
         </div>
       </div>
@@ -325,7 +325,7 @@ if ($session !== null) {
         <div class="php8-code phpcode">
             <?php highlight_php_trimmed(
                 'strlen([]); // Warning: strlen() expects parameter 1 to be string, array given
-array_chunk([], -1); // Warning: array_chunk(): Size parameter expected to be greater than 0'
+array_chunk([], -1); // Warning: array_chunk(): Size parameter expected to be greater than 0',
             );?>
         </div>
       </div>
@@ -335,7 +335,7 @@ array_chunk([], -1); // Warning: array_chunk(): Size parameter expected to be gr
         <div class="php8-code phpcode">
             <?php highlight_php_trimmed(
                 'strlen([]); // TypeError: strlen(): Argument #1 ($str) must be of type string, array given
-array_chunk([], -1); // ValueError: array_chunk(): Argument #2 ($length) must be greater than 0'
+array_chunk([], -1); // ValueError: array_chunk(): Argument #2 ($length) must be greater than 0',
             );?>
         </div>
       </div>

--- a/releases/8.2/release.inc
+++ b/releases/8.2/release.inc
@@ -44,7 +44,7 @@ common_header(message('common_header', $lang));
                 <a class="php8-rfc"
                    href="/manual/<?= $lang ?>/language.oop5.basic.php#language.oop5.basic.class.readonly"><?= message(
                         'documentation',
-                        $lang
+                        $lang,
                     ) ?></a>
             </h2>
             <div class="php8-compare__main">
@@ -102,7 +102,7 @@ PHP
                 <a class="php8-rfc"
                    href="/manual/<?= $lang ?>/migration82.new-features.php#migration82.new-features.core.type-system"><?= message(
                         'documentation',
-                        $lang
+                        $lang,
                     ) ?></a>
             </h2>
             <div class="php8-compare__main">
@@ -252,7 +252,7 @@ PHP
                 <a class="php8-rfc"
                    href="/manual/<?= $lang ?>/migration82.new-features.php#migration82.new-features.core.constant-in-traits"><?= message(
                         'documentation',
-                        $lang
+                        $lang,
                     ) ?></a>
             </h2>
             <div class="php8-compare__main">
@@ -290,7 +290,7 @@ PHP
                 <a class="php8-rfc"
                    href="/manual/<?= $lang ?>/migration82.deprecated.php#migration82.deprecated.core.dynamic-properties"><?= message(
                         'documentation',
-                        $lang
+                        $lang,
                     ) ?></a>
             </h2>
             <div class="php8-compare__main">

--- a/releases/index.php
+++ b/releases/index.php
@@ -106,7 +106,7 @@ foreach ($OLDRELEASES as $major => $a) {
             $release["announcement"] ?? false,
             $release["source"] ?? [],
             $release["windows"] ?? [],
-            $release["museum"] ?? ($i >= 3)
+            $release["museum"] ?? ($i >= 3),
         );
     }
 }
@@ -163,7 +163,7 @@ site_footer(['sidebar' =>
     </ul>
   </div>
 </div>
-']);
+', ]);
 
 function recentEOLBranchesHTML(): string {
     $eol = [];

--- a/results.php
+++ b/results.php
@@ -10,7 +10,7 @@ site_header(
         'noindex',
         'current' => 'help',
         'layout_span' => 12,
-    ]
+    ],
 );
 
 echo '<h1>Search results</h1>';

--- a/search.php
+++ b/search.php
@@ -49,7 +49,7 @@ else {
         "rel" => "search",
         "type" => "application/opensearchdescription+xml",
         "href" => $MYSITE . "phpnetimprovedsearch.src",
-        "title" => "Add PHP.net search"
+        "title" => "Add PHP.net search",
     ];
     site_header("Search", ["link" => [$link], "current" => "help"]);
 

--- a/sites.php
+++ b/sites.php
@@ -223,5 +223,5 @@ SIDEBAR_DATA;
 
 // Print the common footer.
 site_footer([
-    'sidebar' => $SIDEBAR
+    'sidebar' => $SIDEBAR,
 ]);

--- a/src/autoload.php
+++ b/src/autoload.php
@@ -15,7 +15,7 @@ spl_autoload_register(static function (string $class): void {
 
     $relativeClass = substr(
         $class,
-        $length
+        $length,
     );
 
     $file = $directory . str_replace('\\', '/', $relativeClass) . '.php';

--- a/submit-event.php
+++ b/submit-event.php
@@ -12,7 +12,7 @@ $process = [] !== $_POST;
 // Avoid E_NOTICE errors on incoming vars if not set
 $vars = [
     'sday', 'smonth', 'syear', 'eday',
-    'emonth', 'eyear', 'recur', 'recur_day'
+    'emonth', 'eyear', 'recur', 'recur_day',
 ];
 foreach ($vars as $varname) {
     if (empty($_POST[$varname])) {
@@ -20,7 +20,7 @@ foreach ($vars as $varname) {
     }
 }
 $vars = [
-    'type', 'country', 'category', 'email', 'url', 'ldesc', 'sdesc'
+    'type', 'country', 'category', 'email', 'url', 'ldesc', 'sdesc',
 ];
 foreach ($vars as $varname) {
     if (!isset($_POST[$varname])) {
@@ -166,7 +166,7 @@ $re = [
     4 => 'Fourth',
     -1 => 'Last',
     -2 => '2nd Last',
-    -3 => '3rd Last'
+    -3 => '3rd Last',
 ];
 
 // If we have data, display preview

--- a/support.php
+++ b/support.php
@@ -23,7 +23,7 @@ site_header(
     'Getting Help',
     [
         'current' => 'help',
-    ]
+    ],
 );
 ?>
 


### PR DESCRIPTION
This pull request

- [x] enables the `trailing_comma_in_multiline` fixer
- [x] runs `make coding-standards`

Follows #559.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.40.2/doc/rules/control_structure/trailing_comma_in_multiline.rst.