### PR TITLE
Only "linked" parameters should have pointer cursor

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -362,16 +362,29 @@ $(document).ready(function () {
         $(this).append("<a class='genanchor' href='#" + $(this).parent().attr("id") + "'> ¶</a>");
     });
 
-    $('.refentry code.parameter').click(function (event) {
-        var id = $(this).text().replace(/^&?(\.\.\.)?\$?/g, '');
-        var offsetTop = $('.parameters, .options').find('.parameter').filter(function () {
-            return $(this).text().trim() === id; // https://bugs.php.net/bug.php?id=74493
-        }).offset().top - 52;
-        $.scrollTo({
-            top: offsetTop,
-            left: 0
-        }, 400);
-    });
+    function findParameter(elt) {
+        var id = $(elt).text().replace(/^&?(\.\.\.)?\$?/g, '');
+        return $('.parameters, .options').find('.parameter').filter(function () {
+            return $(elt).text().trim() === id; // https://bugs.php.net/bug.php?id=74493
+        }).first();
+    }
+
+    $('.refentry code.parameter')
+        .each(function () {
+            var param = findParameter(this);
+            if (param.length) {
+                $(this).css('cursor', 'pointer');
+            }
+        })
+        .click(function () {
+            var param = findParameter(this);
+            if (param.length) {
+                $.scrollTo({
+                    top: param.offset().top - 52,
+                    left: 0
+                }, 400);
+            }
+        });
 
     $('h1[id], h2[id], h3[id], h4[id]').each(function () {
         var $this = $(this);

--- a/styles/theme-base.css
+++ b/styles/theme-base.css
@@ -1209,9 +1209,6 @@ header.title {
 
 /* {{{ General styles (p, parameters, initializers, ...) */
 
-.refsect1 .parameter {
-    cursor:pointer;
-}
 .refsect1 dt {
     height:1.5rem;
 }


### PR DESCRIPTION
If a parameter has no target to scroll to, it should not suggest otherwise by changing the cursor to a pointer.  Since the scrolling is done via JS, we should also change the cursor via JS.[1]

While we're at it, we also fix the potential JS error where we call the `.offset()` method on an empty `jQuery` object.

[1] <https://github.com/php/doc-en/issues/2071#issuecomment-1354497367>

---

Actually, we should not use JS for this "linking", but rather should output anchors (from PhD) to let the browser do this stuff. But for now, this seems to be a viable solution.