### PR TITLE
Make replaceable class text italic

### DIFF
--- a/styles/theme-medium.css
+++ b/styles/theme-medium.css
@@ -603,3 +603,7 @@ div.elephpants img:focus {
 .thanks__description {
   margin: 0
 }
+
+.replaceable {
+  font-style: italic;
+}


### PR DESCRIPTION
Make replaceable class text italic to visually differentiate content that may or must be replaced.

@Girgias this is a minimal implementation of what I mentioned in https://github.com/php/doc-en/pull/3442.