### PR TITLE
Fix: Run `friendsofphp/php-cs-fixer` on `src/` and `tests/` only

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -6,16 +6,11 @@ $config = new PhpCsFixer\Config();
 
 $finder = $config->getFinder()
     ->ignoreDotFiles(false)
-    ->in(__DIR__)
-    ->exclude('manual/en/')
-    ->name('*.inc')
-    ->name('.php-cs-fixer.php')
-    ->notPath('include/last_updated.inc')
-    ->notPath('include/pregen-confs.inc')
-    ->notPath('include/pregen-news.inc')
-    ->notPath('include/releases.inc')
-    ->notPath('include/version.inc')
-    ->notPath('tests/run-tests.php');
+    ->in([
+        __DIR__ . '/src',
+        __DIR__ . '/tests',
+    ])
+    ->notName('run-tests.php');
 
 $config
     ->setRiskyAllowed(true)


### PR DESCRIPTION
This pull request

- [x] runs `friendsofphp/php-cs-fixer` on `src/` and `tests/` only