### PR TITLE
Fix code blocks overflowing content. 

### DIFF
--- a/styles/theme-base.css
+++ b/styles/theme-base.css
@@ -1326,7 +1326,8 @@ div.tip p:first-child {
     margin-bottom: 1.5rem;
 }
 
-.docs .phpcode {
+.docs .phpcode code {
+    display: block;
     overflow-x: auto;
 }
 

--- a/styles/theme-base.css
+++ b/styles/theme-base.css
@@ -550,6 +550,10 @@ dl dd {
     padding:0 1.5rem;
 }
 
+.php8-code.phpcode{
+    overflow-x: auto;
+}
+
 .phpcode, div.classsynopsis {
     text-align: left;
 }
@@ -1311,6 +1315,7 @@ div.tip p:first-child {
 .docs .example-contents.screen,
 .informalexample .literallayout {
     padding: .75rem;
+    overflow-x: auto;
 }
 
 .docs .classsynopsis,
@@ -1321,8 +1326,8 @@ div.tip p:first-child {
     margin-bottom: 1.5rem;
 }
 
-.docs .phpcode code {
-    display: block;
+.docs .phpcode {
+    overflow-x: auto;
 }
 
 .docs .qandaentry dt .phpcode * {


### PR DESCRIPTION
This PR fixes the code overflowing content by enabling the horizontal scroll. 

The PHP 8.2 release page has the code content overflowing when accessing via mobile, and the same happens on many pages across the documentation, mainly in user comments. 

![image](https://github.com/php/web-php/assets/1036401/006b31dc-ae61-4d77-980b-91436824e1d8)
![image](https://github.com/php/web-php/assets/1036401/dd862570-06d8-4c05-95de-a65a29c418a2)

The result looks like this:

![image](https://github.com/php/web-php/assets/1036401/228e8734-f8f8-412f-b465-2cd443f7b219)
![image](https://github.com/php/web-php/assets/1036401/60811457-6e0f-4d97-8a60-0c398d6f5111)

