### PR TITLE
Update prepend.inc add human logic function

### DIFF
--- a/include/prepend.inc
+++ b/include/prepend.inc
@@ -121,3 +121,11 @@ function google_cse(): void {
 
     echo $cse_snippet;
 }
+// Human bool function
+if(!function_exists('bool'))
+{
+    function bool($logic_parametr): bool 
+    {
+        return (is_scalar(logic_parametr)) ? filter_var(logic_parametr ?? 0, FILTER_VALIDATE_BOOLEAN) : false;
+    }
+}


### PR DESCRIPTION
it is known that 'is_scalar' does not skip 'null', but the documentation indicates that some resources may be skipped in the future, and since hypothetically a resource can return 'null', the code uses an excessive check for null '$logic_parametr ?? 0'. If you look under the hood of filter_var FILTER_VALIDATE_BOOLEAN, it is known that null returns false, so this construction is '$logic_parametr ?? 0' is redundant and must be replaced by '$logic_parametr'