### PR TITLE
Fix: Do not report code coverage to codecov.io

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -52,12 +52,7 @@ jobs:
       - name: "Collect code coverage from running unit tests with phpunit/phpunit"
         env:
           XDEBUG_MODE: "coverage"
-        run: "vendor/bin/phpunit --colors=always --configuration=tests/phpunit.xml --coverage-clover=.build/phpunit/logs/clover.xml --testsuite=unit"
-
-      - name: "Send code coverage report to codecov.io"
-        uses: "codecov/codecov-action@v4"
-        with:
-          files: ".build/phpunit/logs/clover.xml"
+        run: "vendor/bin/phpunit --colors=always --configuration=tests/phpunit.xml --coverage-text --testsuite=unit"
 
   coding-standards:
     name: "Coding Standards"


### PR DESCRIPTION
This pull request

- [x] stops reporting code coverage to [codecov.io](https://codecov.io)

Follows #944.