### PR TITLE
Enhancement: Enable `no_singleline_whitespace_before_semicolons` fixer

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -41,6 +41,7 @@ $config
         'new_with_parentheses' => true,
         'no_extra_blank_lines' => true,
         'no_mixed_echo_print' => true,
+        'no_singleline_whitespace_before_semicolons' => true,
         'no_trailing_whitespace' => true,
         'ordered_class_elements' => true,
         'random_api_migration' => true,

--- a/include/errors.inc
+++ b/include/errors.inc
@@ -582,7 +582,7 @@ function get_legacy_manual_urls(string $uri): array
         if (count($matches) < 2) {
             return '';
         }
-        return $matches[1] ;
+        return $matches[1];
     }, $uri);
 
     if (!isset($pages_ids[$page_id])) {


### PR DESCRIPTION
This pull request

- [x] enables the `no_singleline_whitespace_before_semicolons` fixer
- [x] runs `make coding-standards`

Follows #559.

💁‍♂️ For reference, see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.40.2/doc/rules/semicolon/no_singleline_whitespace_before_semicolons.rst.