### PR TITLE
Fix: Explicitly configure `dots` progress reporter

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -50,7 +50,7 @@ jobs:
         run: "composer install --ansi --no-interaction --no-progress"
 
       - name: "Run friendsofphp/php-cs-fixer"
-        run: "vendor/bin/php-cs-fixer fix --ansi --config=.php-cs-fixer.php --diff --dry-run --verbose"
+        run: "vendor/bin/php-cs-fixer fix --ansi --config=.php-cs-fixer.php --diff --dry-run --show-progress=dots --verbose"
         env:
           PHP_CS_FIXER_IGNORE_ENV: "1"
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ help: ## Displays this list of targets with descriptions
 
 .PHONY: coding-standards
 coding-standards: vendor ## Fixes code style issues with friendsofphp/php-cs-fixer
-	vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.php --diff --verbose
+	vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.php --diff --show-progress=dots --verbose
 
 .PHONY: tests
 tests: ## Runs tests


### PR DESCRIPTION
This pull request

- [x] explicitly configures the `dots` progress reporter

Related to #908.

💁‍♂️ Beginning with `friendsofphp/php-cs-fixer:^3.45.0`, the bar progress printer becomes the new default progress printer.