### PR TITLE
Fix downloads layout on mobile

### DIFF
--- a/styles/theme-base.css
+++ b/styles/theme-base.css
@@ -1166,6 +1166,8 @@ fieldset {
 .content-box .md5sum, .content-box .sha256 {
     display: block;
     font: normal 0.875rem/1.5rem "Fira Mono", "Source Code Pro", monospace;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 .content-box .md5sum:before {
     content: "md5: ";


### PR DESCRIPTION
Should fix:

<img width="586" alt="image" src="https://github.com/user-attachments/assets/e4833134-a218-41ad-adab-bfb6cf304a5b">
