### PR TITLE
Remove double underline on abbr

### DIFF
--- a/styles/theme-base.css
+++ b/styles/theme-base.css
@@ -387,9 +387,9 @@ blockquote {
 }
 
 abbr {
-    border-bottom:1px dotted;
     cursor: help;
 }
+
 a {
     text-decoration:none;
 }

--- a/styles/theme-medium.css
+++ b/styles/theme-medium.css
@@ -19,10 +19,6 @@ html {
   border-right:.25rem solid #666;
 }
 
-abbr {
-  border-color: var(--medium-blue-color);
-}
-
 h1, h2, h3, h4, h5, h6 {
   font-weight: 500;
   color: var(--content-text-color)


### PR DESCRIPTION
UAs already styles `<abbr>` with a underline, and web-php styles double its:

See, for example: https://www.php.net/manual/en/install.unix.php

Google:
![image](https://github.com/php/web-php/assets/10078152/b1c19f69-73eb-45f2-b1c0-4f0a9253fe66)

Firefox:
![image](https://github.com/php/web-php/assets/10078152/0675b73d-97ff-4e9d-a8fa-5029dc9792dd)
