### PR TITLE
Improve sidebar menu contrast to fix accessibility issues

### DIFF
--- a/styles/theme-base.css
+++ b/styles/theme-base.css
@@ -16,6 +16,7 @@
   --light-blue-color: #E2E4EF;
   --dark-magenta-color: #793862;
   --medium-magenta-color: #AE508D;
+  --light-magenta-color: #CF82B1;
 }
 
 .clearfix {

--- a/styles/theme-base.css
+++ b/styles/theme-base.css
@@ -661,6 +661,10 @@ body > footer a {
   display:inline-block;
   border-bottom:0;
 }
+body > footer a:hover,
+body > footer a:focus {
+    color:var(--light-magenta-color);
+}
 
 /* {{{ ElePHPants photo stream */
 
@@ -1526,6 +1530,10 @@ div.soft-deprecation-notice blockquote.sidebar {
 #breadcrumbs a:link,
 #breadcrumbs a:visited {
     border-width:0;
+}
+#breadcrumbs a:hover,
+#breadcrumbs a:focus {
+    color:var(--light-magenta-color);
 }
 
 #breadcrumbs .next,

--- a/styles/theme-medium.css
+++ b/styles/theme-medium.css
@@ -423,8 +423,8 @@ aside.tips .panel > a:hover:after {
 }
 aside.tips a:hover,
 aside.tips a:focus {
-  color:var(--medium-magenta-color);
-  border-color:var(--medium-magenta-color);
+  color:var(--light-magenta-color);
+  border-color:var(--light-magenta-color);
 }
 
 .soft-deprecation-notice {
@@ -456,6 +456,7 @@ aside.tips a:focus {
   color:var(--light-magenta-color);
   border-bottom-color:var(--light-magenta-color);
 }
+.layout-menu ul.parent-menu-list li a:hover,
 .layout-menu ul.child-menu-list li a:hover {
   color:var(--light-magenta-color);
 }

--- a/styles/theme-medium.css
+++ b/styles/theme-medium.css
@@ -456,6 +456,9 @@ aside.tips a:focus {
   color:var(--light-magenta-color);
   border-bottom-color:var(--light-magenta-color);
 }
+.layout-menu ul.child-menu-list li a:hover {
+  color:var(--light-magenta-color);
+}
 .layout-menu ul.child-menu-list a {
   border-color: #666;
 }

--- a/styles/theme-medium.css
+++ b/styles/theme-medium.css
@@ -453,8 +453,8 @@ aside.tips a:focus {
   border-top-color:#666;
 }
 .layout-menu ul.child-menu-list li.current a {
-  color:var(--medium-magenta-color);
-  border-bottom-color:var(--medium-magenta-color);
+  color:var(--light-magenta-color);
+  border-bottom-color:var(--light-magenta-color);
 }
 .layout-menu ul.child-menu-list a {
   border-color: #666;


### PR DESCRIPTION
In order to be accessible, text must have a contrast ratio of at least 4.5:1

See https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html

-----

This increases the contrast of the selected item in the sidebar menu to reach that ratio:

| Before  | After
| ------- | -----
| ![before](https://user-images.githubusercontent.com/73419/214289205-c86c80e0-5b50-4fd4-a4e5-1154b26858e3.png) | ![after](https://user-images.githubusercontent.com/73419/214289217-d3a8d6c1-1567-493f-b735-abea975ac490.png)
| Text contrast: 2.61 | Text contrast: 4.50

