### PR TITLE
Fix: Remove duplicate target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,6 @@ code-coverage: vendor ## Collects code coverage from running unit tests with php
 help: ## Displays this list of targets with descriptions
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[32m%-30s\033[0m %s\n", $$1, $$2}'
 
-.PHONY: code-coverage
-code-coverage: vendor ## Collects coverage from running tests with phpunit/phpunit
-	tests/server start; vendor/bin/phpunit --configuration=tests/phpunit.xml --coverage-text; tests/server stop
-
 .PHONY: coding-standards
 coding-standards: vendor ## Fixes code style issues with friendsofphp/php-cs-fixer
 	vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.php --diff --show-progress=dots --verbose


### PR DESCRIPTION
This pull request

- [x] removes a duplicate target from `Makefile`

Follows #944.