### PR TITLE
php8.4: Fix the title and RFC link of PDO driver specific subclasses

### DIFF
--- a/releases/8.4/languages/en.php
+++ b/releases/8.4/languages/en.php
@@ -20,7 +20,7 @@ return [
     'new_array_find_title' => 'New <code>array_*()</code> functions',
     'new_array_find_description' => 'New functions <a href="/manual/en/function.array-find.php"><code>array_find()</code></a>, <a href="/manual/en/function.array-find-key.php"><code>array_find_key()</code></a>, <a href="/manual/en/function.array-any.php"><code>array_any()</code></a>, and <a href="/manual/en/function.array-all.php"><code>array_all()</code></a> are available.',
     'pdo_driver_specific_subclasses_title' => 'PDO driver specific subclasses',
-    'pdo_driver_specific_subclasses_description' => 'New subclasses <code>Pdo\Dblib</code>, <code>Pdo\Firebird</code>, <code>Pdo\MySql</code>, <code>Pdo\Odbc</code>, and <code>Pdo\Sqlite</code> of <code>PDO</code> are available.',
+    'pdo_driver_specific_subclasses_description' => 'New subclasses <code>Pdo\Dblib</code>, <code>Pdo\Firebird</code>, <code>Pdo\MySql</code>, <code>Pdo\Odbc</code>, <code>Pdo\Pgsql</code>, and <code>Pdo\Sqlite</code> of <code>PDO</code> are available.',
     'new_without_parentheses_title' => '<code>new MyClass()->method()</code> without parentheses',
     'new_without_parentheses_description' => 'Properties and methods of a newly instantiated object can now be accessed without wrapping the <code>new</code> expression in parentheses.',
 

--- a/releases/8.4/languages/en.php
+++ b/releases/8.4/languages/en.php
@@ -19,8 +19,8 @@ return [
     'bcmath_description' => '<p>New <code>BcMath\Number</code> object enables object-oriented usage and standard mathematical operators when working with arbitrary precision numbers.</p><p>These objects are immutable and implement the <code>Stringable</code> interface, so they can be used in string contexts like <code>echo $num</code>.</p>',
     'new_array_find_title' => 'New <code>array_*()</code> functions',
     'new_array_find_description' => 'New functions <a href="/manual/en/function.array-find.php"><code>array_find()</code></a>, <a href="/manual/en/function.array-find-key.php"><code>array_find_key()</code></a>, <a href="/manual/en/function.array-any.php"><code>array_any()</code></a>, and <a href="/manual/en/function.array-all.php"><code>array_all()</code></a> are available.',
-    'pdo_driver_specific_parsers_title' => 'PDO Driver specific SQL parsers',
-    'pdo_driver_specific_parsers_description' => 'New subclasses <code>Pdo\Dblib</code>, <code>Pdo\Firebird</code>, <code>Pdo\MySql</code>, <code>Pdo\Odbc</code>, and <code>Pdo\Sqlite</code> of <code>PDO</code> are available.',
+    'pdo_driver_specific_subclasses_title' => 'PDO driver specific subclasses',
+    'pdo_driver_specific_subclasses_description' => 'New subclasses <code>Pdo\Dblib</code>, <code>Pdo\Firebird</code>, <code>Pdo\MySql</code>, <code>Pdo\Odbc</code>, and <code>Pdo\Sqlite</code> of <code>PDO</code> are available.',
     'new_without_parentheses_title' => '<code>new MyClass()->method()</code> without parentheses',
     'new_without_parentheses_description' => 'Properties and methods of a newly instantiated object can now be accessed without wrapping the <code>new</code> expression in parentheses.',
 

--- a/releases/8.4/languages/es.php
+++ b/releases/8.4/languages/es.php
@@ -18,7 +18,7 @@ return [
     'new_array_find_title' => 'Nuevas funciones <code>array_*()</code>',
     'new_array_find_description' => 'Nuevas funciones disponibles: <a href="/manual/es/function.array-find.php"><code>array_find()</code></a>, <a href="/manual/es/function.array-find-key.php"><code>array_find_key()</code></a>, <a href="/manual/es/function.array-any.php"><code>array_any()</code></a> y <a href="/manual/es/function.array-all.php"><code>array_all()</code></a>.',
     'pdo_driver_specific_subclasses_title' => 'Procesadores SQL específicos para PDO Driver',
-    'pdo_driver_specific_subclasses_description' => 'Nuevas subclases de <code>PDO</code>: <code>Pdo\Dblib</code>, <code>Pdo\Firebird</code>, <code>Pdo\MySql</code>, <code>Pdo\Odbc</code>, <code>Pdo\Sqlite</code> están disponibles.',
+    'pdo_driver_specific_subclasses_description' => 'Nuevas subclases de <code>PDO</code>: <code>Pdo\Dblib</code>, <code>Pdo\Firebird</code>, <code>Pdo\MySql</code>, <code>Pdo\Odbc</code>, <code>Pdo\Pgsql</code>, <code>Pdo\Sqlite</code> están disponibles.',
     'new_without_parentheses_title' => '<code>new MyClass()->method()</code> sin paréntesis',
     'new_without_parentheses_description' => 'Las propiedades y métodos de un objeto recién instanciado ahora se pueden acceder sin envolver la expresión <code>new</code> entre paréntesis.',
 

--- a/releases/8.4/languages/es.php
+++ b/releases/8.4/languages/es.php
@@ -17,8 +17,8 @@ return [
     'dom_additions_html5_description' => '<p>Nueva API DOM que incluye soporte conforme a los estándares para el análisis de documentos HTML5, corrige varios errores de cumplimiento antiguos en el comportamiento de la funcionalidad DOM, y añade varias funciones para hacer más conveniente trabajar con documentos.</p><p>La nueva API DOM está disponible dentro del espacio de nombres <code>Dom</code>. Los documentos que utilizan la nueva API DOM pueden ser creados utilizando las clases <code>Dom\HTMLDocument</code> y <code>Dom\XMLDocument</code>.',
     'new_array_find_title' => 'Nuevas funciones <code>array_*()</code>',
     'new_array_find_description' => 'Nuevas funciones disponibles: <a href="/manual/es/function.array-find.php"><code>array_find()</code></a>, <a href="/manual/es/function.array-find-key.php"><code>array_find_key()</code></a>, <a href="/manual/es/function.array-any.php"><code>array_any()</code></a> y <a href="/manual/es/function.array-all.php"><code>array_all()</code></a>.',
-    'pdo_driver_specific_parsers_title' => 'Procesadores SQL específicos para PDO Driver',
-    'pdo_driver_specific_parsers_description' => 'Nuevas subclases de <code>PDO</code>: <code>Pdo\Dblib</code>, <code>Pdo\Firebird</code>, <code>Pdo\MySql</code>, <code>Pdo\Odbc</code>, <code>Pdo\Sqlite</code> están disponibles.',
+    'pdo_driver_specific_subclasses_title' => 'Procesadores SQL específicos para PDO Driver',
+    'pdo_driver_specific_subclasses_description' => 'Nuevas subclases de <code>PDO</code>: <code>Pdo\Dblib</code>, <code>Pdo\Firebird</code>, <code>Pdo\MySql</code>, <code>Pdo\Odbc</code>, <code>Pdo\Sqlite</code> están disponibles.',
     'new_without_parentheses_title' => '<code>new MyClass()->method()</code> sin paréntesis',
     'new_without_parentheses_description' => 'Las propiedades y métodos de un objeto recién instanciado ahora se pueden acceder sin envolver la expresión <code>new</code> entre paréntesis.',
 

--- a/releases/8.4/languages/fr.php
+++ b/releases/8.4/languages/fr.php
@@ -19,8 +19,8 @@ return [
     'bcmath_description' => '<p>BCMath vous permet de travailler avec des nombres flottants de précision arbitraire en PHP. Avec cette version, vous pouvez bénéficier du style orienté objet et de la surcharge des opérateurs pour utiliser les nombres BCMath.</p><p>Cela signifie que vous pouvez désormais utiliser les opérateurs standard avec les objets <code>BcMath\Number</code>, ainsi que toutes les fonctions <code>bc*</code>.</p><p>Ces objets sont immuables et implémentent l\'interface <code>Stringable</code>, afin d\'être utilisés dans des chaînes de caractères tels que <code>echo $num</code>.</p>',
     'new_array_find_title' => 'Nouvelles fonctions <code>array_*()</code>',
     'new_array_find_description' => 'Les nouvelles fonctions <a href="/manual/fr/function.array-find.php"><code>array_find()</code></a>, <a href="/manual/fr/function.array-find-key.php"><code>array_find_key()</code></a>, <a href="/manual/fr/function.array-any.php"><code>array_any()</code></a> et <a href="/manual/fr/function.array-all.php"><code>array_all()</code></a> sont désormais disponibles.',
-    'pdo_driver_specific_parsers_title' => 'Parseurs SQL spécifiques au pilote PDO',
-    'pdo_driver_specific_parsers_description' => 'De nouvelles sous-classes <code>Pdo\Dblib</code>, <code>Pdo\Firebird</code>, <code>Pdo\MySql</code>, <code>Pdo\Odbc</code> et <code>Pdo\Sqlite</code> de <code>PDO</code> sont désormais disponibles.',
+    'pdo_driver_specific_subclasses_title' => 'Parseurs SQL spécifiques au pilote PDO',
+    'pdo_driver_specific_subclasses_description' => 'De nouvelles sous-classes <code>Pdo\Dblib</code>, <code>Pdo\Firebird</code>, <code>Pdo\MySql</code>, <code>Pdo\Odbc</code> et <code>Pdo\Sqlite</code> de <code>PDO</code> sont désormais disponibles.',
     'new_without_parentheses_title' => '<code>new MyClass()->method()</code> sans parenthèses.',
     'new_without_parentheses_description' => 'Les propriétés et méthodes d\'un objet nouvellement instancié peuvent désormais être accessibles sans entourer l\'expression <code>new</code> entre parenthèses.',
 

--- a/releases/8.4/languages/fr.php
+++ b/releases/8.4/languages/fr.php
@@ -20,7 +20,7 @@ return [
     'new_array_find_title' => 'Nouvelles fonctions <code>array_*()</code>',
     'new_array_find_description' => 'Les nouvelles fonctions <a href="/manual/fr/function.array-find.php"><code>array_find()</code></a>, <a href="/manual/fr/function.array-find-key.php"><code>array_find_key()</code></a>, <a href="/manual/fr/function.array-any.php"><code>array_any()</code></a> et <a href="/manual/fr/function.array-all.php"><code>array_all()</code></a> sont désormais disponibles.',
     'pdo_driver_specific_subclasses_title' => 'Parseurs SQL spécifiques au pilote PDO',
-    'pdo_driver_specific_subclasses_description' => 'De nouvelles sous-classes <code>Pdo\Dblib</code>, <code>Pdo\Firebird</code>, <code>Pdo\MySql</code>, <code>Pdo\Odbc</code> et <code>Pdo\Sqlite</code> de <code>PDO</code> sont désormais disponibles.',
+    'pdo_driver_specific_subclasses_description' => 'De nouvelles sous-classes <code>Pdo\Dblib</code>, <code>Pdo\Firebird</code>, <code>Pdo\MySql</code>, <code>Pdo\Odbc</code>, <code>Pdo\Pgsql</code> et <code>Pdo\Sqlite</code> de <code>PDO</code> sont désormais disponibles.',
     'new_without_parentheses_title' => '<code>new MyClass()->method()</code> sans parenthèses.',
     'new_without_parentheses_description' => 'Les propriétés et méthodes d\'un objet nouvellement instancié peuvent désormais être accessibles sans entourer l\'expression <code>new</code> entre parenthèses.',
 

--- a/releases/8.4/languages/nl.php
+++ b/releases/8.4/languages/nl.php
@@ -18,7 +18,7 @@ return [
     'new_array_find_title' => 'Nieuwe <code>array_*()</code> functies',
     'new_array_find_description' => 'Nieuwe functies <a href="/manual/en/function.array-find.php"><code>array_find()</code></a>, <a href="/manual/en/function.array-find-key.php"><code>array_find_key()</code></a>, <a href="/manual/en/function.array-any.php"><code>array_any()</code></a>, en <a href="/manual/en/function.array-all.php"><code>array_all()</code></a> zijn nu beschikbaar.',
     'pdo_driver_specific_subclasses_title' => 'PDO driver specifieke SQL parsers',
-    'pdo_driver_specific_subclasses_description' => 'Nieuwe subklassen <code>Pdo\Dblib</code>, <code>Pdo\Firebird</code>, <code>Pdo\MySql</code>, <code>Pdo\Odbc</code>, <code>Pdo\Sqlite</code> van <code>PDO</code> zijn nu beschikbaar.',
+    'pdo_driver_specific_subclasses_description' => 'Nieuwe subklassen <code>Pdo\Dblib</code>, <code>Pdo\Firebird</code>, <code>Pdo\MySql</code>, <code>Pdo\Odbc</code>, <code>Pdo\Pgsql</code>, <code>Pdo\Sqlite</code> van <code>PDO</code> zijn nu beschikbaar.',
     'new_without_parentheses_title' => '<code>new MyClass()->method()</code> zonder haakjes',
     'new_without_parentheses_description' => 'Eigenschappen en methoden van een nieuw geïnstantieerd object kunnen nu opgevraagd worden zonder de <code>new</code> expressie tussen haakjes te zetten.',
 

--- a/releases/8.4/languages/nl.php
+++ b/releases/8.4/languages/nl.php
@@ -17,8 +17,8 @@ return [
     'dom_additions_html5_description' => '<p>Nieuwe DOM API met correcte ondersteuning voor de HTML 5 standaard, oplossingen voor verschillende lang bestaande compliance bugs in the DOM functionaliteit, en verschillende nieuwe functies om het werken met documenten eenvoudiger te maken.</p><p>De nieuwe DOM API is beschikbaar via de <code>Dom</code> namespace. Documenten die de nieuwe API willen gebruiken, kunnen aangemaakt worden via de <code>Dom\HTMLDocument</code> en <code>Dom\XMLDocument</code> klassen.</p>',
     'new_array_find_title' => 'Nieuwe <code>array_*()</code> functies',
     'new_array_find_description' => 'Nieuwe functies <a href="/manual/en/function.array-find.php"><code>array_find()</code></a>, <a href="/manual/en/function.array-find-key.php"><code>array_find_key()</code></a>, <a href="/manual/en/function.array-any.php"><code>array_any()</code></a>, en <a href="/manual/en/function.array-all.php"><code>array_all()</code></a> zijn nu beschikbaar.',
-    'pdo_driver_specific_parsers_title' => 'PDO driver specifieke SQL parsers',
-    'pdo_driver_specific_parsers_description' => 'Nieuwe subklassen <code>Pdo\Dblib</code>, <code>Pdo\Firebird</code>, <code>Pdo\MySql</code>, <code>Pdo\Odbc</code>, <code>Pdo\Sqlite</code> van <code>PDO</code> zijn nu beschikbaar.',
+    'pdo_driver_specific_subclasses_title' => 'PDO driver specifieke SQL parsers',
+    'pdo_driver_specific_subclasses_description' => 'Nieuwe subklassen <code>Pdo\Dblib</code>, <code>Pdo\Firebird</code>, <code>Pdo\MySql</code>, <code>Pdo\Odbc</code>, <code>Pdo\Sqlite</code> van <code>PDO</code> zijn nu beschikbaar.',
     'new_without_parentheses_title' => '<code>new MyClass()->method()</code> zonder haakjes',
     'new_without_parentheses_description' => 'Eigenschappen en methoden van een nieuw geïnstantieerd object kunnen nu opgevraagd worden zonder de <code>new</code> expressie tussen haakjes te zetten.',
 

--- a/releases/8.4/languages/pt_BR.php
+++ b/releases/8.4/languages/pt_BR.php
@@ -20,7 +20,7 @@ return [
     'new_array_find_title' => 'Novas funções <code>array_*()</code>',
     'new_array_find_description' => 'Novas funções <a href="/manual/pt_BR/function.array-find.php"><code>array_find()</code></a>, <a href="/manual/pt_BR/function.array-find-key.php"><code>array_find_key()</code></a>, <a href="/manual/pt_BR/function.array-any.php"><code>array_any()</code></a> e <a href="/manual/pt_BR/function.array-all.php"><code>array_all()</code></a> estão disponíveis.',
     'pdo_driver_specific_subclasses_title' => 'Parsers SQL específicos para drivers PDO',
-    'pdo_driver_specific_subclasses_description' => 'Novas subclasses <code>Pdo\Dblib</code>, <code>Pdo\Firebird</code>, <code>Pdo\MySql</code>, <code>Pdo\Odbc</code>, <code>Pdo\Sqlite</code> de <code>PDO</code> estão disponíveis.',
+    'pdo_driver_specific_subclasses_description' => 'Novas subclasses <code>Pdo\Dblib</code>, <code>Pdo\Firebird</code>, <code>Pdo\MySql</code>, <code>Pdo\Odbc</code>, <code>Pdo\Pgsql</code>, <code>Pdo\Sqlite</code> de <code>PDO</code> estão disponíveis.',
     'new_without_parentheses_title' => '<code>new MyClass()->method()</code> sem parênteses',
     'new_without_parentheses_description' => 'Propriedades e métodos de um objeto recém-instanciado agora podem ser acessados sem a necessidade de envolver a expressão <code>new</code> entre parênteses.',
 

--- a/releases/8.4/languages/pt_BR.php
+++ b/releases/8.4/languages/pt_BR.php
@@ -19,8 +19,8 @@ return [
     'bcmath_description' => '<p>O novo objeto <code>BcMath\Number</code> permite o uso orientado a objetos e operadores matemáticos padrão ao trabalhar com números de precisão arbitrária.</p><p>Esses objetos são imutáveis e implementam a interface <code>Stringable</code>, então podem ser usados em contextos de string como <code>echo $num</code>.</p>',
     'new_array_find_title' => 'Novas funções <code>array_*()</code>',
     'new_array_find_description' => 'Novas funções <a href="/manual/pt_BR/function.array-find.php"><code>array_find()</code></a>, <a href="/manual/pt_BR/function.array-find-key.php"><code>array_find_key()</code></a>, <a href="/manual/pt_BR/function.array-any.php"><code>array_any()</code></a> e <a href="/manual/pt_BR/function.array-all.php"><code>array_all()</code></a> estão disponíveis.',
-    'pdo_driver_specific_parsers_title' => 'Parsers SQL específicos para drivers PDO',
-    'pdo_driver_specific_parsers_description' => 'Novas subclasses <code>Pdo\Dblib</code>, <code>Pdo\Firebird</code>, <code>Pdo\MySql</code>, <code>Pdo\Odbc</code>, <code>Pdo\Sqlite</code> de <code>PDO</code> estão disponíveis.',
+    'pdo_driver_specific_subclasses_title' => 'Parsers SQL específicos para drivers PDO',
+    'pdo_driver_specific_subclasses_description' => 'Novas subclasses <code>Pdo\Dblib</code>, <code>Pdo\Firebird</code>, <code>Pdo\MySql</code>, <code>Pdo\Odbc</code>, <code>Pdo\Sqlite</code> de <code>PDO</code> estão disponíveis.',
     'new_without_parentheses_title' => '<code>new MyClass()->method()</code> sem parênteses',
     'new_without_parentheses_description' => 'Propriedades e métodos de um objeto recém-instanciado agora podem ser acessados sem a necessidade de envolver a expressão <code>new</code> entre parênteses.',
 

--- a/releases/8.4/languages/ru.php
+++ b/releases/8.4/languages/ru.php
@@ -20,7 +20,7 @@ return [
     'new_array_find_title' => 'Новые функции <code>array_*()</code>',
     'new_array_find_description' => 'Добавлены функции <a href="/manual/ru/function.array-find.php"><code>array_find()</code></a>, <a href="/manual/ru/function.array-find-key.php"><code>array_find_key()</code></a>, <a href="/manual/ru/function.array-any.php"><code>array_any()</code></a> и <a href="/manual/ru/function.array-all.php"><code>array_all()</code></a>.',
     'pdo_driver_specific_subclasses_title' => 'SQL-парсеры, специфичные для драйверов PDO',
-    'pdo_driver_specific_subclasses_description' => 'Добавлены дочерние классы <code>Pdo\Dblib</code>, <code>Pdo\Firebird</code>, <code>Pdo\MySql</code>, <code>Pdo\Odbc</code>, <code>Pdo\Sqlite</code> драйверов, наследующие <code>PDO</code>.',
+    'pdo_driver_specific_subclasses_description' => 'Добавлены дочерние классы <code>Pdo\Dblib</code>, <code>Pdo\Firebird</code>, <code>Pdo\MySql</code>, <code>Pdo\Odbc</code>, <code>Pdo\Pgsql</code>, <code>Pdo\Sqlite</code> драйверов, наследующие <code>PDO</code>.',
     'new_without_parentheses_title' => '<code>new MyClass()->method()</code> без скобок',
     'new_without_parentheses_description' => 'К свойствам и методам только что инициализированного объекта теперь можно обращаться, не оборачивая выражение <code>new</code> в круглые скобки.',
 

--- a/releases/8.4/languages/ru.php
+++ b/releases/8.4/languages/ru.php
@@ -19,8 +19,8 @@ return [
     'bcmath_description' => '<p>Новый объект <code>BcMath\Number</code> позволяет использовать объектно-ориентированный стиль и стандартные математические операторы при работе с числами произвольной точности.</p><p>Эти объекты неизменяемы и реализуют интерфейс <code>Stringable</code>, поэтому их можно использовать в строковых контекстах, например, <code>echo $num</code>.</p>',
     'new_array_find_title' => 'Новые функции <code>array_*()</code>',
     'new_array_find_description' => 'Добавлены функции <a href="/manual/ru/function.array-find.php"><code>array_find()</code></a>, <a href="/manual/ru/function.array-find-key.php"><code>array_find_key()</code></a>, <a href="/manual/ru/function.array-any.php"><code>array_any()</code></a> и <a href="/manual/ru/function.array-all.php"><code>array_all()</code></a>.',
-    'pdo_driver_specific_parsers_title' => 'SQL-парсеры, специфичные для драйверов PDO',
-    'pdo_driver_specific_parsers_description' => 'Добавлены дочерние классы <code>Pdo\Dblib</code>, <code>Pdo\Firebird</code>, <code>Pdo\MySql</code>, <code>Pdo\Odbc</code>, <code>Pdo\Sqlite</code> драйверов, наследующие <code>PDO</code>.',
+    'pdo_driver_specific_subclasses_title' => 'SQL-парсеры, специфичные для драйверов PDO',
+    'pdo_driver_specific_subclasses_description' => 'Добавлены дочерние классы <code>Pdo\Dblib</code>, <code>Pdo\Firebird</code>, <code>Pdo\MySql</code>, <code>Pdo\Odbc</code>, <code>Pdo\Sqlite</code> драйверов, наследующие <code>PDO</code>.',
     'new_without_parentheses_title' => '<code>new MyClass()->method()</code> без скобок',
     'new_without_parentheses_description' => 'К свойствам и методам только что инициализированного объекта теперь можно обращаться, не оборачивая выражение <code>new</code> в круглые скобки.',
 

--- a/releases/8.4/languages/uk.php
+++ b/releases/8.4/languages/uk.php
@@ -20,7 +20,7 @@ return [
     'new_array_find_title' => 'Нові функції <code>array_*()</code>',
     'new_array_find_description' => 'Нові функції <a href="/manual/uk/function.array-find.php"><code>array_find()</code></a>, <a href="/manual/uk/function.array-find-key.php"><code>array_find_key()</code></a>, <a href="/manual/uk/function.array-any.php"><code>array_any()</code></a> і <a href="/manual/uk/function.array-all.php"><code>array_all()</code></a>.',
     'pdo_driver_specific_subclasses_title' => 'Специфічні аналізатори синтаксису SQL для драйверів PDO',
-    'pdo_driver_specific_subclasses_description' => 'Нові підкласи <code>Pdo\Dblib</code>, <code>Pdo\Firebird</code>, <code>Pdo\MySql</code>, <code>Pdo\Odbc</code> і <code>Pdo\Sqlite</code> для <code>PDO</code>.',
+    'pdo_driver_specific_subclasses_description' => 'Нові підкласи <code>Pdo\Dblib</code>, <code>Pdo\Firebird</code>, <code>Pdo\MySql</code>, <code>Pdo\Odbc</code>, <code>Pdo\Pgsql</code> і <code>Pdo\Sqlite</code> для <code>PDO</code>.',
     'new_without_parentheses_title' => '<code>new MyClass()->method()</code> без дужок',
     'new_without_parentheses_description' => 'До властивостей і методів нового екземпляра об\'єкта тепер можна звертатися, не беручи вираз <code>new</code> у круглі дужки.',
 

--- a/releases/8.4/languages/uk.php
+++ b/releases/8.4/languages/uk.php
@@ -19,8 +19,8 @@ return [
     'bcmath_description' => '<p>Новий об\'єкт <code>BcMath\Number</code> дозволяє використовувати об\'єктно-орієнтовану модель і стандартні математичні оператори під час роботи з числами довільної точності.</p><p>Ці об\'єкти є незмінними і реалізують інтерфейс <code>Stringable</code>, тому їх можна використовувати у контекстах рядків, наприклад, у виразі <code>echo $num</code>.</p>',
     'new_array_find_title' => 'Нові функції <code>array_*()</code>',
     'new_array_find_description' => 'Нові функції <a href="/manual/uk/function.array-find.php"><code>array_find()</code></a>, <a href="/manual/uk/function.array-find-key.php"><code>array_find_key()</code></a>, <a href="/manual/uk/function.array-any.php"><code>array_any()</code></a> і <a href="/manual/uk/function.array-all.php"><code>array_all()</code></a>.',
-    'pdo_driver_specific_parsers_title' => 'Специфічні аналізатори синтаксису SQL для драйверів PDO',
-    'pdo_driver_specific_parsers_description' => 'Нові підкласи <code>Pdo\Dblib</code>, <code>Pdo\Firebird</code>, <code>Pdo\MySql</code>, <code>Pdo\Odbc</code> і <code>Pdo\Sqlite</code> для <code>PDO</code>.',
+    'pdo_driver_specific_subclasses_title' => 'Специфічні аналізатори синтаксису SQL для драйверів PDO',
+    'pdo_driver_specific_subclasses_description' => 'Нові підкласи <code>Pdo\Dblib</code>, <code>Pdo\Firebird</code>, <code>Pdo\MySql</code>, <code>Pdo\Odbc</code> і <code>Pdo\Sqlite</code> для <code>PDO</code>.',
     'new_without_parentheses_title' => '<code>new MyClass()->method()</code> без дужок',
     'new_without_parentheses_description' => 'До властивостей і методів нового екземпляра об\'єкта тепер можна звертатися, не беручи вираз <code>new</code> у круглі дужки.',
 

--- a/releases/8.4/languages/zh.php
+++ b/releases/8.4/languages/zh.php
@@ -21,8 +21,8 @@ return [
     'dom_additions_html5_description' => '<p>新的 DOM API 包括符合标准的支持，用于解析 HTML5 文档，修复了 DOM 功能行为中的几个长期存在的规范性错误，并添加了几个函数，使处理文档更加方便。</p><p>新的 DOM API 可以在 <code>Dom</code> 命名空间中使用。使用新的 DOM API 可以使用 <code>Dom\HTMLDocument</code> 和 <code>Dom\XMLDocument</code> 类创建文档。</p>',
     'new_array_find_title' => '新的 <code>array_*()</code> 函数',
     'new_array_find_description' => '新增函数 <a href="/manual/zh/function.array-find.php"><code>array_find()</code></a>、<a href="/manual/zh/function.array-find-key.php"><code>array_find_key()</code></a>、<a href="/manual/zh/function.array-any.php"><code>array_any()</code></a> 和 <a href="/manual/zh/function.array-all.php"><code>array_all()</code></a>。',
-    'pdo_driver_specific_parsers_title' => 'PDO 驱动程序特定的 SQL 解析器',
-    'pdo_driver_specific_parsers_description' => '新的 <code>Pdo\Dblib</code>、<code>Pdo\Firebird</code>、<code>Pdo\MySql</code>、<code>Pdo\Odbc</code> 和 <code>Pdo\Sqlite</code> 的子类可用。',
+    'pdo_driver_specific_subclasses_title' => 'PDO 驱动程序特定的 SQL 解析器',
+    'pdo_driver_specific_subclasses_description' => '新的 <code>Pdo\Dblib</code>、<code>Pdo\Firebird</code>、<code>Pdo\MySql</code>、<code>Pdo\Odbc</code> 和 <code>Pdo\Sqlite</code> 的子类可用。',
     'new_without_parentheses_title' => '<code>new MyClass()->method()</code> 不需要括号',
     'new_without_parentheses_description' => '现在可以在不使用括号包装 <code>new</code> 表达式的情况下访问新实例化对象的属性和方法。',
 

--- a/releases/8.4/languages/zh.php
+++ b/releases/8.4/languages/zh.php
@@ -22,7 +22,7 @@ return [
     'new_array_find_title' => '新的 <code>array_*()</code> 函数',
     'new_array_find_description' => '新增函数 <a href="/manual/zh/function.array-find.php"><code>array_find()</code></a>、<a href="/manual/zh/function.array-find-key.php"><code>array_find_key()</code></a>、<a href="/manual/zh/function.array-any.php"><code>array_any()</code></a> 和 <a href="/manual/zh/function.array-all.php"><code>array_all()</code></a>。',
     'pdo_driver_specific_subclasses_title' => 'PDO 驱动程序特定的 SQL 解析器',
-    'pdo_driver_specific_subclasses_description' => '新的 <code>Pdo\Dblib</code>、<code>Pdo\Firebird</code>、<code>Pdo\MySql</code>、<code>Pdo\Odbc</code> 和 <code>Pdo\Sqlite</code> 的子类可用。',
+    'pdo_driver_specific_subclasses_description' => '新的 <code>Pdo\Dblib</code>、<code>Pdo\Firebird</code>、<code>Pdo\MySql</code>、<code>Pdo\Odbc</code>、<code>Pdo\Pgsql</code> 和 <code>Pdo\Sqlite</code> 的子类可用。',
     'new_without_parentheses_title' => '<code>new MyClass()->method()</code> 不需要括号',
     'new_without_parentheses_description' => '现在可以在不使用括号包装 <code>new</code> 表达式的情况下访问新实例化对象的属性和方法。',
 

--- a/releases/8.4/release.inc
+++ b/releases/8.4/release.inc
@@ -425,9 +425,9 @@ PHP
             </div>
         </div>
         <div class="php8-compare">
-            <h2 class="php8-h2" id="pdo_driver_specific_parsers">
-                <?= message('pdo_driver_specific_parsers_title', $lang) ?>
-                <a class="php8-rfc" href="https://wiki.php.net/rfc/pdo_driver_specific_parsers">RFC</a>
+            <h2 class="php8-h2" id="pdo_driver_specific_subclasses">
+                <?= message('pdo_driver_specific_subclasses_title', $lang) ?>
+                <a class="php8-rfc" href="https://wiki.php.net/rfc/pdo_driver_specific_subclasses">RFC</a>
             </h2>
             <div class="php8-compare__main">
                 <div class="php8-compare__block example-contents">
@@ -475,7 +475,7 @@ PHP
                 </div>
             </div>
             <div class="php8-compare__content">
-                <?= message('pdo_driver_specific_parsers_description', $lang) ?>
+                <?= message('pdo_driver_specific_subclasses_description', $lang) ?>
             </div>
         </div>
         <div class="php8-compare">


### PR DESCRIPTION
PHP 8.4 has accepted two RFCs with similar titles, and they seem to be mixed up.

- https://wiki.php.net/rfc/pdo_driver_specific_subclasses
- https://wiki.php.net/rfc/pdo_driver_specific_parsers

This PR also adds `Pdo\Pgsql` class in the list of new PDO subclasses.