### PR TITLE
fix: php 8.3 release page example code

### DIFF
--- a/releases/8.3/release.inc
+++ b/releases/8.3/release.inc
@@ -326,7 +326,7 @@ function getBytesFromString(string $string, int $length) {
     $result = '';
     for ($i = 0; $i < $length; $i++) {
         // random_int is not seedable for testing, but secure.
-        $result .= $string[random_int(0, $stringLength - 1)]);
+        $result .= $string[random_int(0, $stringLength - 1)];
     }
 
     return $result;


### PR DESCRIPTION
In that [section](https://www.php.net/releases/8.3/en.php#randomizer_get_bytes_from_string) about `php 8.3` release, I found mistake in example of code and I fixed them.

Before PR:
```
 function getBytesFromString(string $string, int $length) {
    $stringLength = strlen($string);

    $result = '';
    for ($i = 0; $i < $length; $i++) {
        // random_int is not seedable for testing, but secure.
        $result .= $string[random_int(0, $stringLength - 1)]);
    }

    return $result;
}
```

After PR:
```
function getBytesFromString(string $string, int $length) {
    $stringLength = strlen($string);

    $result = '';
    for ($i = 0; $i < $length; $i++) {
        // random_int is not seedable for testing, but secure.
        $result .= $string[random_int(0, $stringLength - 1)];
    }

    return $result;
}
```