### PR TITLE
Use HTTPS URL for event submission to main.php.net, match spam check expectation to web-master

### DIFF
--- a/submit-event.php
+++ b/submit-event.php
@@ -110,7 +110,7 @@ if ($process) {
     }
 
     // Spam question
-    if ($_POST["sane"] != 4) {
+    if ($_POST["sane"] != 3) {
         $errors[] = "It's OK. I'm not real either";
     }
 
@@ -257,7 +257,7 @@ if ($process && count($errors) === 0) {
  </tr>
  <tr>
   <th class="subr">Are you real?</th>
-  <td><select name="sane"><?php display_options(["I, Robot", "I used to be", "WTF?", "No, but I'd still want to submit this", "Yes"], "2"); ?></select></td>
+  <td><select name="sane"><?php display_options(["I, Robot", "I used to be", "WTF?", "Yes", "No, but I'd still want to submit this"], "2"); ?></select></td>
  </tr>
 </table>
 </form>

--- a/submit-event.php
+++ b/submit-event.php
@@ -116,7 +116,7 @@ if ($process) {
 
     if (isset($_POST['action']) && $_POST['action'] === 'Submit' && empty($errors)) {
         // Submit to main.php.net
-        $result = posttohost("http://main.php.net/entry/event.php", $_POST);
+        $result = posttohost("https://main.php.net/entry/event.php", $_POST);
         if ($result) {
             $errors[] = "There was an error processing your submission: $result";
         }


### PR DESCRIPTION
Resolves #999 / GH-999

At some point in the past 12 years (this line was modified in the last 3 years but I doubt it got tested when modified) main.php.net started redirecting insecure HTTP to HTTPS, including for POSTs. The catch with those redirects is that POSTs won't get resubmitted when redirected, so when submitting an event the redirect would result in a GET with no parameters to the event submission endpoint, hence "Missing parameters." So event submission has been broken since main.php.net started redirecting HTTP to HTTPS.

Back in 2012 there was an attempt to switch this and other URLs to HTTPS, but it got rolled back because "there could be mirrors without ssl support." (see blame for the line this commit modifies). Since then, mirrors have been phased out, so we can safely assume we're calling HTTPS endpoints now (and that's the only way this will work anyway).

Verified by hitting the mentioned endpoint both on HTTP and HTTPS. HTTP gets redirected and fails due to missing parameters, HTTPS makes it through to the next step.

Additionally swaps the spam check value back to matching the web-master repo's expected value, as once the above was fixed that became the issue for calling the endpoint through this form. Optimizing for having only one repo needing to be fixed here rather than both this repo and the web-master one, hence not changing the expected antispam value there.