### PR TITLE
Remove special cases for the gettext shorthand function

### DIFF
--- a/error.php
+++ b/error.php
@@ -400,7 +400,6 @@ $uri_aliases = [
     "links" => "support", // BC
     "links.php" => "support", // BC
     "oracle" => "oci8",
-    "_" => "function.gettext",
     "cli" => "features.commandline",
 
     "oop" => "language.oop5",

--- a/include/manual-lookup.inc
+++ b/include/manual-lookup.inc
@@ -126,10 +126,8 @@ function find_manual_page($lang, $keyword)
     // English one in case no page is found
     $langs = ($lang != 'en') ? [$lang, 'en'] : ['en'];
 
-    // Reformat keyword, drop anything in parenthesis --- except a search for the underscore only. (Bug #63490)
-    if ($keyword != '_') {
-        $keyword = str_replace('_', '-', $keyword);
-    }
+    // Reformat keyword, drop anything in parentheses
+    $keyword = str_replace('_', '-', $keyword);
     if (strpos($keyword, '(') !== false) {
         $keyword = preg_replace("!\\(.*\\)!", "-", $keyword);
     }


### PR DESCRIPTION
After https://github.com/php/doc-en/pull/3556 being merged, these special cases for the `gettext()` shorthand `_()` will not be needed anymore.

- Related to https://github.com/php/doc-en/pull/3556
- Related to https://github.com/php/systems/pull/23