### PR TITLE
Fix: missing space in en.php

### DIFF
--- a/releases/8.3/languages/en.php
+++ b/releases/8.3/languages/en.php
@@ -4,7 +4,7 @@ return [
     'common_header' => 'PHP 8.3 is a major update of the PHP language. It contains many new features, such as explicit typing of class constants, deep-cloning of readonly properties and additions to the randomness functionality. As always it also includes performance improvements, bug fixes, and general cleanup.',
     'documentation' => 'Doc',
     'main_title' => 'Released!',
-    'main_subtitle' => 'PHP 8.3 is a major update of the PHP language.<br class="display-none-md">It contains many new features, such as explicit typing of class constants, deep-cloning of readonly properties and additions to the randomness functionality. As always it also includes performance improvements, bug fixes, and general cleanup.',
+    'main_subtitle' => 'PHP 8.3 is a major update of the PHP language.<br class="display-none-md"> It contains many new features, such as explicit typing of class constants, deep-cloning of readonly properties and additions to the randomness functionality. As always it also includes performance improvements, bug fixes, and general cleanup.',
     'upgrade_now' => 'Upgrade to PHP 8.3 now!',
 
     'readonly_title' => 'Deep-cloning of readonly properties',


### PR DESCRIPTION
Added space after first period in main_subtitle
![image](https://github.com/php/web-php/assets/20298508/acdda0ab-77c5-4100-9828-2461500acc40)
