### PR TITLE
fix: adds trailing space

### DIFF
--- a/releases/index.php
+++ b/releases/index.php
@@ -93,7 +93,7 @@ foreach ($OLDRELEASES as $major => $a) {
     if (!in_array($major, $active_majors, false)) {
         echo "\n<br>\n";
         echo "<p>Support for PHP $major has been <b style=\"color: red;\">discontinued</b> ";
-        echo "since <b>" . current($a)['date'] . '</b>.';
+        echo "since <b>" . current($a)['date'] . '</b>. ';
         echo "Please consider upgrading to $latest.</p>\n";
     }
 


### PR DESCRIPTION
I added a trailing space to fix this:
<img width="1115" height="146" alt="image" src="https://github.com/user-attachments/assets/cdc4a24e-eb5e-47a4-8f9b-c7713f4dd41f" />

Please take a look at: https://www.php.net/releases/index.php