### PR TITLE
Fix: Do not pass `null` to function that expects `string`

### DIFF
--- a/include/version.inc
+++ b/include/version.inc
@@ -82,7 +82,7 @@ $RELEASES = (function () {
 function release_get_latest() {
     global $RELEASES;
 
-    $version = null;
+    $version = '0.0.0';
     $current = null;
     foreach ($RELEASES as $versions) {
         foreach ($versions as $ver => $info) {


### PR DESCRIPTION
This pull request

- [x] stops passing `null` to a function that expects `string`

Spotted in #900.


💁‍♂️ In the first iteration of the inner `foreach`-loop, `$version` is `null`:

https://github.com/php/web-php/blob/e1c61689ade5ce4264e575a0a80fe03d349d670a/include/version.inc#L85-L89