### PR TITLE
Enhancement: Enable `function_declaration` fixer

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -29,6 +29,7 @@ $config
         ],
         'constant_case' => true,
         'elseif' => true,
+        'function_declaration' => true,
         'increment_style' => [
             'style' => 'post',
         ],

--- a/include/errors.inc
+++ b/include/errors.inc
@@ -123,7 +123,7 @@ The most commonly searched terms have also been added.
 TODO: Determine if we want to continue 301 -OR- make these official URLs.
 ******************************************************************************/
 
-function is_known_ini (string $ini): ?string {
+function is_known_ini(string $ini): ?string {
     $inis = [
         'engine' => 'apache.configuration.php#ini.engine',
         'short-open-tag' => 'ini.core.php#ini.short-open-tag',
@@ -366,7 +366,7 @@ function is_known_variable(string $variable): ?string {
     return $variables[ltrim($variable, '$')] ?? null;
 }
 
-function is_known_term (string $term): ?string {
+function is_known_term(string $term): ?string {
     $terms = [
         '<>' => 'language.operators.comparison.php',
         '<=>' => 'language.operators.comparison.php',

--- a/include/layout.inc
+++ b/include/layout.inc
@@ -140,7 +140,7 @@ function make_submit($file, $alt = false, $align = false, $extras = false,
 }
 
 // Return a hiperlink to something within the site
-function make_link (string $url, string $linktext = ''): string
+function make_link(string $url, string $linktext = ''): string
 {
     return sprintf("<a href=\"%s\">%s</a>", $url, $linktext ?: $url);
 }
@@ -148,7 +148,7 @@ function make_link (string $url, string $linktext = ''): string
 // make_popup_link()
 // return a hyperlink to something, within the site, that pops up a new window
 //
-function make_popup_link ($url, $linktext = false, $target = false, $windowprops = "", $extras = false) {
+function make_popup_link($url, $linktext = false, $target = false, $windowprops = "", $extras = false) {
     return sprintf("<a href=\"%s\" target=\"%s\" onclick=\"window.open('%s','%s','%s');return false;\"%s>%s</a>",
         htmlspecialchars($url, ENT_QUOTES | ENT_IGNORE),
         ($target ?: "_new"),


### PR DESCRIPTION
This pull request

- [x] enables the `function_declaration` fixer
- [x] runs `make coding-standards`

Follows #559.

💁‍♂️ For reference, see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.40.2/doc/rules/function_notation/function_declaration.rst.