### PR TITLE
Enhancement: Enable and configure `header_comment` fixer

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -1,5 +1,11 @@
 <?php
 
+$header = <<<TXT
+Any ideas?
+
+@see https://github.com/php/web-php
+TXT;
+
 $finder = PhpCsFixer\Finder::create()->in(__DIR__);
 
 $config = new PhpCsFixer\Config();
@@ -20,6 +26,10 @@ $config
     ->setRules([
         'array_indentation' => true,
         'constant_case' => true,
+        'header_comment' => [
+            'comment_type' => 'PHPDoc',
+            'header' => $header,
+        ],
         'indentation_type' => true,
         'line_ending' => true,
         'no_extra_blank_lines' => true,

--- a/archive/index.php
+++ b/archive/index.php
@@ -1,4 +1,11 @@
 <?php
+
+/**
+ * Any ideas?
+ *
+ * @see https://github.com/php/web-php
+ */
+
 include_once __DIR__ . '/../include/prepend.inc';
 $i = 0;
 do {

--- a/autoload.php
+++ b/autoload.php
@@ -1,8 +1,11 @@
 <?php
 
 /**
- * @see https://github.com/php-fig/fig-standards/blob/a1a0674a742c9d07c5dd450209fb33b115ee7b40/accepted/PSR-4-autoloader-examples.md#closure-example
+ * Any ideas?
+ *
+ * @see https://github.com/php/web-php
  */
+
 spl_autoload_register(static function (string $class): void {
     $prefix = 'phpweb\\';
     $directory = __DIR__ . '/src/';

--- a/backend/index.php
+++ b/backend/index.php
@@ -1,5 +1,11 @@
 <?php
-// Simulate a /backend shortcut call (which will lead to a manual page)
+
+/**
+ * Any ideas?
+ *
+ * @see https://github.com/php/web-php
+ */
+
 $_SERVER['REQUEST_URI'] = '/backend';
 include_once __DIR__ . '/../include/prepend.inc';
 include_once __DIR__ . '/../error.php';

--- a/bin/index.php
+++ b/bin/index.php
@@ -1,5 +1,11 @@
 <?php
-// Simulate a /bin shortcut call (which will lead to a manual page)
+
+/**
+ * Any ideas?
+ *
+ * @see https://github.com/php/web-php
+ */
+
 $_SERVER['REQUEST_URI'] = '/bin';
 include_once __DIR__ . '/../include/prepend.inc';
 include_once __DIR__ . '/../error.php';

--- a/cached.php
+++ b/cached.php
@@ -1,15 +1,11 @@
 <?php
-/*
-  Yes, we know this can be used to view the source for any file
-  in the docroot directory. This is intentional and not an LFI
-  vulnerability. The source code for everything in the docroot
-  is publicly available at
 
-    https://github.com/php/web-php
+/**
+ * Any ideas?
+ *
+ * @see https://github.com/php/web-php
+ */
 
-  so there is no vulnerability here. You can't use this to view
-  anything that is private.
-*/
 $_SERVER['BASE_PAGE'] = 'cached.php';
 include_once 'include/prepend.inc';
 

--- a/conferences/index.php
+++ b/conferences/index.php
@@ -1,4 +1,11 @@
 <?php
+
+/**
+ * Any ideas?
+ *
+ * @see https://github.com/php/web-php
+ */
+
 $_SERVER['BASE_PAGE'] = 'conferences/index.php';
 include_once __DIR__ . '/../include/prepend.inc';
 include_once __DIR__ . '/../include/pregen-news.inc';

--- a/credits.php
+++ b/credits.php
@@ -1,4 +1,11 @@
 <?php
+
+/**
+ * Any ideas?
+ *
+ * @see https://github.com/php/web-php
+ */
+
 $_SERVER['BASE_PAGE'] = 'credits.php';
 include_once __DIR__ . '/include/prepend.inc';
 

--- a/error.php
+++ b/error.php
@@ -1,13 +1,10 @@
 <?php
-/*
 
- This script handles all 401, 403 and 404 error redirects,
- and some directory requests (like /images). Uses the
- preferred language setting and the REQUEST_URI to guess what
- page should be displayed. In case there is no page that can
- be displayed, the user is redirected to a search page.
-
-*/
+/**
+ * Any ideas?
+ *
+ * @see https://github.com/php/web-php
+ */
 
 // Ensure that our environment is set up
 include_once __DIR__ . '/include/prepend.inc';

--- a/images/elephpants.php
+++ b/images/elephpants.php
@@ -1,4 +1,11 @@
 <?php
+
+/**
+ * Any ideas?
+ *
+ * @see https://github.com/php/web-php
+ */
+
 include_once __DIR__ . '/../include/prepend.inc';
 
 $now = $_SERVER["REQUEST_TIME"];

--- a/images/index.php
+++ b/images/index.php
@@ -1,5 +1,11 @@
 <?php
-// Simulate a /images shortcut call (which will lead to a manual page)
+
+/**
+ * Any ideas?
+ *
+ * @see https://github.com/php/web-php
+ */
+
 $_SERVER['REQUEST_URI'] = '/images';
 include_once __DIR__ . '/../include/prepend.inc';
 include_once __DIR__ . '/../error.php';

--- a/images/logo.php
+++ b/images/logo.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * Any ideas?
+ *
+ * @see https://github.com/php/web-php
+ */
+
 $refresh = isset($_GET['refresh']);
 
 // Be 100% sure the timezone is set

--- a/include/branches.inc
+++ b/include/branches.inc
@@ -1,4 +1,11 @@
 <?php
+
+/**
+ * Any ideas?
+ *
+ * @see https://github.com/php/web-php
+ */
+
 include_once __DIR__ . '/releases.inc';
 include_once __DIR__ . '/version.inc';
 

--- a/include/changelogs.inc
+++ b/include/changelogs.inc
@@ -1,4 +1,11 @@
 <?php
+
+/**
+ * Any ideas?
+ *
+ * @see https://github.com/php/web-php
+ */
+
 function bugfix($number) {
     echo "Fixed bug "; bugl($number);
 }

--- a/include/countries.inc
+++ b/include/countries.inc
@@ -1,4 +1,11 @@
 <?php
+
+/**
+ * Any ideas?
+ *
+ * @see https://github.com/php/web-php
+ */
+
 return array(
     'AFG' => 'Afghanistan',
     'ALB' => 'Albania',

--- a/include/do-download.inc
+++ b/include/do-download.inc
@@ -1,10 +1,10 @@
 <?php
 
-/*
-   This code redirects the user to the exact file to
-   download, and logs the download if it's something
-   we would like to know about (PHP binary or source).
-*/
+/**
+ * Any ideas?
+ *
+ * @see https://github.com/php/web-php
+ */
 
 function get_actual_download_file($file)
 {

--- a/include/email-validation.inc
+++ b/include/email-validation.inc
@@ -1,6 +1,11 @@
 <?php
 
-// Try to remove anti-SPAM bits
+/**
+ * Any ideas?
+ *
+ * @see https://github.com/php/web-php
+ */
+
 function clean_AntiSPAM($email)
 {
     $remove_spam = "![-_]?(NO|I[-_]?HATE|DELETE|REMOVE)[-_]?(THIS)?(ME|SPAM)?[-_]?!i";

--- a/include/errors.inc
+++ b/include/errors.inc
@@ -1,9 +1,10 @@
 <?php
-/*
-  This script provides functions to print out
-  error messages for users in case something is
-  not available.
-*/
+
+/**
+ * Any ideas?
+ *
+ * @see https://github.com/php/web-php
+ */
 
 // A 'good looking' 404 error message page
 function error_404()

--- a/include/historical_mirrors.inc
+++ b/include/historical_mirrors.inc
@@ -1,4 +1,11 @@
 <?php
+
+/**
+ * Any ideas?
+ *
+ * @see https://github.com/php/web-php
+ */
+
 $historical_mirrors = array(
     array("ARG", "ar2.php.net", "XMundo Hosting Solutions", "http://www.xmundo.net"),
     array("ARM", "am1.php.net", "ARMINCO Global Telecommunications", "http://www.arminco.com/"),

--- a/include/index.php
+++ b/include/index.php
@@ -1,5 +1,11 @@
 <?php
-// Simulate a /include shortcut call (which will lead to a manual page)
+
+/**
+ * Any ideas?
+ *
+ * @see https://github.com/php/web-php
+ */
+
 $_SERVER['REQUEST_URI'] = '/include';
 include_once __DIR__ . '/prepend.inc';
 include_once __DIR__ . '/../error.php';

--- a/include/ip-to-country.inc
+++ b/include/ip-to-country.inc
@@ -1,4 +1,10 @@
-<?php // -*- C++ -*-
+<?php
+
+/**
+ * Any ideas?
+ *
+ * @see https://github.com/php/web-php
+ */
 
 /*
 

--- a/include/langchooser.inc
+++ b/include/langchooser.inc
@@ -1,4 +1,10 @@
-<?php // -*- C++ -*-
+<?php
+
+/**
+ * Any ideas?
+ *
+ * @see https://github.com/php/web-php
+ */
 
 /*
 

--- a/include/languages.inc
+++ b/include/languages.inc
@@ -1,4 +1,10 @@
-<?php // -*- C++ -*-
+<?php
+
+/**
+ * Any ideas?
+ *
+ * @see https://github.com/php/web-php
+ */
 
 /*
  This is a list of all manual languages hosted

--- a/include/manual-lookup.inc
+++ b/include/manual-lookup.inc
@@ -1,4 +1,10 @@
-<?php // -*- C++ -*-
+<?php
+
+/**
+ * Any ideas?
+ *
+ * @see https://github.com/php/web-php
+ */
 
 // We need this for error reporting
 include_once __DIR__ . '/errors.inc';

--- a/include/posttohost.inc
+++ b/include/posttohost.inc
@@ -1,10 +1,10 @@
 <?php
 
-/*
- This code is used to post data to the central server which
- can store the data in database and/or mail notices or requests
- to PHP.net stuff and servers
-*/
+/**
+ * Any ideas?
+ *
+ * @see https://github.com/php/web-php
+ */
 
 function posttohost($url, $data)
 {

--- a/include/releases.inc
+++ b/include/releases.inc
@@ -1,4 +1,11 @@
 <?php
+
+/**
+ * Any ideas?
+ *
+ * @see https://github.com/php/web-php
+ */
+
 $OLDRELEASES = array (
     8 =>
     array (

--- a/include/results.inc
+++ b/include/results.inc
@@ -1,4 +1,11 @@
 <?php
+
+/**
+ * Any ideas?
+ *
+ * @see https://github.com/php/web-php
+ */
+
 function search_results($res, $q, $profile='all', $per_page=10, $s=0, $l='en', $show_title=true, $show_foot=true, $show_attrib=true) {
     $start_result = $s;
     $end_result = $s + $res['ResultSet']['totalResultsReturned'] -1;

--- a/include/shared-manual.inc
+++ b/include/shared-manual.inc
@@ -1,4 +1,10 @@
-<?php // -*- C++ -*-
+<?php
+
+/**
+ * Any ideas?
+ *
+ * @see https://github.com/php/web-php
+ */
 
 /*
 

--- a/include/site.inc
+++ b/include/site.inc
@@ -1,4 +1,10 @@
-<?php // -*- C++ -*-
+<?php
+
+/**
+ * Any ideas?
+ *
+ * @see https://github.com/php/web-php
+ */
 
 // Define some constants, and $MIRRORS array
 // Mirror type constants

--- a/include/version.inc
+++ b/include/version.inc
@@ -1,4 +1,11 @@
-<?php // vim: et
+<?php
+
+/**
+ * Any ideas?
+ *
+ * @see https://github.com/php/web-php
+ */
+
 /* The format is:
  * array(
  *     "major release number" => array(

--- a/index.php
+++ b/index.php
@@ -1,4 +1,11 @@
-<?php // vim: et
+<?php
+
+/**
+ * Any ideas?
+ *
+ * @see https://github.com/php/web-php
+ */
+
 (function ($uri): void {
     // Special redirect cases not able to be captured in error.php
     $shortcuts = [

--- a/js/search-index.php
+++ b/js/search-index.php
@@ -1,4 +1,11 @@
 <?php
+
+/**
+ * Any ideas?
+ *
+ * @see https://github.com/php/web-php
+ */
+
 $_GET["lang"] = "en";
 if (!isset($_GET["lang"])) {
     header("Location: http://php.net");

--- a/manual-lookup.php
+++ b/manual-lookup.php
@@ -1,4 +1,11 @@
 <?php
+
+/**
+ * Any ideas?
+ *
+ * @see https://github.com/php/web-php
+ */
+
 $_SERVER['BASE_PAGE'] = 'manual-lookup.php';
 include __DIR__ . '/include/prepend.inc';
 include __DIR__ . '/include/manual-lookup.inc';

--- a/manual/change.php
+++ b/manual/change.php
@@ -1,4 +1,11 @@
 <?php
+
+/**
+ * Any ideas?
+ *
+ * @see https://github.com/php/web-php
+ */
+
 include_once __DIR__ . '/../include/prepend.inc';
 
 $page = isset($_GET['page']) ? htmlspecialchars($_GET['page'], ENT_QUOTES, 'UTF-8') : '';

--- a/manual/index.php
+++ b/manual/index.php
@@ -1,3 +1,10 @@
 <?php
+
+/**
+ * Any ideas?
+ *
+ * @see https://github.com/php/web-php
+ */
+
 include_once __DIR__ . '/../include/prepend.inc';
 mirror_redirect("/manual/$LANG/index.php");

--- a/manual/spam_challenge.php
+++ b/manual/spam_challenge.php
@@ -1,5 +1,10 @@
 <?php
-// simple and stupid SPAM protection (using little challenges)
+
+/**
+ * Any ideas?
+ *
+ * @see https://github.com/php/web-php
+ */
 
 const NUMS = array('zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine');
 

--- a/mirror-info.php
+++ b/mirror-info.php
@@ -1,5 +1,11 @@
 <?php
-// Define $MYSITE and $LAST_UPDATED variables
+
+/**
+ * Any ideas?
+ *
+ * @see https://github.com/php/web-php
+ */
+
 include_once __DIR__ . '/include/prepend.inc';
 
 // Define release_get_latest() function.

--- a/mirrors.php
+++ b/mirrors.php
@@ -1,4 +1,11 @@
 <?php
+
+/**
+ * Any ideas?
+ *
+ * @see https://github.com/php/web-php
+ */
+
 include_once __DIR__ . '/include/prepend.inc';
 
 header("HTTP/1.1 301 Moved Permanently");

--- a/mod.php
+++ b/mod.php
@@ -1,9 +1,10 @@
 <?php
-/*
- This page supports the PHP.net automoderation system
- with enabling users to confirm their emails via the web.
- This script only need to run on the primary php.net box.
-*/
+
+/**
+ * Any ideas?
+ *
+ * @see https://github.com/php/web-php
+ */
 
 $_SERVER['BASE_PAGE'] = 'mod.php';
 include_once __DIR__ . '/include/prepend.inc';

--- a/pear/index.php
+++ b/pear/index.php
@@ -1,5 +1,11 @@
 <?php
-// Simulate a /pear shortcut call (which will lead to a manual page)
+
+/**
+ * Any ideas?
+ *
+ * @see https://github.com/php/web-php
+ */
+
 $_SERVER['REQUEST_URI'] = '/pear';
 include_once __DIR__ . '/../include/prepend.inc';
 include_once __DIR__ . '/../error.php';

--- a/releases/8.0/common.php
+++ b/releases/8.0/common.php
@@ -1,5 +1,11 @@
 <?php declare(strict_types=1);
 
+/**
+ * Any ideas?
+ *
+ * @see https://github.com/php/web-php
+ */
+
 namespace releases\php80;
 include_once __DIR__ . '/../../include/prepend.inc';
 

--- a/releases/8.0/index.php
+++ b/releases/8.0/index.php
@@ -1,4 +1,11 @@
 <?php
+
+/**
+ * Any ideas?
+ *
+ * @see https://github.com/php/web-php
+ */
+
  $_SERVER['BASE_PAGE'] = 'releases/8.0/index.php';
 include __DIR__ . '/../../include/site.inc';
 

--- a/releases/8.1/common.php
+++ b/releases/8.1/common.php
@@ -1,5 +1,11 @@
 <?php declare(strict_types=1);
 
+/**
+ * Any ideas?
+ *
+ * @see https://github.com/php/web-php
+ */
+
 namespace releases\php81;
 
 include_once __DIR__ . '/../../include/prepend.inc';

--- a/releases/8.1/de.php
+++ b/releases/8.1/de.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * Any ideas?
+ *
+ * @see https://github.com/php/web-php
+ */
+
 $lang = 'de';
 
 include_once __DIR__ . '/release.inc';

--- a/releases/8.1/en.php
+++ b/releases/8.1/en.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * Any ideas?
+ *
+ * @see https://github.com/php/web-php
+ */
+
 $lang = 'en';
 
 include_once __DIR__ . '/release.inc';

--- a/releases/8.1/es.php
+++ b/releases/8.1/es.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * Any ideas?
+ *
+ * @see https://github.com/php/web-php
+ */
+
 $lang = 'es';
 
 include_once __DIR__ . '/release.inc';

--- a/releases/8.1/index.php
+++ b/releases/8.1/index.php
@@ -1,4 +1,11 @@
 <?php
+
+/**
+ * Any ideas?
+ *
+ * @see https://github.com/php/web-php
+ */
+
  $_SERVER['BASE_PAGE'] = 'releases/8.1/index.php';
 include __DIR__ . '/../../include/site.inc';
 

--- a/releases/8.1/ja.php
+++ b/releases/8.1/ja.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * Any ideas?
+ *
+ * @see https://github.com/php/web-php
+ */
+
 $lang = 'ja';
 
 include_once __DIR__ . '/release.inc';

--- a/releases/8.1/ka.php
+++ b/releases/8.1/ka.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * Any ideas?
+ *
+ * @see https://github.com/php/web-php
+ */
+
 $lang = 'ka';
 
 include_once __DIR__ . '/release.inc';

--- a/releases/8.1/languages/de.php
+++ b/releases/8.1/languages/de.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * Any ideas?
+ *
+ * @see https://github.com/php/web-php
+ */
+
 return [
     'common_header' => 'PHP 8.1 ist ein Minor-Update der Sprache PHP und beinhaltet viele neue Features und Verbesserungen. Unter anderem Enumerations, Readonly-Properties, First-Class Callable Syntax, Fibers, Intersection-Types, Performance-Optimierungen.',
     'main_title' => 'Released!',

--- a/releases/8.1/languages/en.php
+++ b/releases/8.1/languages/en.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * Any ideas?
+ *
+ * @see https://github.com/php/web-php
+ */
+
 return [
     'common_header' => 'PHP 8.1 is a major update of the PHP language. Enums, readonly properties, first-class callable syntax, fibers, intersection types, performance improvements and more.',
     'main_title' => 'Released!',

--- a/releases/8.1/languages/es.php
+++ b/releases/8.1/languages/es.php
@@ -1,7 +1,9 @@
 <?php
 
 /**
- * En-revision: 20b1bbed844a4609f3400ef0cd4e6be6fea323af
+ * Any ideas?
+ *
+ * @see https://github.com/php/web-php
  */
 
 return [

--- a/releases/8.1/languages/ja.php
+++ b/releases/8.1/languages/ja.php
@@ -1,7 +1,9 @@
 <?php
 
 /**
- * En-revision: 213a4fafd56620a4efebddaa5bf246afb0758782
+ * Any ideas?
+ *
+ * @see https://github.com/php/web-php
  */
 
 return [

--- a/releases/8.1/languages/ka.php
+++ b/releases/8.1/languages/ka.php
@@ -1,7 +1,9 @@
 <?php
 
 /**
- * En-revision: 20b1bbed844a4609f3400ef0cd4e6be6fea323af
+ * Any ideas?
+ *
+ * @see https://github.com/php/web-php
  */
 
 return [

--- a/releases/8.1/languages/pt_BR.php
+++ b/releases/8.1/languages/pt_BR.php
@@ -1,7 +1,9 @@
 <?php
 
 /**
- * En-revision: 213a4fafd56620a4efebddaa5bf246afb0758782
+ * Any ideas?
+ *
+ * @see https://github.com/php/web-php
  */
 
 return [

--- a/releases/8.1/languages/ru.php
+++ b/releases/8.1/languages/ru.php
@@ -1,7 +1,9 @@
 <?php
 
 /**
- * En-revision: 20b1bbed844a4609f3400ef0cd4e6be6fea323af
+ * Any ideas?
+ *
+ * @see https://github.com/php/web-php
  */
 
 return [

--- a/releases/8.1/languages/zh.php
+++ b/releases/8.1/languages/zh.php
@@ -1,7 +1,9 @@
 <?php
 
 /**
- * En-revision: 213a4fafd56620a4efebddaa5bf246afb0758782
+ * Any ideas?
+ *
+ * @see https://github.com/php/web-php
  */
 
 return [

--- a/releases/8.1/pt_BR.php
+++ b/releases/8.1/pt_BR.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * Any ideas?
+ *
+ * @see https://github.com/php/web-php
+ */
+
 $lang = 'pt_BR';
 
 include_once __DIR__ . '/release.inc';

--- a/releases/8.1/ru.php
+++ b/releases/8.1/ru.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * Any ideas?
+ *
+ * @see https://github.com/php/web-php
+ */
+
 $lang = 'ru';
 
 include_once __DIR__ . '/release.inc';

--- a/releases/8.1/zh.php
+++ b/releases/8.1/zh.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * Any ideas?
+ *
+ * @see https://github.com/php/web-php
+ */
+
 $lang = 'zh';
 
 include_once __DIR__ . '/release.inc';

--- a/releases/active.php
+++ b/releases/active.php
@@ -1,4 +1,11 @@
 <?php
+
+/**
+ * Any ideas?
+ *
+ * @see https://github.com/php/web-php
+ */
+
 $_SERVER['BASE_PAGE'] = 'releases/active.php';
 
 include_once __DIR__ . '/../include/prepend.inc';

--- a/releases/feed.php
+++ b/releases/feed.php
@@ -1,4 +1,11 @@
 <?php
+
+/**
+ * Any ideas?
+ *
+ * @see https://github.com/php/web-php
+ */
+
 header("Content-Type: application/atom+xml");
 
 include __DIR__ . "/../include/version.inc";

--- a/releases/index.php
+++ b/releases/index.php
@@ -1,4 +1,11 @@
 <?php
+
+/**
+ * Any ideas?
+ *
+ * @see https://github.com/php/web-php
+ */
+
 $_SERVER['BASE_PAGE'] = 'releases/index.php';
 include_once __DIR__ . '/../include/prepend.inc';
 include_once __DIR__ . "/../include/branches.inc";

--- a/results.php
+++ b/results.php
@@ -1,4 +1,11 @@
 <?php
+
+/**
+ * Any ideas?
+ *
+ * @see https://github.com/php/web-php
+ */
+
 $_SERVER['BASE_PAGE'] = 'results.php';
 include __DIR__ . '/include/prepend.inc';
 include __DIR__ . '/include/results.inc';

--- a/search.php
+++ b/search.php
@@ -1,4 +1,11 @@
-<?php // vim: et
+<?php
+
+/**
+ * Any ideas?
+ *
+ * @see https://github.com/php/web-php
+ */
+
 $_SERVER['BASE_PAGE'] = 'search.php';
 include_once __DIR__ . '/include/prepend.inc';
 

--- a/src/News/Entry.php
+++ b/src/News/Entry.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * Any ideas?
+ *
+ * @see https://github.com/php/web-php
+ */
+
 namespace phpweb\News;
 
 class Entry {

--- a/src/UserNotes/Sorter.php
+++ b/src/UserNotes/Sorter.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * Any ideas?
+ *
+ * @see https://github.com/php/web-php
+ */
+
 namespace phpweb\UserNotes;
 
 class Sorter {

--- a/styles/index.php
+++ b/styles/index.php
@@ -1,5 +1,11 @@
 <?php
-// Simulate a /styles shortcut call (which will lead to a manual page)
+
+/**
+ * Any ideas?
+ *
+ * @see https://github.com/php/web-php
+ */
+
 $_SERVER['REQUEST_URI'] = '/styles';
 include_once __DIR__ . '/../include/prepend.inc';
 include_once __DIR__ . '/../error.php';


### PR DESCRIPTION
❗ Blocked by #670.

This pull request

- [x] enables and configures the `header_comment` fixer
- [x] runs `make coding-standards`

Follows #559.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.4.0/doc/rules/comment/header_comment.rst.