### PR TITLE
Detect OS and OS variant on downloads page

### DIFF
--- a/downloads.php
+++ b/downloads.php
@@ -99,14 +99,43 @@ $versions = [
     'default' => 'OS default version',
 ];
 
+
+$platform = $_SERVER['HTTP_SEC_CH_UA_PLATFORM'] ?? '';
+$ua = $_SERVER['HTTP_USER_AGENT'] ?? '';
+$auto_os = null;
+$auto_osvariant = null;
+
+if (!empty($platform) || !empty($ua)) {
+    $platform = strtolower(trim($platform, '"'));
+    if ($platform === 'windows' || stripos($ua, 'Windows') !== false) {
+        $auto_os = 'windows';
+    } elseif ($platform === 'macos' || stripos($ua, 'Mac') !== false) {
+        $auto_os = 'osx';
+    } elseif ($platform === 'linux' || stripos($ua, 'Linux') !== false) {
+        $auto_os = 'linux';
+        if (stripos($ua, 'Ubuntu') !== false) {
+            $auto_osvariant = 'linux-ubuntu';
+        } elseif (stripos($ua, 'Debian') !== false) {
+            $auto_osvariant = 'linux-debian';
+        } elseif (stripos($ua, 'Fedora') !== false) {
+            $auto_osvariant = 'linux-fedora';
+        } elseif (stripos($ua, 'Red Hat') !== false || stripos($ua, 'RedHat') !== false) {
+            $auto_osvariant = 'linux-redhat';
+        }
+    }
+}
+
 $defaults = [
-    'os' => 'linux',
+    'os' => $auto_os ?? 'linux',
     'version' => 'default',
     'usage' => 'web',
 ];
 
 $options = array_merge($defaults, $_GET);
-if (!array_key_exists('osvariant', $options) || !array_key_exists($options['osvariant'], $os[$options['os']]['variants'])) {
+
+if ($auto_osvariant && (!array_key_exists('osvariant', $options) || !array_key_exists($options['osvariant'], $os[$options['os']]['variants']))) {
+    $options['osvariant'] = $auto_osvariant;
+} elseif (!array_key_exists('osvariant', $options) || !array_key_exists($options['osvariant'], $os[$options['os']]['variants'])) {
     $options['osvariant'] = array_key_first($os[$options['os']]['variants']);
 }
 ?>


### PR DESCRIPTION
This is an attempt to do basic os detection on the downloads page to choose defaults, based on the user agent and the platform user agent client hint that newer browsers support.