### PR TITLE
Switch "today" marker on supported versions image from red to dark grey to differentiate from EOL versions

### DIFF
--- a/images/supported-versions.php
+++ b/images/supported-versions.php
@@ -98,13 +98,13 @@ $height = $header_height + $footer_height + (count($branches) * $branch_height);
 			}
 
 			.today line {
-				stroke: #f33;
+				stroke: #333;
 				stroke-dasharray: 7,7;
 				stroke-width: 3px;
 			}
 
 			.today text {
-				fill: #f33;
+				fill: #333;
 				text-anchor: middle;
 			}
 


### PR DESCRIPTION
Resolves #1018 / GH-1018