### PR TITLE
Remove the extra colon from the language selector

### DIFF
--- a/include/ui_translation/pt_br.ini
+++ b/include/ui_translation/pt_br.ini
@@ -1,4 +1,4 @@
-change_language = "Selecione a língua:"
+change_language = "Selecione a língua"
 improve_this_page = "Melhore Esta Página"
 how_to_improve_this_page = "Aprenda Como Melhorar Esta Página"
 contribution_guidlines_on_github = "Este atalho te leva ao nosso guia de contribuição no GitHub"


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/4243dc7e-b84b-421f-b60e-cf6dd528a33b)

![image](https://github.com/user-attachments/assets/15134eb8-7e39-4ecf-a50a-839afbeda9fb)
