### PR TITLE
Enhancement: Enable `unary_operator_spaces` fixer

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -48,6 +48,7 @@ $config
         'strict_param' => true,
         'switch_case_space' => true,
         'trim_array_spaces' => true,
+        'unary_operator_spaces' => true,
         'visibility_required' => true,
         'void_return' => true,
         'whitespace_after_comma_in_array' => true,

--- a/include/email-validation.inc
+++ b/include/email-validation.inc
@@ -12,7 +12,7 @@ function is_emailable_address($email)
 {
     $email = filter_var($email, FILTER_VALIDATE_EMAIL);
     // No email, no validation
-    if (! $email) {
+    if (!$email) {
         return false;
     }
 


### PR DESCRIPTION
This pull request

- [x] enables the `unary_operator_spaces` fixer
- [x] runs `make coding-standards`

Follows #559.

💁‍♂️ For reference, see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.40.2/doc/rules/operator/unary_operator_spaces.rst.