### PR TITLE
Redirect MongoDB from set to book

### DIFF
--- a/error.php
+++ b/error.php
@@ -251,6 +251,9 @@ $manual_page_moves = [
     // Refactored
     'regexp.reference' => 'regexp.introduction',
     "security" => "manual/security",
+
+    // Set to book
+    'set.mongodb.php' => 'book.mongodb.php',
 ];
 
 if (isset($manual_page_moves[$URI])) {

--- a/error.php
+++ b/error.php
@@ -352,7 +352,7 @@ $uri_aliases = [
     "gd" => "image",
     "bcmath" => "bc",
     'streams' => 'book.stream',
-    "mongodb" => "set.mongodb",
+    "mongodb" => "book.mongodb",
     "hrtime" => "function.hrtime", // Prefer function over PECL ext
 
     "callback" => "language.pseudo-types",

--- a/error.php
+++ b/error.php
@@ -253,7 +253,7 @@ $manual_page_moves = [
     "security" => "manual/security",
 
     // Set to book
-    'set.mongodb.php' => 'book.mongodb.php',
+    'set.mongodb' => 'book.mongodb',
 ];
 
 if (isset($manual_page_moves[$URI])) {


### PR DESCRIPTION
Due to <https://github.com/php/doc-en/pull/3627>, the MongoDB documentation's main page has been moved; we redirect accordingly.

---

Frankly, I have no idea where to put that redirect, or what would be the difference between `$manual_page_moves` and `$manual_redirections`. Maybe someone else knows.