### PR TITLE
Enhancement: Enable and configure `increment_style` fixer

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -27,6 +27,9 @@ $config
             'spacing' => 'one',
         ],
         'constant_case' => true,
+        'increment_style' => [
+            'style' => 'post',
+        ],
         'indentation_type' => true,
         'line_ending' => true,
         'no_extra_blank_lines' => true,

--- a/include/layout.inc
+++ b/include/layout.inc
@@ -404,7 +404,7 @@ function print_news($news, $dog, $max = 5, $onlyyear = null, $return = false) {
         foreach ($item["category"] as $category) {
             if (is_null($dog) || in_array($category["term"], (array)$dog, true)) {
                 $ok = true;
-                ++$count;
+                $count++;
                 break;
             }
         }

--- a/src/News/Entry.php
+++ b/src/News/Entry.php
@@ -183,7 +183,7 @@ class Entry {
         $filename = date("Y-m-d", $_SERVER["REQUEST_TIME"]);
         $count = 0;
         do {
-            ++$count;
+            $count++;
             $id = $filename . "-" . $count;
             $basename = "{$id}.xml";
         } while (file_exists(self::ARCHIVE_ENTRIES_ABS . $basename));


### PR DESCRIPTION
This pull request

- [x] enables and configures the `increment_style` fixer
- [x] runs `make coding-standards`

Replaces #545.
Follows #559.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.4.0/doc/rules/operator/increment_style.rst.