### PR TITLE
Font display swap fix

### DIFF
--- a/fonts/Fira/fira.css
+++ b/fonts/Fira/fira.css
@@ -8,6 +8,7 @@
          url('/fonts/Fira/ttf/FiraSans-Book.ttf') format('truetype');
     font-weight: 400;
     font-style: normal;
+    font-display: swap;
 }
 
 @font-face{
@@ -20,6 +21,7 @@
          url('/fonts/Fira/ttf/FiraSans-BookItalic.ttf') format('truetype');
     font-weight: 400;
     font-style: italic;
+    font-display: swap;
 }
 
 @font-face{
@@ -32,6 +34,7 @@
          url('/fonts/Fira/ttf/FiraSans-Medium.ttf') format('truetype');
     font-weight: 500;
     font-style: normal;
+    font-display: swap;
 }
 
 @font-face{
@@ -44,6 +47,7 @@
          url('/fonts/Fira/ttf/FiraSans-MediumItalic.ttf') format('truetype');
     font-weight: 500;
     font-style: italic;
+    font-display: swap;
 }
 
 @font-face{
@@ -56,6 +60,7 @@
          url('/fonts/Fira/ttf/FiraMono-Regular.ttf') format('truetype');
     font-weight: 400;
     font-style: normal;
+    font-display: swap;
 }
 
 @font-face{
@@ -68,4 +73,5 @@
          url('/fonts/Fira/ttf/FiraMono-Bold.ttf') format('truetype');
     font-weight: 700;
     font-style: normal;
+    font-display: swap;
 }

--- a/fonts/Font-Awesome/css/fontello.css
+++ b/fonts/Font-Awesome/css/fontello.css
@@ -7,6 +7,7 @@
        url('/fonts/Font-Awesome/font/fontello.svg?60964435#fontello') format('svg');
   font-weight: normal;
   font-style: normal;
+  font-display: swap;
 }
 /* Chrome hack: SVG is rendered more smooth in Windozze. 100% magic, uncomment if you need it. */
 /* Note, that will break hinting! In other OS-es font will be not as sharp as it could be */


### PR DESCRIPTION
What `font-family: swap` does is `Fallback text is immediately rendered in the next available system typeface in the font stack until the custom font loads, in which case the new typeface will be swap ped in`

This fixes the issue on slow connections where fonts on the page are invisible while the remote font is still downloading, this provides a fallback to the system fonts until the remote font has been downloaded.

More information about it here: 
- https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display
- https://developer.chrome.com/docs/lighthouse/performance/font-display/
