### PR TITLE
Reflect move to mlmmj

### DIFF
--- a/mailing-lists.php
+++ b/mailing-lists.php
@@ -374,9 +374,9 @@ function output_lists_table($mailing_lists): void
  If you experience trouble subscribing via the form above, you may also
  subscribe by sending an email to the list server.
  To subscribe to any mailing list, send an email to
- <code><em>listname</em>-subscribe@lists.php.net</code>
+ <code><em>listname</em>+subscribe@lists.php.net</code>
  (substituting the name of the list for <code><em>listname</em></code>
- &mdash; for example, <code>php-general-subscribe@lists.php.net</code>).
+ &mdash; for example, <code>php-general+subscribe@lists.php.net</code>).
 </p>
 
 <h2>Mailing list options</h2>
@@ -384,11 +384,13 @@ function output_lists_table($mailing_lists): void
 <p>
  All of the mailing lists hosted at <a
  href="http://lists.php.net/">lists.php.net</a> are managed using the <a
- href="http://untroubled.org/ezmlm/">ezmlm-idx</a> mailing list software.
+ href="http://mlmmj.org/">mlmmj</a> mailing list software.
+ <!--
  There are a variety of commands you can use to modify your subscription.
- Either send a message to <code>php-whatever-help@lists.php.net</code> (as in,
- <code>php-general-help@lists.php.net</code>) or you can view the commands for
- ezmlm <a href="http://untroubled.org/ezmlm/ezman/ezman1.html">here.</a>
+ Either send a message to <code>php-whatever+help@lists.php.net</code> (as in,
+ <code>php-general+help@lists.php.net</code>) or you can view the commands for
+ mlmmj <a href="http://untroubled.org/ezmlm/ezman/ezman1.html">here.</a>
+ -->
 </p>
 
 <?php site_footer(); ?>


### PR DESCRIPTION
This commit removes everthing related to ezmlm and replaces that with the corresponding info for mlmmj