### PR TITLE
Add rel=me verification link for Mastodon

### DIFF
--- a/index.php
+++ b/index.php
@@ -164,6 +164,8 @@ site_header("Hypertext Preprocessor",
 
 <meta property="og:image" content="{$meta_image_path}" />
 <meta property="og:description" content="$meta_description" />
+
+<link href="https://fosstodon.org/@php" rel="me" />
 META
     ]
 );


### PR DESCRIPTION
This PR adds a `rel="me"` link to the head of the home page, which Mastodon servers will use to verify the mutual ownership of the Fosstodon account and the php.net website. Fixes #829