### PR TITLE
Add scroll padding for anchor links

### DIFF
--- a/styles/theme-base.css
+++ b/styles/theme-base.css
@@ -18,6 +18,7 @@
   --dark-magenta-color: #793862;
   --medium-magenta-color: #AE508D;
   --light-magenta-color: #CF82B1;
+  scroll-padding-top: 4rem;
 }
 
 .clearfix {


### PR DESCRIPTION
On pages with sticky breadcrumbs, this fixes the anchored link to scroll less to account for the stickied header.

This may not be enough if the sticky bar happens to occur more space than 64 pixels (4rem) I set it to.

Example link to try on: https://www.php.net/manual/en/opcache.configuration.php#ini.opcache.blacklist-filename

Before:
![image](https://github.com/user-attachments/assets/9daf3476-23e4-49c9-98ab-fdf5ff20e889)

After:
![image](https://github.com/user-attachments/assets/64be40c3-899b-4d70-a6af-3137e6fe5b46)
