### PR TITLE
releases/8.4: Make minor codestyle changes to array_find example

### DIFF
--- a/releases/8.4/release.inc
+++ b/releases/8.4/release.inc
@@ -366,7 +366,7 @@ PHP
                             <<<'PHP'
 $animal = array_find(
     ['dog', 'cat', 'cow', 'duck', 'goose'],
-    static fn(string $value): bool => str_starts_with($value, 'c'),
+    static fn (string $value): bool => str_starts_with($value, 'c'),
 );
 
 var_dump($animal); // string(3) "cat"


### PR DESCRIPTION
This syncs the array function syntax in the array_find example with the one in the PDO subclasses example by adding the space between the `fn` and `(`.