### PR TITLE
Format arrow functions on 8.4 release page consistently with other docs pages

### DIFF
--- a/releases/8.4/release.inc
+++ b/releases/8.4/release.inc
@@ -411,7 +411,7 @@ PHP
                             <<<'PHP'
 $animal = array_find(
     ['dog', 'cat', 'cow', 'duck', 'goose'],
-    static fn (string $value): bool => str_starts_with($value, 'c'),
+    static fn(string $value): bool => str_starts_with($value, 'c'),
 );
 
 var_dump($animal); // string(3) "cat"
@@ -443,7 +443,7 @@ $connection = new PDO(
 
 $connection->sqliteCreateFunction(
     'prepend_php',
-    static fn ($string) => "PHP {$string}",
+    static fn($string) => "PHP {$string}",
 );
 
 $connection->query('SELECT prepend_php(version) FROM php');
@@ -465,7 +465,7 @@ $connection = PDO::connect(
 
 $connection->createFunction(
     'prepend_php',
-    static fn ($string) => "PHP {$string}",
+    static fn($string) => "PHP {$string}",
 ); // Does not exist on a mismatching driver.
 
 $connection->query('SELECT prepend_php(version) FROM php');


### PR DESCRIPTION
Compare the examples on https://www.php.net/manual/en/functions.arrow.php.

[According to the author of the Arrow Functions RFC](https://www.reddit.com/r/PHP/comments/fctb18/comment/fjd9u6a/), they are intended to be written in the format `fn($x) => $x` (without a space after the `fn` keyword). This is also the formatting required by the popular [PER Coding Style](https://www.php-fig.org/per/coding-style/#71-short-closures).