### PR TITLE
Enhancement: Enable `no_superfluous_elseif` fixer

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -42,6 +42,7 @@ $config
         'no_extra_blank_lines' => true,
         'no_mixed_echo_print' => true,
         'no_singleline_whitespace_before_semicolons' => true,
+        'no_superfluous_elseif' => true,
         'no_trailing_whitespace' => true,
         'ordered_class_elements' => true,
         'random_api_migration' => true,

--- a/include/layout.inc
+++ b/include/layout.inc
@@ -212,9 +212,9 @@ function sect_to_file($string) {
     $feat = "features.$string.php";
     $struct = "control-structures.$string.php";
     if (@is_file($func)) return $func;
-    elseif (@is_file($chap)) return $chap;
-    elseif (@is_file($feat)) return $feat;
-    elseif (@is_file($struct)) return $struct;
+    if (@is_file($chap)) return $chap;
+    if (@is_file($feat)) return $feat;
+    if (@is_file($struct)) return $struct;
     else return "$string.php";
 }
 


### PR DESCRIPTION
This pull request

- [x] enables the `no_superfluous_elseif` fixer
- [x] runs `make coding-standards`

Follows #559.

💁‍♂️ For reference, see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.40.2/doc/rules/control_structure/no_superfluous_elseif.rst.