### PR TITLE
Remove `LAST_LANG` cookie as it is not used anymore.

### DIFF
--- a/include/langchooser.inc
+++ b/include/langchooser.inc
@@ -50,9 +50,6 @@ function language_choose_code()
     // Specified for the request (GET/POST parameter)
     if (!empty($_REQUEST['lang']) && is_string($_REQUEST['lang'])) {
         $explicitly_specified = language_add(htmlspecialchars($_REQUEST['lang'], ENT_QUOTES, 'UTF-8'), $languages);
-
-        // Set the language in a cookie for a year
-        mirror_setcookie("LAST_LANG", $explicitly_specified, 60 * 60 * 24 * 365);
     }
 
     // Specified in a shortcut URL (eg. /en/echo or /pt_br/echo)
@@ -82,9 +79,6 @@ function language_choose_code()
         if (empty($explicitly_specified)) {
             $explicitly_specified = $flang;
         }
-
-        // Set the language in a cookie for a year
-        mirror_setcookie("LAST_LANG", $flang, 60 * 60 * 24 * 365);
     }
 
     // Honor the users own language setting (if available)

--- a/my.php
+++ b/my.php
@@ -94,9 +94,8 @@ site_header("My PHP.net", ["current" => "community"]);
  If you use a shortcut or search for a function, the language used
  is determined by checking for the following settings. The list is
  in priority order, the first is the most important. Normally you don't
- need to set your preferred language, as your last seen language is
- always remembered, and is a good estimate of your preferred language
- most of the time.
+ need to set your preferred language, as your browser's language preferences
+ are detected automatically using the Accept-Language header.
 </p>
 
 <div class="indent">
@@ -108,9 +107,6 @@ $langinfo = [
 
     "<label for=\"form-my_lang\">Your preferred language</label>" =>
     $langpref,
-
-    "Last seen language" =>
-    (isset($_COOKIE['LAST_LANG']) ? htmlentities($_COOKIE['LAST_LANG'], ENT_QUOTES | ENT_IGNORE, 'UTF-8') : "None"),
 
     "Your Accept-Language browser setting" =>
     (isset($_SERVER['HTTP_ACCEPT_LANGUAGE']) ? htmlentities($_SERVER['HTTP_ACCEPT_LANGUAGE'], ENT_QUOTES | ENT_IGNORE, 'UTF-8') : "None"),


### PR DESCRIPTION
The "last seen language" is no longer respected since 4 years ago.
So we should stop setting the `LAST_LANG` cookie.

See 7691b44067db646287064df92ad6bd10718ba9a6 and https://bugs.php.net/bug.php?id=79524