### PR TITLE
Enhancement: Split test suite

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -95,8 +95,11 @@ jobs:
       - name: "Install dependencies with composer"
         run: "composer install --ansi --no-interaction --no-progress"
 
+      - name: "Run unit tests with phpunit/phpunit"
+        run: "vendor/bin/phpunit --colors=always --configuration=tests/phpunit.xml --testsuite=unit"
+
       - name: "Start built-in web server for PHP"
         run: "php -S ${{ env.HTTP_HOST }} .router.php &"
 
-      - name: "Run phpunit/phpunit"
-        run: "vendor/bin/phpunit --colors=always --configuration=tests/phpunit.xml"
+      - name: "Run end-to-end tests with phpunit/phpunit"
+        run: "vendor/bin/phpunit --colors=always --configuration=tests/phpunit.xml --testsuite=end-to-end"

--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,10 @@ coding-standards: vendor ## Fixes code style issues with friendsofphp/php-cs-fix
 	vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.php --diff --show-progress=dots --verbose
 
 .PHONY: tests
-tests: vendor ## Runs tests with phpunit/phpunit
+tests: vendor ## Runs unit and end-to-end tests with phpunit/phpunit
+	vendor/bin/phpunit --configuration=tests/phpunit.xml --testsuite=unit
 	rm -rf tests/server.log
-	tests/server start; vendor/bin/phpunit --configuration=tests/phpunit.xml; tests/server stop
+	tests/server start; vendor/bin/phpunit --configuration=tests/phpunit.xml --testsuite=end-to-end; tests/server stop
 
 vendor: composer.json composer.lock
 	composer validate --strict

--- a/tests/Unit/UserNotes/Sorter/sort-no-notes.phpt
+++ b/tests/Unit/UserNotes/Sorter/sort-no-notes.phpt
@@ -8,7 +8,7 @@ precision=-1
 use phpweb\UserNotes\Sorter;
 use phpweb\UserNotes\UserNote;
 
-require_once __DIR__ . "/../../../src/autoload.php";
+require_once __DIR__ . "/../../../../src/autoload.php";
 
 $notes = [];
 

--- a/tests/Unit/UserNotes/Sorter/sort-notes-full.phpt
+++ b/tests/Unit/UserNotes/Sorter/sort-notes-full.phpt
@@ -8,9 +8,9 @@ precision=-1
 use phpweb\UserNotes\Sorter;
 use phpweb\UserNotes\UserNote;
 
-require_once __DIR__ . "/../../../src/autoload.php";
+require_once __DIR__ . "/../../../../src/autoload.php";
 
-$file = file(__DIR__ . "/../../../backend/notes/d7/d7742c269d23ea86");
+$file = file(__DIR__ . "/../../../../backend/notes/d7/d7742c269d23ea86");
 $notes = [];
 foreach ($file as $line) {
     @list($id, $sect, $rate, $ts, $user, $note, $up, $down) = explode("|", $line);

--- a/tests/Unit/UserNotes/Sorter/sort-single-note-with-no-votes.phpt
+++ b/tests/Unit/UserNotes/Sorter/sort-single-note-with-no-votes.phpt
@@ -8,7 +8,7 @@ precision=-1
 use phpweb\UserNotes\Sorter;
 use phpweb\UserNotes\UserNote;
 
-require_once __DIR__ . "/../../../src/autoload.php";
+require_once __DIR__ . "/../../../../src/autoload.php";
 
 $notes = [
     new UserNote('1', '', '', '1613487094', '', '', 0, 0),

--- a/tests/Unit/UserNotes/Sorter/sort-some-notes.phpt
+++ b/tests/Unit/UserNotes/Sorter/sort-some-notes.phpt
@@ -8,7 +8,7 @@ precision=-1
 use phpweb\UserNotes\Sorter;
 use phpweb\UserNotes\UserNote;
 
-require_once __DIR__ . "/../../../src/autoload.php";
+require_once __DIR__ . "/../../../../src/autoload.php";
 
 $notes = [
     new UserNote('1', '', '', '1613487094', '', '', 0, 2),

--- a/tests/Unit/clean-anti-spam.phpt
+++ b/tests/Unit/clean-anti-spam.phpt
@@ -3,7 +3,7 @@ clean_AntiSPAM() removes spam terms
 --FILE--
 <?php
 
-require_once __DIR__ . '/../include/email-validation.inc';
+require_once __DIR__ . '/../../include/email-validation.inc';
 
 $emails = array (
     'asasasd324324@php.net',

--- a/tests/Unit/gen-challenge.phpt
+++ b/tests/Unit/gen-challenge.phpt
@@ -3,7 +3,7 @@ gen_challenge() generates a spam challenge
 --FILE--
 <?php
 
-require_once __DIR__ . '/../manual/spam_challenge.php';
+require_once __DIR__ . '/../../manual/spam_challenge.php';
 
 mt_srand(9001);
 

--- a/tests/Unit/is-emailable-address.phpt
+++ b/tests/Unit/is-emailable-address.phpt
@@ -3,7 +3,7 @@ is_emailable_address() returns whether email is emailable
 --FILE--
 <?php
 
-require_once __DIR__ . '/../include/email-validation.inc';
+require_once __DIR__ . '/../../include/email-validation.inc';
 
 $emails = array(
     'asasasd324324@php.net',

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -32,7 +32,10 @@
     </source>
     <testsuites>
         <testsuite name="end-to-end">
-            <directory suffix=".phpt">.</directory>
+            <directory suffix=".phpt">EndToEnd/</directory>
+        </testsuite>
+        <testsuite name="unit">
+            <directory suffix=".phpt">Unit/</directory>
         </testsuite>
     </testsuites>
 </phpunit>


### PR DESCRIPTION
This pull request

- [x] splits the test suite

Follows #605.

💁‍♂️ Splitting the test suite could have the following advantages:

- we could cater to different bootstrapping requirements
  - end-to-end tests require a server to be running
  - unit tests require autoloading to be set uo
- we could now start using `PHPUnit\Framework\TestCase` for tests where appropriate (and document corresponding namespaces in `composer.json` via `autoload-dev`
