### PR TITLE
Fix email test

### DIFF
--- a/tests/is-emailable-address.phpt
+++ b/tests/is-emailable-address.phpt
@@ -8,7 +8,7 @@ require_once __DIR__ . '/../include/email-validation.inc';
 $emails = array(
     'asasasd324324@php.net',
     'jcastagnetto-delete-this-@yahoo.com',
-    'jcastagnetto-i-hate-spam@NOSPAMyahoo.com',
+    'jcastagnetto-i-hate-spam@NOSPAMyahoo.test',
     'jcastagnetto-NO-SPAM@yahoo.com',
     'jcastagnetto@NoSpam-yahoo.com',
     'jesusmc@scripps.edu',


### PR DESCRIPTION
It seems NOSPAMyahoo.com is now a [valid domain](https://who.is/whois/nospamyahoo.com) since 2023-11-13, so test fails :)