### PR TITLE
Enhancement: Enable `random_api_migration` fixer

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -32,6 +32,7 @@ $config
         'no_extra_blank_lines' => true,
         'no_trailing_whitespace' => true,
         'ordered_class_elements' => true,
+        'random_api_migration' => true,
         'single_space_after_construct' => true,
         'strict_param' => true,
         'switch_case_space' => true,

--- a/download-logos.php
+++ b/download-logos.php
@@ -22,7 +22,7 @@ function print_star(): void
 function random_bgcolor($min, $max): void
 {
     echo "style=\"background-color: #" .
-         sprintf('%02x%02x%02x', rand($min, $max) * 51, rand($min, $max) * 51, rand($min, $max) * 51) .
+         sprintf('%02x%02x%02x', mt_rand($min, $max) * 51, mt_rand($min, $max) * 51, mt_rand($min, $max) * 51) .
          ";\"";
 }
 ?>

--- a/manual/spam_challenge.php
+++ b/manual/spam_challenge.php
@@ -8,7 +8,7 @@ function plus($a, $b) {
 }
 
 function gen_plus($a) {
-    return rand(0, 9 - $a);
+    return mt_rand(0, 9 - $a);
 }
 
 function minus($a, $b) {
@@ -16,7 +16,7 @@ function minus($a, $b) {
 }
 
 function gen_minus($a) {
-    return rand(0, $a);
+    return mt_rand(0, $a);
 }
 
 function print_infix($name, $a, $b) {
@@ -37,11 +37,11 @@ const CHALLENGES = [
 
 // generate a challenge
 function gen_challenge() {
-    $c = CHALLENGES[rand(0, count(CHALLENGES) - 1)];
+    $c = CHALLENGES[mt_rand(0, count(CHALLENGES) - 1)];
 
-    $a = rand(0, 9);
+    $a = mt_rand(0, 9);
     $an = NUMS[$a];
-    $b = isset($c[2]) ? $c[2]($a) : rand(0, 9);
+    $b = isset($c[2]) ? $c[2]($a) : mt_rand(0, 9);
     $bn = NUMS[$b];
 
     return [$c[0], $an, $bn, $c[1]($c[0], $an, $bn)];


### PR DESCRIPTION
This pull request

- [x] enables the `random_api_migration` fixer
- [x] runs `make coding-standards`

Replaces #545.
Follows #559.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.4.0/doc/rules/alias/random_api_migration.rst.