### PR TITLE
Add a security.txt file to php.net

### DIFF
--- a/.well-known/security.txt
+++ b/.well-known/security.txt
@@ -8,51 +8,24 @@ Preferred-Languages: en
 Canonical: https://www.php.net/.well-known/security.txt
 Policy: https://github.com/php/php-src/security/policy
 
-# Signed by Ben Ramsey <ramsey@php.net> on 2023-09-28.
+# Signed by Ben Ramsey <ramsey@php.net> on 2023-09-29.
 
-# All changes to this file are signed by a PHP release manager for a currently
-# supported version of PHP (at the time of the changes).
-# Supported PHP versions are listed at <https://www.php.net/supported-versions.php>.
-# Release manager PGP keys are listed at <https://www.php.net/gpg-keys.php>.
-#
-# To make changes to this file:
-#
-# 1. First, remove the PGP signature that wraps the body of this file:
-#
-#        gpg --decrypt --output security.txt security.txt
-#
-# 2. Make and save your changes to this file, i.e., update the Expires
-#    timestamp. Be sure to update the signature above to include your name,
-#    the email address for your PGP key, and the current date.
-#
-# 3. Sign your changes:
-#
-#        gpg --clearsign --local-user YOU@php.net --output security.txt.asc security.txt
-#
-#    Note: you cannot output the signature to the same file as the input or it
-#    will result in a signature wrapped around empty content.
-#
-# 4. Last, replace security.txt with security.txt.asc and commit your changes:
-#
-#        mv security.txt.asc security.txt
-#        git commit security.txt
-#
-# For more information about this file, see <https://securitytxt.org> and
-# RFC 9116 <https://www.rfc-editor.org/rfc/rfc9116>.
+# For instructions on how to update this file, read
+# <https://github.com/php/php-src/blob/master/docs/security-policies.md#making-changes-to-securitytxt>
 -----BEGIN PGP SIGNATURE-----
 
-iQJDBAEBCAAtFiEEObZBND2MEEsrFG3D+cOdwLlphUQFAmUV+rUPHHJhbXNleUBw
-aHAubmV0AAoJEPnDncC5aYVEecgQAI5vAj7c/FwzaZm02IxUWofKFH8ZPivXlRbI
-1aKDJkIFZwxq59Lr9EW2AnZRSdSmBDPJ1ED91DP737wACVx/rmQecuW3fJ2UtyYC
-TnwERb34ff3Ojt0qO9RTXc3X/+Aq7j28cZVM8JmGrTIbIMh9FnYoWmdoMjy3dqF/
-YBPQw/7wFMBW9wpRJx4ZSjf02VoUn6grR2UTMAfveCQcFKNAo7qo6km/ogJMnPsi
-pcpgYA1d7plx4H1BhnyExSwZ/V9wmNOOPOME75wvx2V9nVNWKha/XCoNU53ySi9V
-15U/zdXa2zjCo+8KASWgYqFAipMTa7oCzRLuqbWLc59amMMflRpbfKHAnC4W2L1d
-M2HdG4loOh45OFZAenOFAQxAbT5cFhA1jWMDP4jY1X7ivuCV62YaBfqYBILaTps+
-/uutLUq73WMVsCdtwN5Va/2CWplvgFPcwVbpNeGJcjHTsA/ikSuVhNoTeDLfwUck
-ZBo67oqwkAHJsKX79PD9eemZqrqHvS9qx0l05ZlRE7dUdq0XY7YCZOREBKnipX7O
-RnMXnjSg9oE6I5m02OdPeKy24KthQPFCev+nu6TwgNfvc5AWADanYNf5BnhWRzea
-tc0VUoaXaxQtbInFA0E0NfMUVcy6mR9RFYhDCt62xFHp0TDkyaHszBs701Tebxei
-tAj40vPD
-=U/gC
+iQJDBAEBCAAtFiEEObZBND2MEEsrFG3D+cOdwLlphUQFAmUXFR8PHHJhbXNleUBw
+aHAubmV0AAoJEPnDncC5aYVE5FsP/0vTzaiBB6ESAex1QPWU2tUFPiVsFBZN0/lo
+DHVokFrOQ0CiUaXmOltia8ZJK5WR5IRlKjm94GlgFqdg5Mn0sLvo9JF9e4eq2PZa
+AYj3rGL4C6GCXc8voKz9TXZ/eerkCSA2BY/0a1PM69dDam0XBcrCIndcil/3Evj0
+ztiWPWcMRHubBadxmDosoGtXwcw5u13IIGDmSsHwNtdkKNbS1eb1+o7DFSVQZicY
+hW5SI4pfjW5BsIYxHLR7F9qCtoTWkZwtwTqX5LNIPBh6M/C8aYl/3vAfikBbqvXu
+SPnObTGBNXeaHavVXMohBFNZsWdiJzBSAKQBhsqGTElVJfSbuzyaNIFN7LuuheS4
+Od7Ar9V8tUsfy/y9OisWOIbNVpm7FgQIDKTTXXJpI1THQ1kmsHKsPN5eFZw1O8ZE
+ZSztjMyo0jaLTlwrfzAmqSwEiuAQAv1fvc4PncHeat1SMFFG4wP1/lEfmzunmLiq
+yUzwii/5JOLWwAGfkuNaWTOTX7XJVyfTcr34nD+2WNxws4vrAA9KES2qhLBYpZ/K
+xELiqGcogoDBiQYZ7AnofsbghFQn1cpX90uUxdXXAimiUWgBm3ONnXX9YoNsYMdd
+eVMZ3JfOOUL8Gfe5vjaQex46o4zN/1g2baAmu5usfD21TLZEcrD9HhFiarEWjYv0
+Tr0agdzE
+=CJdS
 -----END PGP SIGNATURE-----

--- a/.well-known/security.txt
+++ b/.well-known/security.txt
@@ -1,0 +1,36 @@
+-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA256
+
+Contact: https://github.com/php/php-src/security/advisories/new
+Contact: mailto:security@php.net
+Expires: 2024-11-28T11:59:59.999Z
+Preferred-Languages: en
+Canonical: https://www.php.net/.well-known/security.txt
+Policy: https://github.com/php/php-src/security/policy
+
+# Signed by Ben Ramsey <ramsey@php.net> on 2023-09-28.
+
+# All changes to this file are signed by a PHP release manager for a currently
+# supported version of PHP (at the time of the changes).
+# Supported PHP versions are listed at <https://www.php.net/supported-versions.php>.
+# Release manager PGP keys are listed at <https://www.php.net/gpg-keys.php>.
+
+# For more information about this file, see <https://securitytxt.org> and
+# RFC 9116 <https://www.rfc-editor.org/rfc/rfc9116>.
+-----BEGIN PGP SIGNATURE-----
+
+iQJDBAEBCAAtFiEEObZBND2MEEsrFG3D+cOdwLlphUQFAmUVzUwPHHJhbXNleUBw
+aHAubmV0AAoJEPnDncC5aYVEnQYQAIFr8yIGOJ8GBGJ0L8LkGmE23UHukVQKdqFw
+lt/evxz7c+Z3GX2i4j+TyVKl5mSgXaryOMIo3e6HCjnmqPZp+gBlamYLusgn6b/3
+bmCQ1jh+7lEeEg8eTF7URNvR/8ao3I22iu0TAAQIF3B3bhYq7hwQYJtQvIdAvn/X
+qGInKHGJ+QJRyR+GHOOPUDrQ6geU6lSMd2znAe2WUTtZZWo3A0OURmW7m1m7w9E/
+vq5Mzttkjk0syKOJ6/5GLk8Olag7KV8gCnsazjBRzUD5fN5tbo2XX/6EJYkqeptq
+LREVYi2c/iWotwapoHZJrG+Gx3GgtLDYBZ+cJ8ZpR+8OevCeBQOdYLMNbhvdAM7b
+HZm36EpmBSfU7YngaKnq1Erb2GsgtF03dG4eeXSViVhVT/ERGvzidK7OG4RWBnL/
+AwMb5LsdQswM2PHq2QwNz9hwv1AL3UOLMM4e2cOMvmZlOZ7PDYQHp+UqWy5VaGRU
+YoZ9wQWudpnpJ4RzOAzf9/fQG8wracwJqgCk2CinTd9Dk/4rueVwv5FvyCSq6EiK
+iuq9cnhQlPFGwOR3dfYlTU+CdevlnP7JFSwBdQuyrNV8YSTqMD4O2I8Kwo+1MNN2
+elK4pT1pHGKe50c31NM82ZwY5RLW2cLj8Q4Y+pvOfTqhzr3vPAy/NfZZiwlNYsRE
+KN9Ixm67
+=n+Pu
+-----END PGP SIGNATURE-----

--- a/.well-known/security.txt
+++ b/.well-known/security.txt
@@ -14,23 +14,45 @@ Policy: https://github.com/php/php-src/security/policy
 # supported version of PHP (at the time of the changes).
 # Supported PHP versions are listed at <https://www.php.net/supported-versions.php>.
 # Release manager PGP keys are listed at <https://www.php.net/gpg-keys.php>.
-
+#
+# To make changes to this file:
+#
+# 1. First, remove the PGP signature that wraps the body of this file:
+#
+#        gpg --decrypt --output security.txt security.txt
+#
+# 2. Make and save your changes to this file, i.e., update the Expires
+#    timestamp. Be sure to update the signature above to include your name,
+#    the email address for your PGP key, and the current date.
+#
+# 3. Sign your changes:
+#
+#        gpg --clearsign --local-user YOU@php.net --output security.txt.asc security.txt
+#
+#    Note: you cannot output the signature to the same file as the input or it
+#    will result in a signature wrapped around empty content.
+#
+# 4. Last, replace security.txt with security.txt.asc and commit your changes:
+#
+#        mv security.txt.asc security.txt
+#        git commit security.txt
+#
 # For more information about this file, see <https://securitytxt.org> and
 # RFC 9116 <https://www.rfc-editor.org/rfc/rfc9116>.
 -----BEGIN PGP SIGNATURE-----
 
-iQJDBAEBCAAtFiEEObZBND2MEEsrFG3D+cOdwLlphUQFAmUVzUwPHHJhbXNleUBw
-aHAubmV0AAoJEPnDncC5aYVEnQYQAIFr8yIGOJ8GBGJ0L8LkGmE23UHukVQKdqFw
-lt/evxz7c+Z3GX2i4j+TyVKl5mSgXaryOMIo3e6HCjnmqPZp+gBlamYLusgn6b/3
-bmCQ1jh+7lEeEg8eTF7URNvR/8ao3I22iu0TAAQIF3B3bhYq7hwQYJtQvIdAvn/X
-qGInKHGJ+QJRyR+GHOOPUDrQ6geU6lSMd2znAe2WUTtZZWo3A0OURmW7m1m7w9E/
-vq5Mzttkjk0syKOJ6/5GLk8Olag7KV8gCnsazjBRzUD5fN5tbo2XX/6EJYkqeptq
-LREVYi2c/iWotwapoHZJrG+Gx3GgtLDYBZ+cJ8ZpR+8OevCeBQOdYLMNbhvdAM7b
-HZm36EpmBSfU7YngaKnq1Erb2GsgtF03dG4eeXSViVhVT/ERGvzidK7OG4RWBnL/
-AwMb5LsdQswM2PHq2QwNz9hwv1AL3UOLMM4e2cOMvmZlOZ7PDYQHp+UqWy5VaGRU
-YoZ9wQWudpnpJ4RzOAzf9/fQG8wracwJqgCk2CinTd9Dk/4rueVwv5FvyCSq6EiK
-iuq9cnhQlPFGwOR3dfYlTU+CdevlnP7JFSwBdQuyrNV8YSTqMD4O2I8Kwo+1MNN2
-elK4pT1pHGKe50c31NM82ZwY5RLW2cLj8Q4Y+pvOfTqhzr3vPAy/NfZZiwlNYsRE
-KN9Ixm67
-=n+Pu
+iQJDBAEBCAAtFiEEObZBND2MEEsrFG3D+cOdwLlphUQFAmUV+rUPHHJhbXNleUBw
+aHAubmV0AAoJEPnDncC5aYVEecgQAI5vAj7c/FwzaZm02IxUWofKFH8ZPivXlRbI
+1aKDJkIFZwxq59Lr9EW2AnZRSdSmBDPJ1ED91DP737wACVx/rmQecuW3fJ2UtyYC
+TnwERb34ff3Ojt0qO9RTXc3X/+Aq7j28cZVM8JmGrTIbIMh9FnYoWmdoMjy3dqF/
+YBPQw/7wFMBW9wpRJx4ZSjf02VoUn6grR2UTMAfveCQcFKNAo7qo6km/ogJMnPsi
+pcpgYA1d7plx4H1BhnyExSwZ/V9wmNOOPOME75wvx2V9nVNWKha/XCoNU53ySi9V
+15U/zdXa2zjCo+8KASWgYqFAipMTa7oCzRLuqbWLc59amMMflRpbfKHAnC4W2L1d
+M2HdG4loOh45OFZAenOFAQxAbT5cFhA1jWMDP4jY1X7ivuCV62YaBfqYBILaTps+
+/uutLUq73WMVsCdtwN5Va/2CWplvgFPcwVbpNeGJcjHTsA/ikSuVhNoTeDLfwUck
+ZBo67oqwkAHJsKX79PD9eemZqrqHvS9qx0l05ZlRE7dUdq0XY7YCZOREBKnipX7O
+RnMXnjSg9oE6I5m02OdPeKy24KthQPFCev+nu6TwgNfvc5AWADanYNf5BnhWRzea
+tc0VUoaXaxQtbInFA0E0NfMUVcy6mR9RFYhDCt62xFHp0TDkyaHszBs701Tebxei
+tAj40vPD
+=U/gC
 -----END PGP SIGNATURE-----


### PR DESCRIPTION
This file implements the standard defined in RFC 9116 for a machine-parsable format to aid in security vulnerability disclosure.

Of note:

1. We must include an `Expires` field, which the RFC suggests should be less than a year in the future. I have set it for the assumed date for GA of PHP 8.4/9.0. I recommend we update the expires time each year on this date, since it's already a date of significance for us.

2. I have signed it with my php.net release manager key. Since we publish our release manager keys, I'm recommending that a release manager for a currently supported version of PHP (at the time) be the one to digitally sign this file after making changes.

For more details about security.txt, see:

- https://securitytxt.org
- https://www.rfc-editor.org/rfc/rfc9116