### PR TITLE
Ignore `include/releases.inc` file in CS-Fixer

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -13,6 +13,7 @@ $finder = $config->getFinder()
     ->notPath('include/last_updated.inc')
     ->notPath('include/pregen-confs.inc')
     ->notPath('include/pregen-news.inc')
+    ->notPath('include/releases.inc')
     ->notPath('tests/run-tests.php');
 
 $config


### PR DESCRIPTION
Ignore `include/releases.inc` file in CS-Fixer,
because it's auto-generated by `./bin/bumpRelease`.

Relates 86ea3fc524ac0797d463043c567f039429933002