### PR TITLE
[feature] Expose PHP version support states and dates as JSON

### DIFF
--- a/releases/states.php
+++ b/releases/states.php
@@ -1,0 +1,30 @@
+<?php
+$_SERVER['BASE_PAGE'] = 'releases/active.php';
+
+include_once __DIR__ . '/../include/prepend.inc';
+include_once $_SERVER['DOCUMENT_ROOT'] . '/include/branches.inc';
+
+header('Content-Type: application/json; charset=UTF-8');
+
+$states = [];
+
+function formatDate($date = null) {
+    return $date !== null ? $date->format('c') : null;
+}
+
+foreach (get_all_branches() as $major => $releases) {
+    $states[$major] = [];
+    foreach ($releases as $branch => $release) {
+        $states[$major][$branch] = [
+            'state' => get_branch_support_state($branch),
+            'initial_release' => formatDate(get_branch_release_date($branch)),
+            'active_support_end' => formatDate(get_branch_bug_eol_date($branch)),
+            'security_support_end' => formatDate(get_branch_security_eol_date($branch)),
+        ];
+    }
+    krsort($states[$major]);
+}
+
+krsort($states);
+
+echo json_encode($states);


### PR DESCRIPTION
## Why
Expose PHP version support states for the community and PHP monitoring tools.

## How
Expose a new JSON page `/releases/states` (in the spirit of `/releases/active`) listing all PHP Branch and their support state.

## Preview
```json
{
	"8": {
		"8.2": {
			"state": "stable",
			"initial_release": "2022-12-08T00:00:00+00:00",
			"active_support_end": "2024-12-08T00:00:00+00:00",
			"security_support_end": "2025-12-08T00:00:00+00:00"
		},
		"8.1": {
			"state": "stable",
			"initial_release": "2021-11-25T00:00:00+00:00",
			"active_support_end": "2023-11-25T00:00:00+00:00",
			"security_support_end": "2024-11-25T00:00:00+00:00"
		},
		"8.0": {
			"state": "security",
			"initial_release": "2020-11-26T00:00:00+00:00",
			"active_support_end": "2022-11-26T00:00:00+00:00",
			"security_support_end": "2023-11-26T00:00:00+00:00"
		}
	},
	"7": {
		"7.4": {
			"state": "eol",
			"initial_release": "2019-11-28T00:00:00+00:00",
			"active_support_end": "2021-11-28T00:00:00+00:00",
			"security_support_end": "2022-11-28T00:00:00+00:00"
		},
		"7.3": {
			"state": "eol",
			"initial_release": "2018-12-06T00:00:00+00:00",
			"active_support_end": "2020-12-06T00:00:00+00:00",
			"security_support_end": "2021-12-06T00:00:00+00:00"
		},
		"7.2": {
			"state": "eol",
			"initial_release": "2017-11-30T00:00:00+00:00",
			"active_support_end": "2019-11-30T00:00:00+00:00",
			"security_support_end": "2020-11-30T00:00:00+00:00"
		},
		"7.1": {
			"state": "eol",
			"initial_release": "2016-12-01T00:00:00+00:00",
			"active_support_end": "2018-12-01T00:00:00+00:00",
			"security_support_end": "2019-12-01T00:00:00+00:00"
		},
		"7.0": {
			"state": "eol",
			"initial_release": "2015-12-03T00:00:00+00:00",
			"active_support_end": "2018-01-04T00:00:00+00:00",
			"security_support_end": "2019-01-10T00:00:00+00:00"
		}
	},
	...
}
```

## TODO
- [x] Implementation
- [x] `make tests` passes ✅ 
- [x] `make coding-standards` passes ✅ 