### PR TITLE
Fix: Do not pass `null` to function that expects `DateTime` or `string`

### DIFF
--- a/eol.php
+++ b/eol.php
@@ -48,7 +48,7 @@ site_header('Unsupported Branches');
 		<?php foreach (get_eol_branches() as $major => $branches): ?>
 			<?php foreach ($branches as $branch => $detail): ?>
 				<?php $eolDate = get_branch_security_eol_date($branch) ?>
-				<?php $eolPeriod = format_interval($eolDate, null) ?>
+				<?php $eolPeriod = format_interval($eolDate, new DateTime('now')) ?>
 					<tr>
 						<td><?php echo htmlspecialchars($branch); ?></td>
 						<td>

--- a/include/branches.inc
+++ b/include/branches.inc
@@ -43,11 +43,10 @@ $BRANCHES = [
  * page. (Currently 28 days.) */
 $KEEP_EOL = new DateInterval('P28D');
 
-function format_interval($from, $to) {
+function format_interval($from, DateTime $to) {
     try {
         $from_obj = $from instanceof DateTime ? $from : new DateTime($from);
-        $to_obj = $to instanceof DateTime ? $to : new DateTime($to);
-        $diff = $to_obj->diff($from_obj);
+        $diff = $to->diff($from_obj);
 
         $times = [];
         if ($diff->y) {

--- a/supported-versions.php
+++ b/supported-versions.php
@@ -54,6 +54,7 @@ $VERSION_NOTES = [
                 $initial = get_branch_release_date($branch);
                 $until = get_branch_bug_eol_date($branch);
                 $eol = get_branch_security_eol_date($branch);
+                $now = new DateTime('now');
                 ?>
 				<tr class="<?php echo $state ?>">
 					<td>
@@ -63,11 +64,11 @@ $VERSION_NOTES = [
 						<?php endif ?>
 					</td>
 					<td><?php echo htmlspecialchars($initial->format('j M Y')) ?></td>
-					<td class="collapse-phone"><em><?php echo htmlspecialchars(format_interval($initial, null)) ?></em></td>
+					<td class="collapse-phone"><em><?php echo htmlspecialchars(format_interval($initial, $now)) ?></em></td>
 					<td><?php echo htmlspecialchars($until->format('j M Y')) ?></td>
-					<td class="collapse-phone"><em><?php echo htmlspecialchars(format_interval($until, null)) ?></em></td>
+					<td class="collapse-phone"><em><?php echo htmlspecialchars(format_interval($until, $now)) ?></em></td>
 					<td><?php echo htmlspecialchars($eol->format('j M Y')) ?></td>
-					<td class="collapse-phone"><em><?php echo htmlspecialchars(format_interval($eol, null)) ?></em></td>
+					<td class="collapse-phone"><em><?php echo htmlspecialchars(format_interval($eol, $now)) ?></em></td>
 				</tr>
 			<?php endforeach ?>
 		<?php endforeach ?>


### PR DESCRIPTION
This pull request

- [x] stops passing `null` to a function that expects `DateTime` or `string`

### Before

See http://localhost:8080/supported-versions.php:

<img width="2672" alt="CleanShot 2023-12-06 at 16 59 45@2x" src="https://github.com/php/web-php/assets/605483/679b0ad4-7ca2-451e-9c4d-5acdd23f13b2">


### After

See http://localhost:8080/supported-versions.php:


<img width="2672" alt="CleanShot 2023-12-06 at 17 00 03@2x" src="https://github.com/php/web-php/assets/605483/4fb29d78-2208-4b11-b74b-1c2634326a34">

