### PR TITLE
Fix broken Windows builds links after new releases

### DIFF
--- a/include/download-instructions/windows-downloads.php
+++ b/include/download-instructions/windows-downloads.php
@@ -1,5 +1,5 @@
 <?php
-$baseDownloads  = 'https://downloads.php.net/~windows/releases/';
+$baseDownloads  = 'https://downloads.php.net/~windows/releases/archives/';
 
 $dataStr = @file_get_contents(__DIR__ . '/../../backend/win-releases.json');
 $releases = $dataStr ? json_decode($dataStr, true) : null;


### PR DESCRIPTION
After a new windows releases, until releases.json file is synced, the links for windows are broken. This PR fixes that by always referencing builds from archives directory, so on new releases they are not broken.