### PR TITLE
Link to GH issues instead of bugs.php.net for documentation issues

### DIFF
--- a/include/shared-manual.inc
+++ b/include/shared-manual.inc
@@ -30,7 +30,7 @@ use phpweb\UserNotes\UserNote;
  *
  * @param array<string, UserNote> $notes
  */
-function manual_notes($notes):void {
+function manual_notes($notes, $repo = 'en'):void {
     // Get needed values
     list($filename) = $GLOBALS['PGI']['this'];
 
@@ -45,6 +45,7 @@ function manual_notes($notes):void {
     // Link target to add a note to the current manual page,
     // and it's extended form with a [+] image
     $addnotelink = '/manual/add-note.php?sect=' . $filename .
+                   '&amp;repo=' . $repo .
                    '&amp;redirect=' . $_SERVER['BASE_HREF'];
     $addnotesnippet = make_link(
         $addnotelink,
@@ -408,7 +409,7 @@ function manual_footer($setup): void {
     </div>
 CONTRIBUTE;
 
-    manual_notes($USERNOTES);
+    manual_notes($USERNOTES, $repo);
     site_footer([
         'related_menu' => $__RELATED['toc'],
         'related_menu_deprecated' => $__RELATED['toc_deprecated'],

--- a/manual/add-note.php
+++ b/manual/add-note.php
@@ -18,6 +18,10 @@ if (empty($_POST['sect']) && isset($_GET['sect'])) {
 if (empty($_POST['redirect']) && isset($_GET['redirect'])) {
     $_POST['redirect'] = $_GET['redirect'];
 }
+// Assume English if we didn't get a language
+if (empty($_POST['repo'])) {
+    $_POST['repo'] = 'en';
+}
 
 // Decide on whether all vars are present for processing
 $process = true;
@@ -258,8 +262,8 @@ else {
 <div class='columns'>
 <ul>
   <li><strong>Bug reports &amp; Missing documentation</strong>
-    Instead <a href="http://bugs.php.net/report.php?bug_type=Documentation+problem<?php echo isset($_POST['sect']) ? '&amp;manpage=' . clean($_POST['sect']) : ''; ?>">report a bug</a>
-  for this manual page to the bug database.
+    Instead <a href="https://github.com/php/doc-<?=clean($_POST['repo'])?>/issues/new?body=From%20manual%20page:%20https:%2F%2Fphp.net%2F<?=clean($_POST['sect'])?>%0A%0A---">report an issue</a>
+  for this manual page.
   </li>
   <li><strong>Support questions or request for help</strong> See the <a href="/support.php">support page</a> for available options. In other words, do not ask questions within the user notes.</li>
   <li><strong>References to other notes or authors</strong>  This is not a forum; we do not encourage nor permit discussions here.  Further, if a note is referenced directly and is later removed or modified it causes confusion.
@@ -347,9 +351,9 @@ else {?>
    <td colspan="2">
     <b>
      <a href="/support.php">Click here to go to the support pages.</a><br>
-     <a href="http://bugs.php.net/report.php?bug_type=Documentation+problem&amp;manpage=<?php echo clean($_POST['sect']); ?>">Click here to submit a bug report.</a><br>
-     <a href="http://bugs.php.net/report.php?bug_type=Documentation+problem&amp;manpage=<?php echo clean($_POST['sect']); ?>">Click here to request a feature.</a><br>
-     (Again, please note, if you ask a question, report a bug, or request a feature,
+     <a href="https://github.com/php/doc-<?=clean($_POST['repo'])?>/issues/new?body=From%20manual%20page:%20https:%2F%2Fphp.net%2F<?=clean($_POST['sect'])?>%0A%0A---">Click here to submit an issue about the documentation.</a><br>
+     <a href="https://github.com/php/php-src/issues/new?body=From%20manual%20page:%20https:%2F%2Fphp.net%2F<?=clean($_POST['sect'])?>%0A%0A---">Click here to submit an issue about PHP itself.</a><br>
+     (Again, please note, if you ask a question, report an issue, or request a feature,
      your note <i>will be deleted</i>.)
     </b>
    </td>

--- a/styles/add-note.css
+++ b/styles/add-note.css
@@ -47,6 +47,7 @@
     -webkit-columns:15rem;
     -moz-columns:15rem;
     columns:15rem;
+    margin-bottom: 1em;
   }
   #whatnottoenter .columns li {
     -webkit-column-break-inside:avoid;


### PR DESCRIPTION
Make sure we're linking to the GH issue tracker instead of bugs.php.net.

(Also one little layout tweak that was bugging me.)