### PR TITLE
Add realeases/next.php endpoint

### DIFF
--- a/releases/next.php
+++ b/releases/next.php
@@ -1,0 +1,24 @@
+<?php
+$_SERVER['BASE_PAGE'] = 'releases/next.php';
+
+include_once __DIR__ . '/../include/prepend.inc';
+include_once __DIR__ . "/../include/gpg-keys.inc";
+include_once $_SERVER['DOCUMENT_ROOT'] . '/include/branches.inc';
+
+$activeList = get_active_branches();
+ksort($activeList);
+$activeList = array_keys(end($activeList));
+usort($activeList, 'version_compare');
+$latestActive = end($activeList);
+
+$managedList = array_keys(gpg_key_get_branches(false));
+usort($managedList, 'version_compare');
+$latestManaged = end($managedList);
+
+$next = $latestManaged && $latestActive && version_compare($latestManaged, $latestActive, '>')
+    ? $latestManaged
+    : null;
+
+header('Content-Type: application/json; charset=UTF-8');
+
+echo json_encode($next);


### PR DESCRIPTION
This Pull Request is actually a feature request.

The goal is to expose an endpoint that users can use to fetch the upcoming release.

The `realeases/next.php` returns a JSON response with the next version, for example:

```json
"8.2"
```

I don't mind if another approach is proposed instead.