### PR TITLE
releases/8.4: Make minor codestyle changes to aviz example

### DIFF
--- a/releases/8.4/release.inc
+++ b/releases/8.4/release.inc
@@ -169,7 +169,7 @@ class PhpVersion
     {
         [$major, $minor] = explode('.', $this->version);
         $minor++;
-        $this->version = "$major.$minor";
+        $this->version = "{$major}.{$minor}";
     }
 }
 PHP
@@ -191,7 +191,7 @@ class PhpVersion
     {
         [$major, $minor] = explode('.', $this->version);
         $minor++;
-        $this->version = "$major.$minor";
+        $this->version = "{$major}.{$minor}";
     }
 }
 PHP


### PR DESCRIPTION
This is a small follow-up to php/web-php#1135. It syncs the interpolation syntax with the PDO subclasses example by using the “brace-style” interpolation.

/cc @theodorejb 