### PR TITLE
Simplify stand-alone type example

### DIFF
--- a/releases/8.2/release.inc
+++ b/releases/8.2/release.inc
@@ -160,9 +160,9 @@ PHP
                             <<<'PHP'
 class Falsy
 {
-    public function almostFalse(): string|bool { /* ... */ *}
+    public function almostFalse(): bool { /* ... */ *}
 
-    public function almostTrue(): string|bool { /* ... */ *}
+    public function almostTrue(): bool { /* ... */ *}
 
     public function almostNull(): string|null { /* ... */ *}
 }


### PR DESCRIPTION
These string types confused me -- seems like we can drop them?