### PR TITLE
Allow "/" when editing code

### DIFF
--- a/js/search.js
+++ b/js/search.js
@@ -295,7 +295,7 @@ const initSearchModal = () => {
     // Open when / is pressed
     document.addEventListener("keydown", (event) => {
         if (event.target.contentEditable === 'true') {
-          return;
+            return;
         }
 
         if (event.key === "/") {

--- a/js/search.js
+++ b/js/search.js
@@ -294,6 +294,10 @@ const initSearchModal = () => {
 
     // Open when / is pressed
     document.addEventListener("keydown", (event) => {
+        if (event.target.contentEditable) {
+          return;
+        }
+
         if (event.key === "/") {
             show();
             event.preventDefault();

--- a/js/search.js
+++ b/js/search.js
@@ -294,7 +294,7 @@ const initSearchModal = () => {
 
     // Open when / is pressed
     document.addEventListener("keydown", (event) => {
-        if (event.target.contentEditable === 'true') {
+        if (event.target.contentEditable === "true") {
             return;
         }
 

--- a/js/search.js
+++ b/js/search.js
@@ -294,7 +294,7 @@ const initSearchModal = () => {
 
     // Open when / is pressed
     document.addEventListener("keydown", (event) => {
-        if (event.target.contentEditable) {
+        if (event.target.contentEditable === 'true') {
           return;
         }
 


### PR DESCRIPTION
It was reported that you can't hit "/" when editing code, this fixes it. I was suprised that this part of the code doesn't use `mousetrap` as in `js/common.js`.