### PR TITLE
Provide a release list in JSON format

### DIFF
--- a/releases/releases.list.json.php
+++ b/releases/releases.list.json.php
@@ -1,0 +1,37 @@
+<?php
+include_once __DIR__ . '/../include/branches.inc';
+include_once __DIR__ . '/../include/releases.inc';
+include_once __DIR__ . '/../include/version.inc';
+
+function get_releases_data(): array {
+    global $RELEASES, $OLDRELEASES;
+
+    $allReleases = array_merge(
+        ...$OLDRELEASES,
+        ...$RELEASES
+    );
+
+    $activeBranches = array_keys(array_merge(...get_active_branches(true)));
+
+    $data = [];
+    foreach ($allReleases as $version => $release) {
+        $data[$version] = [
+            'version'       => $version,
+            'date'          => date('Y-m-d', strtotime($release['date'])),
+            'active_branch' => in_array(version_number_to_branch($version), $activeBranches),
+            'security'      => in_array('security', $release['tags'] ?? []),
+        ];
+    }
+
+    uksort(
+        $data,
+        function (string $a, string $b): int {
+            return - version_compare($a, $b);
+        }
+    );
+
+    return array_values($data);
+}
+
+header('Content-Type: application/json');
+echo json_encode(get_releases_data(), JSON_PRETTY_PRINT);


### PR DESCRIPTION
I work on a company that develops an open-source application that is using PHP as its server language. Most of the time, our application is installed, by people who are unfamiliar with the PHP ecosystem, on a server whose maintenance is unfortunately often neglected.
In our application installation/update process, we would like to recommend upgrading to a newer version of PHP when the server is using an unmaintained version, or a version for which a security issue has been fixed. This features requires to be able to access a list of releases that can be easilly parsed by a script.

I propose to add a list of PHP releases, into JSON format, directly on `www.php.net` website.
With current proposal, accessing `/releases/releases.list.json.php` would return the complete list of PHP releases, in following format:
```json
[
    {
        "version": "8.2.4",
        "date": "2023-03-16",
        "active_branch": true,
        "security": false
    },
    {
        "version": "8.2.3",
        "date": "2023-02-14",
        "active_branch": true,
        "security": true
    },
...
    {
        "version": "7.4.33",
        "date": "2022-11-03",
        "active_branch": false,
        "security": true
    },
...
    {
        "version": "3.0.x (latest)",
        "date": "2000-10-20",
        "active_branch": false,
        "security": false
    }
]
```
