### PR TITLE
Additional redirects for mongodb set-to-book conversion

### DIFF
--- a/error.php
+++ b/error.php
@@ -252,8 +252,14 @@ $manual_page_moves = [
     'regexp.reference' => 'regexp.introduction',
     "security" => "manual/security",
 
-    // Set to book
+    // MongoDB converted from set to book
     'set.mongodb' => 'book.mongodb',
+    'mongodb.installation.homebrew' => 'mongodb.installation',
+    'mongodb.installation.manual' => 'mongodb.installation',
+    'mongodb.installation.pecl' => 'mongodb.installation',
+    'mongodb.installation.windows' => 'mongodb.installation',
+    'mongodb.persistence.deserialization' => 'mongodb.persistence',
+    'mongodb.persistence.serialization' => 'mongodb.persistence',
 ];
 
 if (isset($manual_page_moves[$URI])) {

--- a/error.php
+++ b/error.php
@@ -254,12 +254,12 @@ $manual_page_moves = [
 
     // MongoDB converted from set to book
     'set.mongodb' => 'book.mongodb',
-    'mongodb.installation.homebrew' => 'mongodb.installation',
-    'mongodb.installation.manual' => 'mongodb.installation',
-    'mongodb.installation.pecl' => 'mongodb.installation',
-    'mongodb.installation.windows' => 'mongodb.installation',
-    'mongodb.persistence.deserialization' => 'mongodb.persistence',
-    'mongodb.persistence.serialization' => 'mongodb.persistence',
+    'mongodb.installation.homebrew' => 'mongodb.installation#mongodb.installation.homebrew',
+    'mongodb.installation.manual' => 'mongodb.installation#mongodb.installation.manual',
+    'mongodb.installation.pecl' => 'mongodb.installation#mongodb.installation.pecl',
+    'mongodb.installation.windows' => 'mongodb.installation#mongodb.installation.windows',
+    'mongodb.persistence.deserialization' => 'mongodb.persistence#mongodb.persistence.deserialization',
+    'mongodb.persistence.serialization' => 'mongodb.persistence#mongodb.persistence.serialization',
 ];
 
 if (isset($manual_page_moves[$URI])) {
@@ -268,7 +268,13 @@ if (isset($manual_page_moves[$URI])) {
 } elseif (preg_match("!^manual/([^/]+)/([^/]+).php$!", $URI, $match) &&
           isset($manual_page_moves[$match[2]])) {
     status_header(301);
-    mirror_redirect("/manual/$match[1]/" . $manual_page_moves[$match[2]] . ".php");
+
+    $parts = explode('#', $manual_page_moves[$match[2]], 2);
+    if (count($parts) === 1) {
+        mirror_redirect("/manual/{$match[1]}/{$parts[0]}.php");
+    } else {
+        mirror_redirect("/manual/{$match[1]}/{$parts[0]}.php#{$parts[1]}");
+    }
 }
 
 $manual_redirections = [


### PR DESCRIPTION
The first redirect was added in php/web-php#1100, but additional sections that no longer have their own page were missed. The original conversion was done in php/doc-en#3627 and php/doc-base#138.

https://jira.mongodb.org/browse/PHPC-1247