### PR TITLE
Disable spellchecker for interactive code examples

### DIFF
--- a/js/interactive-examples.js
+++ b/js/interactive-examples.js
@@ -57,6 +57,7 @@ async function main() {
     }
 
     const code = phpcode.querySelector("code");
+    code.spellcheck = false;
     code.setAttribute("contentEditable", true);
 
     button.innerText = "Run code";


### PR DESCRIPTION
Otherwise almost all identifiers will be marked as erroneous.