### PR TITLE
Enhancement: Enable `blank_line_after_opening_tag` fixer

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -24,6 +24,7 @@ $config
         'array_syntax' => true,
         'binary_operator_spaces' => true,
         'blank_line_after_namespace' => true,
+        'blank_line_after_opening_tag' => true,
         'class_attributes_separation' => true,
         'class_definition' => true,
         'concat_space' => [

--- a/.router.php
+++ b/.router.php
@@ -1,4 +1,5 @@
 <?php
+
 $_SERVER["SERVER_ADDR"] = $_SERVER["HTTP_HOST"];
 
 $filename = $_SERVER["PATH_INFO"] ?? $_SERVER["SCRIPT_NAME"];

--- a/archive/index.php
+++ b/archive/index.php
@@ -1,4 +1,5 @@
 <?php
+
 include_once __DIR__ . '/../include/prepend.inc';
 $i = 0;
 do {

--- a/backend/index.php
+++ b/backend/index.php
@@ -1,4 +1,5 @@
 <?php
+
 // Simulate a /backend shortcut call (which will lead to a manual page)
 $_SERVER['REQUEST_URI'] = '/backend';
 include_once __DIR__ . '/../include/prepend.inc';

--- a/bin/index.php
+++ b/bin/index.php
@@ -1,4 +1,5 @@
 <?php
+
 // Simulate a /bin shortcut call (which will lead to a manual page)
 $_SERVER['REQUEST_URI'] = '/bin';
 include_once __DIR__ . '/../include/prepend.inc';

--- a/conferences/index.php
+++ b/conferences/index.php
@@ -1,4 +1,5 @@
 <?php
+
 $_SERVER['BASE_PAGE'] = 'conferences/index.php';
 include_once __DIR__ . '/../include/prepend.inc';
 include_once __DIR__ . '/../include/pregen-news.inc';

--- a/credits.php
+++ b/credits.php
@@ -1,4 +1,5 @@
 <?php
+
 $_SERVER['BASE_PAGE'] = 'credits.php';
 include_once __DIR__ . '/include/prepend.inc';
 

--- a/images/elephpants.php
+++ b/images/elephpants.php
@@ -1,4 +1,5 @@
 <?php
+
 include_once __DIR__ . '/../include/prepend.inc';
 
 $now = $_SERVER["REQUEST_TIME"];

--- a/images/index.php
+++ b/images/index.php
@@ -1,4 +1,5 @@
 <?php
+
 // Simulate a /images shortcut call (which will lead to a manual page)
 $_SERVER['REQUEST_URI'] = '/images';
 include_once __DIR__ . '/../include/prepend.inc';

--- a/include/branches.inc
+++ b/include/branches.inc
@@ -1,4 +1,5 @@
 <?php
+
 include_once __DIR__ . '/releases.inc';
 include_once __DIR__ . '/version.inc';
 

--- a/include/changelogs.inc
+++ b/include/changelogs.inc
@@ -1,4 +1,5 @@
 <?php
+
 function bugfix($number): void {
     echo "Fixed bug "; bugl($number);
 }

--- a/include/countries.inc
+++ b/include/countries.inc
@@ -1,4 +1,5 @@
 <?php
+
 return [
     'AFG' => 'Afghanistan',
     'ALB' => 'Albania',

--- a/include/historical_mirrors.inc
+++ b/include/historical_mirrors.inc
@@ -1,4 +1,5 @@
 <?php
+
 $historical_mirrors = [
     ["ARG", "ar2.php.net", "XMundo Hosting Solutions", "http://www.xmundo.net"],
     ["ARM", "am1.php.net", "ARMINCO Global Telecommunications", "http://www.arminco.com/"],

--- a/include/index.php
+++ b/include/index.php
@@ -1,4 +1,5 @@
 <?php
+
 // Simulate a /include shortcut call (which will lead to a manual page)
 $_SERVER['REQUEST_URI'] = '/include';
 include_once __DIR__ . '/prepend.inc';

--- a/include/results.inc
+++ b/include/results.inc
@@ -1,4 +1,5 @@
 <?php
+
 function search_results($res, $q, $profile = 'all', $per_page = 10, $s = 0, $l = 'en', $show_title = true, $show_foot = true, $show_attrib = true): void {
     $start_result = $s;
     $end_result = $s + $res['ResultSet']['totalResultsReturned'] - 1;

--- a/index.php
+++ b/index.php
@@ -1,4 +1,5 @@
 <?php
+
 (function ($uri): void {
     // Special redirect cases not able to be captured in error.php
     $shortcuts = [

--- a/js/search-index.php
+++ b/js/search-index.php
@@ -1,4 +1,5 @@
 <?php
+
 $_GET["lang"] = "en";
 if (!isset($_GET["lang"])) {
     header("Location: http://php.net");

--- a/manual-lookup.php
+++ b/manual-lookup.php
@@ -1,4 +1,5 @@
 <?php
+
 $_SERVER['BASE_PAGE'] = 'manual-lookup.php';
 include __DIR__ . '/include/prepend.inc';
 include __DIR__ . '/include/manual-lookup.inc';

--- a/manual/change.php
+++ b/manual/change.php
@@ -1,4 +1,5 @@
 <?php
+
 include_once __DIR__ . '/../include/prepend.inc';
 
 $page = isset($_GET['page']) ? htmlspecialchars($_GET['page'], ENT_QUOTES, 'UTF-8') : '';

--- a/manual/index.php
+++ b/manual/index.php
@@ -1,3 +1,4 @@
 <?php
+
 include_once __DIR__ . '/../include/prepend.inc';
 mirror_redirect("/manual/$LANG/index.php");

--- a/manual/spam_challenge.php
+++ b/manual/spam_challenge.php
@@ -1,4 +1,5 @@
 <?php
+
 // simple and stupid SPAM protection (using little challenges)
 
 const NUMS = ['zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine'];

--- a/mirror-info.php
+++ b/mirror-info.php
@@ -1,4 +1,5 @@
 <?php
+
 // Define $MYSITE and $LAST_UPDATED variables
 include_once __DIR__ . '/include/prepend.inc';
 

--- a/mirrors.php
+++ b/mirrors.php
@@ -1,4 +1,5 @@
 <?php
+
 include_once __DIR__ . '/include/prepend.inc';
 
 header("HTTP/1.1 301 Moved Permanently");

--- a/pear/index.php
+++ b/pear/index.php
@@ -1,4 +1,5 @@
 <?php
+
 // Simulate a /pear shortcut call (which will lead to a manual page)
 $_SERVER['REQUEST_URI'] = '/pear';
 include_once __DIR__ . '/../include/prepend.inc';

--- a/releases/8.0/common.php
+++ b/releases/8.0/common.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace releases\php80;
 

--- a/releases/8.0/index.php
+++ b/releases/8.0/index.php
@@ -1,4 +1,5 @@
 <?php
+
  $_SERVER['BASE_PAGE'] = 'releases/8.0/index.php';
 include __DIR__ . '/../../include/site.inc';
 

--- a/releases/8.1/common.php
+++ b/releases/8.1/common.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace releases\php81;
 

--- a/releases/8.1/index.php
+++ b/releases/8.1/index.php
@@ -1,4 +1,5 @@
 <?php
+
  $_SERVER['BASE_PAGE'] = 'releases/8.1/index.php';
 include __DIR__ . '/../../include/site.inc';
 

--- a/releases/8.2/common.php
+++ b/releases/8.2/common.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace releases\php82;
 

--- a/releases/8.2/index.php
+++ b/releases/8.2/index.php
@@ -1,4 +1,5 @@
 <?php
+
  $_SERVER['BASE_PAGE'] = 'releases/8.2/index.php';
 include __DIR__ . '/../../include/site.inc';
 

--- a/releases/8.3/common.php
+++ b/releases/8.3/common.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace releases\php83;
 

--- a/releases/8.3/index.php
+++ b/releases/8.3/index.php
@@ -1,4 +1,5 @@
 <?php
+
  $_SERVER['BASE_PAGE'] = 'releases/8.3/index.php';
 include __DIR__ . '/../../include/site.inc';
 

--- a/releases/active.php
+++ b/releases/active.php
@@ -1,4 +1,5 @@
 <?php
+
 $_SERVER['BASE_PAGE'] = 'releases/active.php';
 
 include_once __DIR__ . '/../include/prepend.inc';

--- a/releases/feed.php
+++ b/releases/feed.php
@@ -1,4 +1,5 @@
 <?php
+
 header("Content-Type: application/atom+xml");
 
 include __DIR__ . "/../include/version.inc";

--- a/releases/index.php
+++ b/releases/index.php
@@ -1,4 +1,5 @@
 <?php
+
 $_SERVER['BASE_PAGE'] = 'releases/index.php';
 include_once __DIR__ . '/../include/prepend.inc';
 include_once __DIR__ . "/../include/branches.inc";

--- a/releases/states.php
+++ b/releases/states.php
@@ -1,4 +1,5 @@
 <?php
+
 $_SERVER['BASE_PAGE'] = 'releases/active.php';
 
 include_once __DIR__ . '/../include/prepend.inc';

--- a/results.php
+++ b/results.php
@@ -1,4 +1,5 @@
 <?php
+
 $_SERVER['BASE_PAGE'] = 'results.php';
 include __DIR__ . '/include/prepend.inc';
 include __DIR__ . '/include/results.inc';

--- a/search.php
+++ b/search.php
@@ -1,4 +1,5 @@
 <?php
+
 $_SERVER['BASE_PAGE'] = 'search.php';
 include_once __DIR__ . '/include/prepend.inc';
 

--- a/styles/index.php
+++ b/styles/index.php
@@ -1,4 +1,5 @@
 <?php
+
 // Simulate a /styles shortcut call (which will lead to a manual page)
 $_SERVER['REQUEST_URI'] = '/styles';
 include_once __DIR__ . '/../include/prepend.inc';


### PR DESCRIPTION
This pull request

- [x] enables the `blank_line_after_opening_tag` fixer
- [x] runs `make coding-standards`

Follows #559.

💁‍♂️ For reference, see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.40.2/doc/rules/php_tag/blank_line_after_opening_tag.rst.