### PR TITLE
Fix: Replace weird comment with DocBlock

### DIFF
--- a/releases/index.php
+++ b/releases/index.php
@@ -180,10 +180,13 @@ function recentEOLBranchesHTML(): string {
     return implode('', array_slice($eol, 0, 2));
 }
 
+/**
+ * @param bool|array $announcement
+ */
 function mk_rel(int $major,
                 string $ver,
                 string $date,
-                /* bool | array */ $announcement,
+                $announcement,
                 array $source,
                 array $windows,
                 bool $museum): void {


### PR DESCRIPTION
This pull request

- [x] replaces a weird comment with a DocBlock

Follows https://github.com/php/web-php/pull/648#discussion_r918890489.