### PR TITLE
Auto-detect user's language on PHP8.3 release page

### DIFF
--- a/releases/8.3/common.php
+++ b/releases/8.3/common.php
@@ -6,6 +6,17 @@ namespace releases\php83;
 
 include_once __DIR__ . '/../../include/prepend.inc';
 
+const LANGUAGES = [
+    'en' => 'English',
+    'es' => 'Español',
+    'de' => 'Deutsch',
+    'ru' => 'Russian',
+    'zh' => '简体中文',
+    'pt_BR' => 'Português do Brasil',
+    'ja' => '日本語',
+    'uk' => 'Українська',
+];
+
 function common_header(string $description): void {
     global $MYSITE;
 
@@ -35,17 +46,6 @@ META
 }
 
 function language_chooser(string $currentLang): void {
-    $LANGUAGES = [
-        'en' => 'English',
-        'es' => 'Español',
-        'de' => 'Deutsch',
-        'ru' => 'Russian',
-        'zh' => '简体中文',
-        'pt_BR' => 'Português do Brasil',
-        'ja' => '日本語',
-        'uk' => 'Українська',
-    ];
-
     // Print out the form with all the options
     echo '
       <form action="" method="get" id="changelang" name="changelang">
@@ -55,7 +55,7 @@ function language_chooser(string $currentLang): void {
 ';
 
     $tab = '            ';
-    foreach ($LANGUAGES as $lang => $text) {
+    foreach (LANGUAGES as $lang => $text) {
         $selected = ($lang === $currentLang) ? ' selected="selected"' : '';
         echo $tab, "<option value='$lang'$selected>$text</option>\n";
     }

--- a/releases/8.3/index.php
+++ b/releases/8.3/index.php
@@ -1,6 +1,13 @@
 <?php
 
- $_SERVER['BASE_PAGE'] = 'releases/8.3/index.php';
-include __DIR__ . '/../../include/site.inc';
+use phpweb\LangChooser;
+use const releases\php83\LANGUAGES;
 
-mirror_redirect('/releases/8.3/en.php');
+$_SERVER['BASE_PAGE'] = 'releases/8.3/index.php';
+require_once __DIR__ . '/common.php';
+require_once __DIR__ . '/../../src/autoload.php';
+
+$langChooser = new LangChooser(LANGUAGES, [], "", "");
+[$lang,] = $langChooser->chooseCode("", "", $_SERVER['HTTP_ACCEPT_LANGUAGE']);
+
+mirror_redirect("/releases/8.3/$lang.php");


### PR DESCRIPTION
Follow up of #1081 

`/releases/8.3/index.php` detects the browser's preferred language and redirects to the page of the language if available.
If the language is not available, it falls back to English.