### PR TITLE
Enhancement: Enable `ternary_operator_spaces` fixer

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -51,6 +51,7 @@ $config
         ],
         'strict_param' => true,
         'switch_case_space' => true,
+        'ternary_operator_spaces' => true,
         'trailing_comma_in_multiline' => [
             'elements' => [
                 'arguments',


### PR DESCRIPTION
This pull request

- [x] enables the `ternary_operator_spaces` fixer
- [ ] runs `make coding-standards`

Follows #559.

💁‍♂️ For reference, see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.40.2/doc/rules/operator/ternary_operator_spaces.rst.