### PR TITLE
Normalize language code case in LangChooser

### DIFF
--- a/src/LangChooser.php
+++ b/src/LangChooser.php
@@ -97,7 +97,7 @@ class LangChooser
                 // The language part is either a code or a code with a quality
                 // We cannot do anything with a * code, so it is skipped
                 // If the quality is missing, it is assumed to be 1 according to the RFC
-                if (preg_match("!([a-z-]+)(;q=([0-9\\.]+))?!", trim($value), $found)) {
+                if (preg_match("!([a-z-]+)(;q=([0-9\\.]+))?!", strtolower(trim($value)), $found)) {
                     $quality = (isset($found[3]) ? (float) $found[3] : 1.0);
                     $browser_langs[] = [$found[1], $quality];
                 }


### PR DESCRIPTION
Fix #1302

In `cs,en;q=0.9,fr;q=0.8,zh-CN;q=0.7,zh;q=0.6`, `zh-CN` is not converted to lowercase, so the match is `zh-` with a quality of 1. After converting `zh-` to zh, quality is greater than 0.9 for en.