### PR TITLE
Add MacPorts instructions for switching PHP versions

### DIFF
--- a/include/download-instructions/osx-macports.php
+++ b/include/download-instructions/osx-macports.php
@@ -5,7 +5,9 @@ On the command line, run the following commands:
 # Please refer to https://guide.macports.org/chunked/installing.macports.html for installing MacPorts.
 
 # Install PHP <?= $version; ?>
+
 sudo port install php<?= $versionNoDot; ?>
+
 
 # Switch Active PHP <?= $version; ?> version
 sudo port select php php<?= $versionNoDot; ?>


### PR DESCRIPTION
Per issue #1314 , this PR adds some instructions to the MacOS MacPorts installation documentation for changing between PHP versions.