### PR TITLE
Exclude input and textarea from "/" key handler

### DIFF
--- a/js/search.js
+++ b/js/search.js
@@ -294,7 +294,13 @@ const initSearchModal = () => {
 
     // Open when / is pressed
     document.addEventListener("keydown", (event) => {
-        if (event.target.contentEditable === "true") {
+        const target = event.target;
+
+        if (
+            target.contentEditable === "true" ||
+            target.tagName === "INPUT" ||
+            target.tagName === "TEXTAREA"
+        ) {
             return;
         }
 


### PR DESCRIPTION
Fix #1211 

Updated the keydown event listener to exclude <input> and <textarea> elements in addition to contentEditable elements. This ensures that the "/" shortcut does not interfere with user input in form fields or editable areas.