### PR TITLE
Revert "Enable Polish translation again", for now

### DIFF
--- a/include/languages.inc
+++ b/include/languages.inc
@@ -30,6 +30,7 @@ $LANGUAGES = [
  - http://docs.php.net/
 */
 $INACTIVE_ONLINE_LANGUAGES = [
+    'pl' => 'Polish',
     'ro' => 'Romanian',
     'uk' => 'Ukrainian',
 ];


### PR DESCRIPTION
This reverts commit 70bd5e0aa9134022e3c2269a7c72dbb3b1ab0fdd.

While the docs do build, I belive there's at least a few specific action points we should tackle before we open them up to the world.

I really wanna avoid going into the infinite beta mode, i.e. "lemme just do this _>>one more thing<<_ and then we'll surely release" but at the same time I want to stay responsible and as such, I wanna make sure few things are done before we start showing this up for people in Poland.

- [ ] some infra problem, the Polish option does appear in the select but it leads to 404
- [ ] getting rid of some terribly outdated pages: to stay specific I would say lets at least deal with files without En-Revision in most used `reference/*` directories
- [ ] update parameter names to match the PHP's source code: while many files are technically up-to-date (from revcheck's standpoint) they are using translated parameter names. I believe this is what all documentations used to do in the old days. Now that we have named parameters it means that people will get invalid information from the manual. I hope that there's some script in doc-base that I can utilize to find such cases, otherwise I might end up writing something myself
- [ ] generally speaking I believe we should run all kinds of QA scripts that are available. Better to do it now that the documentation is small rather than much later
- [x] minor point: I remembered now that there are some translations embedded in the phd itself. I think I even wrote a script eons ago that can show if the files went out of sync with the English version. I have no clue if phd received much love in recent years but the Polish translations file in its repo should be checked as well