### PR TITLE
Fix: Wrapping

### DIFF
--- a/conferences/index.php
+++ b/conferences/index.php
@@ -50,10 +50,8 @@ $content .= "</div>";
 
 echo $content;
 
-site_footer(
-    [
-        "atom" => "/feed.atom",
-        "elephpants" => true,
-        "sidebar" => $panels,
-    ]
-);
+site_footer([
+    "atom" => "/feed.atom",
+    "elephpants" => true,
+    "sidebar" => $panels,
+]);

--- a/elephpant.php
+++ b/elephpant.php
@@ -35,8 +35,6 @@ site_header("ElePHPant", ["current" => "footer"]);
 
 <?php
 // Print the common footer.
-site_footer(
-    [
-        'elephpants' => true
-    ]
-);
+site_footer([
+    'elephpants' => true
+]);

--- a/index.php
+++ b/index.php
@@ -225,10 +225,8 @@ $announcements
 SIDEBAR_DATA;
 
 // Print the common footer.
-site_footer(
-    [
-        "atom" => "/feed.atom", // Add a link to the feed at the bottom
-        'elephpants' => true,
-        'sidebar' => $SIDEBAR
-    ]
-);
+site_footer([
+    "atom" => "/feed.atom", // Add a link to the feed at the bottom
+    'elephpants' => true,
+    'sidebar' => $SIDEBAR
+]);

--- a/sites.php
+++ b/sites.php
@@ -189,7 +189,7 @@ site_header("A Tourist's Guide", ["current" => "help"]);
 <h2 id="windows" class="content-header"><a href="https://windows.php.net/">windows.php.net</a>: PHP for Windows</h2>
 
 <p class="content-box">
- This site is dedicated to supporting PHP on Microsoft Windows. 
+ This site is dedicated to supporting PHP on Microsoft Windows.
  It also supports ports of PHP extensions or features as well as providing special builds for the various Windows architectures.
 </p>
 
@@ -222,8 +222,6 @@ $SIDEBAR = <<<SIDEBAR_DATA
 SIDEBAR_DATA;
 
 // Print the common footer.
-site_footer(
-    [
-        'sidebar' => $SIDEBAR
-    ]
-);
+site_footer([
+    'sidebar' => $SIDEBAR
+]);


### PR DESCRIPTION
This pull request

- [x] wraps the argument to `site_footer()` instead of the list of arguments

Somewhat related to #857.

💁‍♂️ Running

```shell
git grep -i site_footer\($
```

on current `master` yields

```console
conferences/index.php:53:site_footer(
elephpant.php:38:site_footer(
index.php:228:site_footer(
sites.php:225:site_footer(
```