### PR TITLE
Clarify older CascadiaPHP CFP entry title

### DIFF
--- a/archive/entries/2024-06-21-1.xml
+++ b/archive/entries/2024-06-21-1.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <entry xmlns="http://www.w3.org/2005/Atom" xmlns:default="http://php.net/ns/news">
-  <title>CascadiaPHP 2024</title>
+  <title>CascadiaPHP 2024 - Call For Papers</title>
   <id>https://www.php.net/archive/2024.php#2024-06-21-1</id>
   <published>2024-06-21T18:36:21+00:00</published>
   <updated>2024-06-21T18:36:21+00:00</updated>


### PR DESCRIPTION
Having two entries back-to-back with "CascadiaPHP" wasn't my intention; sorry about that. This clarifies that the older one is for the CFP (which has now closed and isn't on the front page of php.net anymore).