### PR TITLE
Replace MYPHPNET global var with the UserPreferences class

### DIFF
--- a/error.php
+++ b/error.php
@@ -9,6 +9,8 @@
 
 */
 
+use phpweb\UserPreferences;
+
 // Ensure that our environment is set up
 include_once __DIR__ . '/include/prepend.inc';
 include_once __DIR__ . '/include/languages.inc';
@@ -708,7 +710,7 @@ if (strpos($URI, "manual/") === 0) {
 // ============================================================================
 // If no match was found till this point, the last action is to start a
 // search with the URI the user typed in
-$fallback = (myphpnet_urlsearch() === MYPHPNET_URL_MANUAL ? "404manual" : "404quickref");
+$fallback = (myphpnet_urlsearch() === UserPreferences::URL_MANUAL ? "404manual" : "404quickref");
 mirror_redirect(
     '/search.php?show=' . $fallback . '&lang=' . urlencode($LANG) .
     '&pattern=' . substr($_SERVER['REQUEST_URI'], 1),

--- a/include/prepend.inc
+++ b/include/prepend.inc
@@ -101,7 +101,7 @@ include __DIR__ . '/last_updated.inc';
 function myphpnet_load(): void
 {
     UserPreferences::$languageCode = '';
-    UserPreferences::$searchType = MYPHPNET_URL_NONE;
+    UserPreferences::$searchType = UserPreferences::URL_NONE;
     UserPreferences::$isUserGroupTipsEnabled = false;
 
     if (!isset($_COOKIE['MYPHPNET']) || !is_string($_COOKIE['MYPHPNET']) || $_COOKIE['MYPHPNET'] === '') {
@@ -117,7 +117,7 @@ function myphpnet_load(): void
      */
     $preferences = explode(",", $_COOKIE['MYPHPNET']);
     UserPreferences::$languageCode = $preferences[0] ?? '';
-    if (isset($preferences[1]) && in_array($preferences[1], [MYPHPNET_URL_FUNC, MYPHPNET_URL_MANUAL], true)) {
+    if (isset($preferences[1]) && in_array($preferences[1], [UserPreferences::URL_FUNC, UserPreferences::URL_MANUAL], true)) {
         UserPreferences::$searchType = $preferences[1];
     }
 
@@ -130,15 +130,11 @@ function myphpnet_language(): string
     return UserPreferences::$languageCode;
 }
 
-const MYPHPNET_URL_NONE = false;
-const MYPHPNET_URL_FUNC = 'quickref';
-const MYPHPNET_URL_MANUAL = 'manual';
-
 // Set URL search fallback preference
 function myphpnet_urlsearch($type = false)
 {
     // Set type if specified and if correct
-    if ($type && in_array($type, [MYPHPNET_URL_FUNC, MYPHPNET_URL_MANUAL], true)) {
+    if ($type && in_array($type, [UserPreferences::URL_FUNC, UserPreferences::URL_MANUAL], true)) {
         UserPreferences::$searchType = $type;
     }
 

--- a/include/prepend.inc
+++ b/include/prepend.inc
@@ -1,4 +1,9 @@
 <?php
+
+use phpweb\UserPreferences;
+
+require_once __DIR__ . '/../src/autoload.php';
+
 // Compress all pages, if ext/zlib is available on the mirror
 // XXX Deactivated by sas, causes errors towards delivery machines
 // ini_set("zlib.output_compression", 1);
@@ -68,7 +73,6 @@ unset($SEARCH_BASE);
 unset($LANG);
 unset($COUNTRY);
 unset($ONLOAD);
-unset($MYPHPNET);
 unset($LAST_UPDATED);
 
 // Load the My PHP.net settings before any includes
@@ -96,32 +100,30 @@ include __DIR__ . '/last_updated.inc';
 // Load in the user preferences
 function myphpnet_load(): void
 {
-    global $MYPHPNET, $MYSITE;
+    global $MYSITE;
 
     // Empty the preferences array
-    $MYPHPNET = [false, false, "NONE", 0, false];
+    UserPreferences::$myPhpNet = [false, false, "NONE", 0, false];
 
     if ($MYSITE === 'http://docs.php.net/') {
-        $MYPHPNET[4] = true;
+        UserPreferences::$myPhpNet[4] = true;
     }
 
     // If we have a cookie, set the values in the array
     if (!empty($_COOKIE['MYPHPNET'])) {
-        $MYPHPNET = explode(",", $_COOKIE['MYPHPNET']);
+        UserPreferences::$myPhpNet = explode(",", $_COOKIE['MYPHPNET']);
     }
 
     // Ignore site part, and always use https://www.php.net
-    $MYPHPNET[2] = 'https://www.php.net';
+    UserPreferences::$myPhpNet[2] = 'https://www.php.net';
 }
 
 // Get preferred language code
 function myphpnet_language(): string
 {
-    global $MYPHPNET;
-
     // Return code
-    if (isset($MYPHPNET[0]) && $MYPHPNET[0]) {
-        return $MYPHPNET[0];
+    if (isset(UserPreferences::$myPhpNet[0]) && UserPreferences::$myPhpNet[0]) {
+        return UserPreferences::$myPhpNet[0];
     }
     return '';
 }
@@ -133,32 +135,28 @@ const MYPHPNET_URL_MANUAL = 'manual';
 // Set URL search fallback preference
 function myphpnet_urlsearch($type = false)
 {
-    global $MYPHPNET;
-
     // Set type if specified and if correct
     if ($type && in_array($type, [MYPHPNET_URL_FUNC, MYPHPNET_URL_MANUAL], true)) {
-        $MYPHPNET[1] = $type;
+        UserPreferences::$myPhpNet[1] = $type;
     }
 
     // Return code or NONE
-    elseif (isset($MYPHPNET[1]) && !empty($MYPHPNET[1])) {
-        return $MYPHPNET[1];
+    elseif (isset(UserPreferences::$myPhpNet[1]) && !empty(UserPreferences::$myPhpNet[1])) {
+        return UserPreferences::$myPhpNet[1];
     } else { return MYPHPNET_URL_NONE; }
 }
 
 function myphpnet_showug($enable = null) {
-    global $MYPHPNET;
-
     if (isset($_GET["showug"])) {
         $enable = true;
     }
 
     if ($enable !== null) {
-        $MYPHPNET[3] = $enable;
+        UserPreferences::$myPhpNet[3] = $enable;
     }
 
-    if (isset($MYPHPNET[3])) {
-        return $MYPHPNET[3];
+    if (isset(UserPreferences::$myPhpNet[3])) {
+        return UserPreferences::$myPhpNet[3];
     }
 
     if ($_SERVER["REQUEST_TIME"] % 10) {
@@ -171,15 +169,13 @@ function myphpnet_showug($enable = null) {
 // Save user settings in cookie
 function myphpnet_save(): void
 {
-    global $MYPHPNET;
-
     // Fill in values not specified
     for ($i = 0; $i <= 3; $i++) {
-        if (!isset($MYPHPNET[$i])) { $MYPHPNET[$i] = false; }
+        if (!isset(UserPreferences::$myPhpNet[$i])) { UserPreferences::$myPhpNet[$i] = false; }
     }
 
     // Set all the preferred values for a year
-    mirror_setcookie("MYPHPNET", join(",", $MYPHPNET), 60 * 60 * 24 * 365);
+    mirror_setcookie("MYPHPNET", join(",", UserPreferences::$myPhpNet), 60 * 60 * 24 * 365);
 
 }
 

--- a/include/prepend.inc
+++ b/include/prepend.inc
@@ -100,32 +100,34 @@ include __DIR__ . '/last_updated.inc';
 // Load in the user preferences
 function myphpnet_load(): void
 {
-    global $MYSITE;
+    UserPreferences::$languageCode = '';
+    UserPreferences::$searchType = MYPHPNET_URL_NONE;
+    UserPreferences::$isUserGroupTipsEnabled = false;
 
-    // Empty the preferences array
-    UserPreferences::$myPhpNet = [false, false, "NONE", 0, false];
-
-    if ($MYSITE === 'http://docs.php.net/') {
-        UserPreferences::$myPhpNet[4] = true;
+    if (!isset($_COOKIE['MYPHPNET']) || !is_string($_COOKIE['MYPHPNET']) || $_COOKIE['MYPHPNET'] === '') {
+        return;
     }
 
-    // If we have a cookie, set the values in the array
-    if (!empty($_COOKIE['MYPHPNET'])) {
-        UserPreferences::$myPhpNet = explode(",", $_COOKIE['MYPHPNET']);
+    /**
+     * 0 - Language code
+     * 1 - URL search fallback
+     * 2 - Mirror site (removed)
+     * 3 - User Group tips
+     * 4 - Documentation developmental server (removed)
+     */
+    $preferences = explode(",", $_COOKIE['MYPHPNET']);
+    UserPreferences::$languageCode = $preferences[0] ?? '';
+    if (isset($preferences[1]) && in_array($preferences[1], [MYPHPNET_URL_FUNC, MYPHPNET_URL_MANUAL], true)) {
+        UserPreferences::$searchType = $preferences[1];
     }
 
-    // Ignore site part, and always use https://www.php.net
-    UserPreferences::$myPhpNet[2] = 'https://www.php.net';
+    UserPreferences::$isUserGroupTipsEnabled = isset($preferences[3]) && $preferences[3];
 }
 
 // Get preferred language code
 function myphpnet_language(): string
 {
-    // Return code
-    if (isset(UserPreferences::$myPhpNet[0]) && UserPreferences::$myPhpNet[0]) {
-        return UserPreferences::$myPhpNet[0];
-    }
-    return '';
+    return UserPreferences::$languageCode;
 }
 
 const MYPHPNET_URL_NONE = false;
@@ -137,13 +139,10 @@ function myphpnet_urlsearch($type = false)
 {
     // Set type if specified and if correct
     if ($type && in_array($type, [MYPHPNET_URL_FUNC, MYPHPNET_URL_MANUAL], true)) {
-        UserPreferences::$myPhpNet[1] = $type;
+        UserPreferences::$searchType = $type;
     }
 
-    // Return code or NONE
-    elseif (isset(UserPreferences::$myPhpNet[1]) && !empty(UserPreferences::$myPhpNet[1])) {
-        return UserPreferences::$myPhpNet[1];
-    } else { return MYPHPNET_URL_NONE; }
+    return UserPreferences::$searchType;
 }
 
 function myphpnet_showug($enable = null) {
@@ -151,32 +150,37 @@ function myphpnet_showug($enable = null) {
         $enable = true;
     }
 
-    if ($enable !== null) {
-        UserPreferences::$myPhpNet[3] = $enable;
+    if (is_bool($enable)) {
+        UserPreferences::$isUserGroupTipsEnabled = $enable;
     }
 
-    if (isset(UserPreferences::$myPhpNet[3])) {
-        return UserPreferences::$myPhpNet[3];
-    }
-
+    // Show the ug tips to lucky few, depending on time.
     if ($_SERVER["REQUEST_TIME"] % 10) {
-        return true;
+        UserPreferences::$isUserGroupTipsEnabled = true;
     }
 
-    return false;
+    return UserPreferences::$isUserGroupTipsEnabled;
 }
 
 // Save user settings in cookie
 function myphpnet_save(): void
 {
-    // Fill in values not specified
-    for ($i = 0; $i <= 3; $i++) {
-        if (!isset(UserPreferences::$myPhpNet[$i])) { UserPreferences::$myPhpNet[$i] = false; }
-    }
+    /**
+     * 0 - Language code
+     * 1 - URL search fallback
+     * 2 - Mirror site (removed)
+     * 3 - User Group tips
+     * 4 - Documentation developmental server (removed)
+     */
+    $preferences = [
+        UserPreferences::$languageCode,
+        UserPreferences::$searchType,
+        '',
+        UserPreferences::$isUserGroupTipsEnabled,
+    ];
 
     // Set all the preferred values for a year
-    mirror_setcookie("MYPHPNET", join(",", UserPreferences::$myPhpNet), 60 * 60 * 24 * 365);
-
+    mirror_setcookie("MYPHPNET", join(",", $preferences), 60 * 60 * 24 * 365);
 }
 
 // Embed Google Custom Search engine

--- a/include/shared-manual.inc
+++ b/include/shared-manual.inc
@@ -22,8 +22,6 @@ $PGI = []; $SIDEBAR_DATA = '';
 // User note display functions
 // =============================================================================
 
-require_once __DIR__ . '/../src/autoload.php';
-
 use phpweb\UserNotes\Sorter;
 use phpweb\UserNotes\UserNote;
 

--- a/my.php
+++ b/my.php
@@ -182,11 +182,11 @@ if (i2c_valid_country()) {
  Your setting: <input id="form-urlsearch-quickref" type="radio" name="urlsearch" value="quickref"
 <?php
 $type = myphpnet_urlsearch();
-if ($type === MYPHPNET_URL_NONE || $type === MYPHPNET_URL_FUNC) {
+if ($type === UserPreferences::URL_NONE || $type === UserPreferences::URL_FUNC) {
     echo ' checked="checked"';
 }
 echo '> <label for="form-urlsearch-quickref">Function list search</label> <input id="form-urlsearch-manual" type="radio" name="urlsearch" value="manual"';
-if ($type === MYPHPNET_URL_MANUAL) {
+if ($type === UserPreferences::URL_MANUAL) {
     echo ' checked="checked"';
 }
 ?>

--- a/my.php
+++ b/my.php
@@ -16,7 +16,7 @@ $options = [];
 if (isset($_POST['my_lang'], $langs[$_POST['my_lang']])) {
 
     // Set the language preference
-    UserPreferences::$myPhpNet[0] = $_POST['my_lang'];
+    UserPreferences::$languageCode = $_POST['my_lang'];
 
     // Add this as first option, selected
     $options[] = '<option value="' . $_POST['my_lang'] . '" selected>' .

--- a/my.php
+++ b/my.php
@@ -1,4 +1,7 @@
 <?php
+
+use phpweb\UserPreferences;
+
 $_SERVER['BASE_PAGE'] = 'my.php';
 include_once __DIR__ . '/include/prepend.inc';
 
@@ -13,7 +16,7 @@ $options = [];
 if (isset($_POST['my_lang'], $langs[$_POST['my_lang']])) {
 
     // Set the language preference
-    $MYPHPNET[0] = $_POST['my_lang'];
+    UserPreferences::$myPhpNet[0] = $_POST['my_lang'];
 
     // Add this as first option, selected
     $options[] = '<option value="' . $_POST['my_lang'] . '" selected>' .

--- a/src/UserPreferences.php
+++ b/src/UserPreferences.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace phpweb;
+
+/**
+ * Handles the "My PHP.net" preferences.
+ */
+final class UserPreferences
+{
+    public static array $myPhpNet = [false, false, "NONE", 0, false];
+}

--- a/src/UserPreferences.php
+++ b/src/UserPreferences.php
@@ -7,6 +7,12 @@ namespace phpweb;
  */
 final class UserPreferences
 {
+    public const URL_NONE = false;
+
+    public const URL_FUNC = 'quickref';
+
+    public const URL_MANUAL = 'manual';
+
     public static string $languageCode = '';
 
     /**
@@ -14,7 +20,7 @@ final class UserPreferences
      *
      * @var 'manual'|'quickref'|false
      */
-    public static string|false $searchType = false;
+    public static string|false $searchType = self::URL_NONE;
 
     public static bool $isUserGroupTipsEnabled = false;
 }

--- a/src/UserPreferences.php
+++ b/src/UserPreferences.php
@@ -7,5 +7,14 @@ namespace phpweb;
  */
 final class UserPreferences
 {
-    public static array $myPhpNet = [false, false, "NONE", 0, false];
+    public static string $languageCode = '';
+
+    /**
+     * URL search fallback
+     *
+     * @var 'manual'|'quickref'|false
+     */
+    public static string|false $searchType = false;
+
+    public static bool $isUserGroupTipsEnabled = false;
 }


### PR DESCRIPTION
- Replaces the `$MYPHPNET` global variable with static properties of the `phpweb\UserPreferences` class
- Moves the `MYPHPNET_URL_*` global constants to the `phpweb\UserPreferences` class
- Removes the `src/autoload.php` include in `shared-manual.inc` as it is already included in `prepend.inc`

Using static properties for this is not great, but it is an improvement over the global variable.