### PR TITLE
Apply white-space:pre to .phpcode and div.classsynopsis

### DIFF
--- a/styles/theme-base.css
+++ b/styles/theme-base.css
@@ -551,6 +551,7 @@ dl dd {
 
 .phpcode, div.classsynopsis {
     text-align: left;
+    white-space: pre;
 }
 div.classsynopsisinfo_comment {
     margin-top:1.5rem;


### PR DESCRIPTION
This is currently unnecessary, since PhD renders NBSPs instead of regular space there, but if that changes, the layout needs to be preserved.