### PR TITLE
Fix: Move cache file to `.build/php-cs-fixer/`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,3 @@ backend/mirror.jpg
 backend/GeoIP.dat
 tests/server.log
 tests/server.pid
-.php-cs-fixer.cache

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -13,6 +13,7 @@ $finder = $config->getFinder()
     ->notName('run-tests.php');
 
 $config
+    ->setCacheFile(__DIR__ . '/.build/php-cs-fixer/php-cs-fixer.cache')
     ->setRiskyAllowed(true)
     ->setRules([
         'array_indentation' => true,


### PR DESCRIPTION
This pull request

- [x] moves the cache file for `friendsofphp/php-cs-fixer` to `.build/php-cs-fixer/`