### PR TITLE
Fix news2html truncation

### DIFF
--- a/bin/news2html
+++ b/bin/news2html
@@ -30,7 +30,7 @@ while(($ln = fgets($fp)) !== false) {
 	}
 	if (!$inside) { continue; }
 
-	if (preg_match('/,? PHP \d+.\d+.\d+/', $ln)) {
+	if (preg_match('/, PHP \d+.\d+.\d+/', $ln)) {
 		// next entry - we're done
 		break;
 	}


### PR DESCRIPTION
If there are NEWS entries referring to a certain PHP version, these are interpreted as belonging to that PHP version.  Since the lines actually delimiting PHP versions are supposed to have comma after the date, we enforce that now.