### PR TITLE
Enhancement: Enable `class_definition` fixer

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -24,6 +24,7 @@ $config
         'array_syntax' => true,
         'binary_operator_spaces' => true,
         'class_attributes_separation' => true,
+        'class_definition' => true,
         'concat_space' => [
             'spacing' => 'one',
         ],

--- a/src/News/Entry.php
+++ b/src/News/Entry.php
@@ -2,7 +2,8 @@
 
 namespace phpweb\News;
 
-class Entry {
+class Entry
+{
     public const CATEGORIES = [
         'frontpage' => 'PHP.net frontpage news',
         'releases' => 'New PHP release',

--- a/src/UserNotes/Sorter.php
+++ b/src/UserNotes/Sorter.php
@@ -2,7 +2,8 @@
 
 namespace phpweb\UserNotes;
 
-class Sorter {
+class Sorter
+{
     private $maxVote;
 
     private $minVote;


### PR DESCRIPTION
This pull request

- [x] enables the `class_definition` fixer
- [x] runs `make coding-standards`

Follows #559.

💁‍♂️ For reference, see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.40.2/doc/rules/class_notation/class_definition.rst.