### PR TITLE
Add style for captions

### DIFF
--- a/styles/theme-base.css
+++ b/styles/theme-base.css
@@ -1899,3 +1899,6 @@ aside.tips div.inner {
 
 /* }}} */
 
+.caption {
+  font-size: 0.85rem;
+}


### PR DESCRIPTION
There is now one caption (as in a `<caption>` tag in docbook) used in `doc-en` under the `xkcd` image on [`goto`'s page](https://www.php.net/manual/en/control-structures.goto.php). I've already opened a PR for Phd ([here](https://github.com/php/phd/pull/109)) which wraps the text of the caption in a `div` with the class `caption`. This PR adds formatting to that class.