### PR TITLE
Fix search result descriptions are double-escaped

### DIFF
--- a/js/search-index.php
+++ b/js/search-index.php
@@ -59,7 +59,7 @@ $js = json_decode($s, true);
 
 foreach ($js as $k => $item) {
     if ($item && isset($index[$k])) {
-        $index[$k][1] = $item;
+        $index[$k][1] = html_entity_decode($item);
     }
 }
 

--- a/js/search.js
+++ b/js/search.js
@@ -418,7 +418,7 @@ const initSearchUI = ({ searchCallback, language, limit = 30 }) => {
                             id="search-modal__result-description-${i}"
                             class="search-modal__result-description"
                         >
-                            ${description}
+                            ${escape(description)}
                         </div>
                     </div>
                 </a>

--- a/js/search.js
+++ b/js/search.js
@@ -418,7 +418,7 @@ const initSearchUI = ({ searchCallback, language, limit = 30 }) => {
                             id="search-modal__result-description-${i}"
                             class="search-modal__result-description"
                         >
-                            ${escape(description)}
+                            ${description}
                         </div>
                     </div>
                 </a>


### PR DESCRIPTION
Fix #1239

The data is already escaped.

![image](https://github.com/user-attachments/assets/cdc47ae1-f42d-4c63-9c89-a9c3493eb7e7)
