### PR TITLE
OG meta tags by default

### DIFF
--- a/include/layout.inc
+++ b/include/layout.inc
@@ -424,6 +424,9 @@ function site_header(string $title = 'Hypertext Preprocessor', array $config = [
 {
     global $MYSITE;
 
+    $meta_image_path = $MYSITE . 'images/meta-image.png';
+    $meta_description = "PHP is a popular general-purpose scripting language that powers everything from your blog to the most popular websites in the world.";
+
     $defaults = [
         "lang" => myphpnet_language(),
         "current" => "",
@@ -432,6 +435,25 @@ function site_header(string $title = 'Hypertext Preprocessor', array $config = [
         'layout_span' => 9,
         "cache" => false,
         "headsup" => "",
+        'meta_tags' => <<<META
+<meta name="Description" content="{$meta_description}" />
+
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:site" content="@official_php" />
+<meta name="twitter:title" content="PHP: Hypertext Preprocessor" />
+<meta name="twitter:description" content="{$meta_description}" />
+<meta name="twitter:creator" content="@official_php" />
+<meta name="twitter:image:src" content="{$meta_image_path}" />
+
+<meta itemprop="name" content="PHP: Hypertext Preprocessor" />
+<meta itemprop="description" content="$meta_description" />
+<meta itemprop="image" content="{$meta_image_path}" />
+
+<meta property="og:image" content="{$meta_image_path}" />
+<meta property="og:description" content="$meta_description" />
+
+<link href="https://fosstodon.org/@php" rel="me" />
+META
     ];
 
     $config = array_merge($defaults, $config);

--- a/index.php
+++ b/index.php
@@ -118,10 +118,6 @@ $intro .= <<<EOF
   </div>
 EOF;
 
-// Write out common header
-$meta_image_path = $MYSITE . 'images/meta-image.png';
-$meta_description = "PHP is a popular general-purpose scripting language that powers everything from your blog to the most popular websites in the world.";
-
 site_header("Hypertext Preprocessor",
     [
         'current' => 'home',
@@ -149,25 +145,6 @@ site_header("Hypertext Preprocessor",
         ],
         'css' => ['home.css'],
         'intro' => $intro,
-        'meta_tags' => <<<META
-<meta name="Description" content="{$meta_description}" />
-
-<meta name="twitter:card" content="summary_large_image" />
-<meta name="twitter:site" content="@official_php" />
-<meta name="twitter:title" content="PHP: Hypertext Preprocessor" />
-<meta name="twitter:description" content="{$meta_description}" />
-<meta name="twitter:creator" content="@official_php" />
-<meta name="twitter:image:src" content="{$meta_image_path}" />
-
-<meta itemprop="name" content="PHP: Hypertext Preprocessor" />
-<meta itemprop="description" content="$meta_description" />
-<meta itemprop="image" content="{$meta_image_path}" />
-
-<meta property="og:image" content="{$meta_image_path}" />
-<meta property="og:description" content="$meta_description" />
-
-<link href="https://fosstodon.org/@php" rel="me" />
-META
     ],
 );
 


### PR DESCRIPTION
OG meta tags are available for all pages by default,
and can be overridden if needed (such as for PHP 8.0-8.3 release pages).

Should fix #981