### PR TITLE
Fix: Provide token

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -58,6 +58,7 @@ jobs:
         uses: "codecov/codecov-action@v4.0.1"
         with:
           files: ".build/phpunit/logs/clover.xml"
+          token: "${{ secrets.CODECOV_TOKEN }}"
 
   coding-standards:
     name: "Coding Standards"


### PR DESCRIPTION
This pull request

- [x] provides a token when reporting code coverage

Follows #944.

💁‍♂️ Needs a `CODECOV_TOKEN` secret to be proved, ideally for both

- https://github.com/php/web-php/settings/secrets/actions
- https://github.com/php/web-php/settings/secrets/dependabot

For reference, see 

- https://github.com/codecov/codecov-action?tab=readme-ov-file#v4-release 
- https://github.com/php/web-php/pull/945#issuecomment-1941704779