### PR TITLE
Add schedule announcement for Longhorn Php 2025

### DIFF
--- a/archive/archive.xml
+++ b/archive/archive.xml
@@ -9,6 +9,7 @@
     <uri>http://php.net/contact</uri>
     <email>php-webmaster@lists.php.net</email>
   </author>
+  <xi:include href="entries/2025-08-20-1.xml"/>
   <xi:include href="entries/2025-08-14-1.xml"/>
   <xi:include href="entries/2025-08-10-1.xml"/>
   <xi:include href="entries/2025-08-08-1.xml"/>

--- a/archive/entries/2025-08-20-1.xml
+++ b/archive/entries/2025-08-20-1.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<entry xmlns="http://www.w3.org/2005/Atom" xmlns:default="http://php.net/ns/news">
+  <title>Longhorn PHP 2025 - Speakers and Schedule Announced!</title>
+  <id>https://www.php.net/archive/2025.php#2025-08-20-1</id>
+  <published>2025-08-20T17:41:57+00:00</published>
+  <updated>2025-08-20T17:41:57+00:00</updated>
+  <link href="https://www.php.net/conferences/index.php#2025-08-20-1" rel="alternate" type="text/html"/>
+  <link href="https://longhornphp.com/schedule" rel="via" type="text/html"/>
+  <default:finalTeaserDate xmlns="http://php.net/ns/news">2025-08-20</default:finalTeaserDate>
+  <category term="conferences" label="Conference announcement"/>
+  <default:newsImage xmlns="http://php.net/ns/news" link="https://longhornphp.com/schedule" title="LonghornPHP">longhornphp.png</default:newsImage>
+  <content type="html">Longhorn PHP is back for 2025 - and our schedule and speakers list is now live! The conference will be held in Austin, Texas, and will start with an optional tutorial day on Thursday, October 23, followed by two days full of talks and keynotes plus open spaces and more, on Friday and Saturday, October 24-25.<br/><br/>
+  Longhorn PHP is a regional community run conference, designed to help PHP developers level up their craft and connect with the larger PHP community. <a href="https://longhornphp.com/schedule">Our full schedule is available now</a>, with Blind Bird pricing still available until end of day, Sunday August 24, so grab your tickets before prices go up!
+  </content>
+</entry>

--- a/archive/entries/2025-08-20-1.xml
+++ b/archive/entries/2025-08-20-1.xml
@@ -9,7 +9,10 @@
   <default:finalTeaserDate xmlns="http://php.net/ns/news">2025-08-20</default:finalTeaserDate>
   <category term="conferences" label="Conference announcement"/>
   <default:newsImage xmlns="http://php.net/ns/news" link="https://longhornphp.com/schedule" title="LonghornPHP">longhornphp.png</default:newsImage>
-  <content type="html">Longhorn PHP is back for 2025 - and our schedule and speakers list is now live! The conference will be held in Austin, Texas, and will start with an optional tutorial day on Thursday, October 23, followed by two days full of talks and keynotes plus open spaces and more, on Friday and Saturday, October 24-25.<br/><br/>
-  Longhorn PHP is a regional community run conference, designed to help PHP developers level up their craft and connect with the larger PHP community. <a href="https://longhornphp.com/schedule">Our full schedule is available now</a>, with Blind Bird pricing still available until end of day, Sunday August 24, so grab your tickets before prices go up!
+    <content type="xhtml">
+      <div xmlns="http://www.w3.org/1999/xhtml">
+        <p>Longhorn PHP is back for 2025 - and our schedule and speakers list is now live! The conference will be held in Austin, Texas, and will start with an optional tutorial day on Thursday, October 23, followed by two days full of talks and keynotes plus open spaces and more, on Friday and Saturday, October 24-25.</p>
+        <p>Longhorn PHP is a regional community run conference, designed to help PHP developers level up their craft and connect with the larger PHP community. <a href="https://longhornphp.com/schedule">Our full schedule is available now</a>, with Blind Bird pricing still available until end of day, Sunday August 24, so grab your tickets before prices go up!</p>
+      </div>
   </content>
 </entry>


### PR DESCRIPTION
Adds announcement for Longhorn PHP, now that our schedule is live. 

The createNewsEntry script crashed when I ran it because I used a "&" so I did have to edit the XML file by hand after that and copied the xhtml tags from a previous entry. 🤞🏼 