### PR TITLE
Simplify DNF example

### DIFF
--- a/releases/8.2/release.inc
+++ b/releases/8.2/release.inc
@@ -113,11 +113,7 @@ PHP
                             <<<'PHP'
 class Foo {
     public function bar(mixed $entity) {
-        if ($entity === null) {
-            return null;
-        }
-
-        if (($entity instanceof A) && ($entity instanceof B)) {
+        if ((($entity instanceof A) && ($entity instanceof B)) || ($entity === null)) {
             return $entity;
         }
 
@@ -137,10 +133,6 @@ PHP
                             <<<'PHP'
 class Foo {
     public function bar((A&B)|null $entity) {
-        if ($entity === null) {
-            return null;
-        }
-
         return $entity;
     }
 }


### PR DESCRIPTION
As has been pointed out by Thomas Gutbier[1], the PHP 8.2 code doesn't need the special handling for `null`, so we remove it, and accordingly merge the special case handling in the pre PHP 8.2 snippet as well.

[1] <https://externals.io/message/119096#119097>