### PR TITLE
Enhancement: Enable `include` fixer

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -32,6 +32,7 @@ $config
         'constant_case' => true,
         'elseif' => true,
         'function_declaration' => true,
+        'include' => true,
         'increment_style' => [
             'style' => 'post',
         ],


### PR DESCRIPTION
This pull request

- [x] enables the `include` fixer
- [x] runs `make coding-standards`

Follows #559.

💁‍♂️ For reference, see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.40.2/doc/rules/control_structure/include.rst.