### PR TITLE
Fix: Remove useless function

### DIFF
--- a/releases/8.2/common.php
+++ b/releases/8.2/common.php
@@ -4,12 +4,6 @@ namespace releases\php82;
 
 include_once __DIR__ . '/../../include/prepend.inc';
 
-function language_redirect(string $currentLang): void {
-    // We don't use the general language selection of php.net,
-    // so soldier on with this one.
-    return;
-}
-
 function common_header(string $description): void {
     global $MYSITE;
 

--- a/releases/8.2/release.inc
+++ b/releases/8.2/release.inc
@@ -2,7 +2,6 @@
 
 use function releases\php82\common_header;
 use function releases\php82\language_chooser;
-use function releases\php82\language_redirect;
 use function releases\php82\message;
 
 if (!isset($lang)) {
@@ -12,8 +11,6 @@ if (!isset($lang)) {
 $_SERVER['BASE_PAGE'] = 'releases/8.2/' . $lang . '.php';
 
 include_once __DIR__ . '/common.php';
-
-language_redirect($lang);
 
 common_header(message('common_header', $lang));
 

--- a/releases/8.3/common.php
+++ b/releases/8.3/common.php
@@ -4,12 +4,6 @@ namespace releases\php83;
 
 include_once __DIR__ . '/../../include/prepend.inc';
 
-function language_redirect(string $currentLang): void {
-    // We don't use the general language selection of php.net,
-    // so soldier on with this one.
-    return;
-}
-
 function common_header(string $description): void {
     global $MYSITE;
 

--- a/releases/8.3/release.inc
+++ b/releases/8.3/release.inc
@@ -2,7 +2,6 @@
 
 use function releases\php83\common_header;
 use function releases\php83\language_chooser;
-use function releases\php83\language_redirect;
 use function releases\php83\message;
 
 if (!isset($lang)) {
@@ -12,8 +11,6 @@ if (!isset($lang)) {
 $_SERVER['BASE_PAGE'] = 'releases/8.3/' . $lang . '.php';
 
 include_once __DIR__ . '/common.php';
-
-language_redirect($lang);
 
 common_header(message('common_header', $lang));
 


### PR DESCRIPTION
This pull request

- [x] removes a useless function 

💁‍♂️ Running

```shell
git grep -i language_redirect
```

on current `master` yields

```console
releases/8.2/common.php:7:function language_redirect(string $currentLang): void {
releases/8.2/release.inc:5:use function releases\php82\language_redirect;
releases/8.2/release.inc:16:language_redirect($lang);
releases/8.3/common.php:7:function language_redirect(string $currentLang): void {
releases/8.3/release.inc:5:use function releases\php83\language_redirect;
releases/8.3/release.inc:16:language_redirect($lang);
```