### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @saundefined

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @saundefined
+* @sy-records


### PR DESCRIPTION
@pronskiy and I are suggesting to create a `CODEOWNERS` file
to automatically assign people to review PRs and triage issues.

We have a @php/web-team, but I'm not sure if all people on that team want to be notified every time,
and also it's easier to add people who want to be added via PR rather than team admin.

If anyone wants to add themselves to this file as well, feel free to add yourself :)
(but you must have write access to that repository)