### PR TITLE
Enhancement: Enable `switch_case_space` fixer

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -27,6 +27,7 @@ $config
         'ordered_class_elements' => true,
         'single_space_after_construct' => true,
         'strict_param' => true,
+        'switch_case_space' => true,
         'trim_array_spaces' => true,
         'visibility_required' => true,
         'whitespace_after_comma_in_array' => true,

--- a/error.php
+++ b/error.php
@@ -122,9 +122,9 @@ $URI = rtrim($URI, '/');
 // Some nice URLs for getting something for download
 if (preg_match("!^get/([^/]+)$!", $URI, $what)) {
     switch ($what[1]) {
-        case "php"           : $URI = "downloads"; break;
-        case "docs"          : // intentional
-        case "documentation" : $URI = "download-docs"; break;
+        case "php": $URI = "downloads"; break;
+        case "docs": // intentional
+        case "documentation": $URI = "download-docs"; break;
     }
 }
 

--- a/error.php
+++ b/error.php
@@ -122,9 +122,13 @@ $URI = rtrim($URI, '/');
 // Some nice URLs for getting something for download
 if (preg_match("!^get/([^/]+)$!", $URI, $what)) {
     switch ($what[1]) {
-        case "php": $URI = "downloads"; break;
+        case "php":
+            $URI = "downloads";
+            break;
         case "docs": // intentional
-        case "documentation": $URI = "download-docs"; break;
+        case "documentation":
+            $URI = "download-docs";
+            break;
     }
 }
 

--- a/include/langchooser.inc
+++ b/include/langchooser.inc
@@ -122,10 +122,10 @@ function language_choose_code()
 
         // Translation table for accept-language codes and phpdoc codes
         switch ($langdata[0]) {
-            case "pt-br" : $langdata[0] = 'pt_br'; break;
-            case "zh-cn" : $langdata[0] = 'zh'; break;
-            case "zh-hk" : $langdata[0] = 'hk'; break;
-            case "zh-tw" : $langdata[0] = 'tw'; break;
+            case "pt-br": $langdata[0] = 'pt_br'; break;
+            case "zh-cn": $langdata[0] = 'zh'; break;
+            case "zh-hk": $langdata[0] = 'hk'; break;
+            case "zh-tw": $langdata[0] = 'tw'; break;
         }
 
         // We do not support flavors of languages (except the ones above)

--- a/include/langchooser.inc
+++ b/include/langchooser.inc
@@ -122,10 +122,18 @@ function language_choose_code()
 
         // Translation table for accept-language codes and phpdoc codes
         switch ($langdata[0]) {
-            case "pt-br": $langdata[0] = 'pt_br'; break;
-            case "zh-cn": $langdata[0] = 'zh'; break;
-            case "zh-hk": $langdata[0] = 'hk'; break;
-            case "zh-tw": $langdata[0] = 'tw'; break;
+            case "pt-br":
+                $langdata[0] = 'pt_br';
+                break;
+            case "zh-cn":
+                $langdata[0] = 'zh';
+                break;
+            case "zh-hk":
+                $langdata[0] = 'hk';
+                break;
+            case "zh-tw":
+                $langdata[0] = 'tw';
+                break;
         }
 
         // We do not support flavors of languages (except the ones above)


### PR DESCRIPTION
This pull request

- [x] enables the `switch_case_space` fixer
- [x] runs `make coding-standards`

Follows #559.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.4.0/doc/rules/control_structure/switch_case_space.rst.