### PR TITLE
Add DPC 2024 schedule + trainings

### DIFF
--- a/archive/archive.xml
+++ b/archive/archive.xml
@@ -9,6 +9,7 @@
     <uri>http://php.net/contact</uri>
     <email>php-webmaster@lists.php.net</email>
   </author>
+  <xi:include href="entries/2024-02-13-1.xml"/>
   <xi:include href="entries/2024-01-30-1.xml"/>
   <xi:include href="entries/2024-01-24-1.xml"/>
   <xi:include href="entries/2024-01-20-1.xml"/>

--- a/archive/entries/2024-02-13-1.xml
+++ b/archive/entries/2024-02-13-1.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<entry xmlns="http://www.w3.org/2005/Atom" xmlns:default="http://php.net/ns/news">
+  <title/>
+  <id>https://www.php.net/archive/2024.php#2024-02-13-1</id>
+  <published>2024-02-13T05:23:52+00:00</published>
+  <updated>2024-02-13T05:23:52+00:00</updated>
+  <link href="https://www.php.net/conferences/index.php#2024-02-13-1" rel="alternate" type="text/html"/>
+  <link href="https://phpconference.nl/schedule-2024/" rel="via" type="text/html"/>
+  <default:finalTeaserDate xmlns="http://php.net/ns/news">2024-03-12</default:finalTeaserDate>
+  <category term="conferences" label="Conference announcement"/>
+  <default:newsImage xmlns="http://php.net/ns/news" link="https://phpconference.nl/schedule-2024/" title="Dutch PHP Conference 2024">DPC-logo.png</default:newsImage>
+  <content type="xhtml">
+    <div xmlns="http://www.w3.org/1999/xhtml">
+     <p>Get ready for 4 days of the Dutch PHP Conference 2024 - In Person Edition 🔥 ! Two training days, a tutorial day and a conference day.</p>
+     <p><strong>Training day 1 &amp; 2</strong></p>
+     <p>We are offering 2 in-depth workshop days this year, to dive into a particular topic together with an experienced coach &amp; speaker:</p>
+     <ul>
+      <li><a href="https://phpconference.nl/session/dockerizing-php-applications-part-1/">Dockerizing PHP Applications</a> by Nic Wortel (2 workshop days - Tuesday &amp; Wednesday)</li>
+      <li><a href="https://phpconference.nl/session/advanced-typescript-workshop-part-1/">Advanced TypeScript Workshop</a> by Craig Spence (1 workshop day - Tuesday)</li>
+      <li><a href="https://phpconference.nl/session/lessons-learned-from-playing-terrible-games-part-1/">Lessons learned from playing terrible games</a> by Ramon de la Fuente (1 workshop day - Wednesday)</li>
+      <li><a href="https://phpconference.nl/session/effective-unit-testing-part-1/">Effective Unit Testing</a> by Mark Niebergall (1 workshop day - Wednesday)</li>
+     </ul>
+     <p>The location of DPC this year is <a href="https://phpconference.nl/event-info/">Pathe Amsterdam Noord</a>, so you can also go for the Movie Passe-partout and catch a movie in case you have some free time left. 🎥</p>
+     <p><strong>Tutorial day &amp; conference day</strong></p>
+     <p>In addition to the training days, we will offer a tutorial day and conference day. The full schedule can be found <a href="https://phpconference.nl/schedule-2024/">here</a>. We also hope to see you at our after party in the <a href="https://www.hollywoodcafe.nl/hollywoodcafe-amsterdam/">hollywood cafe</a> after the conference on Friday!</p>
+     <p>We look forward to meeting you all in Amsterdam from 12 to 15 March! Mark those calendars! </p>
+     <p>Follow us on <a href="https://twitter.com/dpcon">𝕏</a> &amp; <a href="https://mastodon.social/@dpc_ibuildings">M</a></p>
+    </div>
+  </content>
+</entry>


### PR DESCRIPTION
This adds the announcement of the Dutch PHP Conference 2023 schedule and trainings. Thanks!

FYI: used the logo from previous editions to not add unnecessary files and disk space ;)