### PR TITLE
Enhancement: Enable `blank_line_after_namespace` fixer

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -23,6 +23,7 @@ $config
         'array_indentation' => true,
         'array_syntax' => true,
         'binary_operator_spaces' => true,
+        'blank_line_after_namespace' => true,
         'class_attributes_separation' => true,
         'class_definition' => true,
         'concat_space' => [

--- a/releases/8.0/common.php
+++ b/releases/8.0/common.php
@@ -1,6 +1,7 @@
 <?php declare(strict_types=1);
 
 namespace releases\php80;
+
 include_once __DIR__ . '/../../include/prepend.inc';
 
 function common_header(string $description): void {


### PR DESCRIPTION
This pull request

- [x] enables the `blank_line_after_namespace` fixer
- [x] runs `make coding-standards`

Follows #559.

💁‍♂️ For reference, see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.40.2/doc/rules/namespace_notation/blank_line_after_namespace.rst.