### PR TITLE
8.4: Changed announced version to 8.4 from 8.4.0

### DIFF
--- a/releases/8.4/common.php
+++ b/releases/8.4/common.php
@@ -26,7 +26,7 @@ function common_header(string $description): void {
         \filter_var($MYSITE . 'images/php8/php_8_4_released.png', \FILTER_VALIDATE_URL));
     $meta_description = \htmlspecialchars($description);
 
-    \site_header("PHP 8.4.0 Release Announcement", [
+    \site_header("PHP 8.4 Release Announcement", [
         'current' => 'php8',
         'css' => ['php8.css'],
         'meta_tags' => <<<META


### PR DESCRIPTION
The version officially announced was 8.4.1, so it's better to skip the patch version in the page header.