### PR TITLE
interactive-examples.js: Fix access on null value

### DIFF
--- a/js/interactive-examples.js
+++ b/js/interactive-examples.js
@@ -74,7 +74,9 @@ async function main() {
     if (exampleTitleContainer !== null) {
       exampleTitleParagraphElement = exampleTitleContainer.querySelector("p")
       const exampleScreenContainer = exampleTitleContainer.nextElementSibling;
-      exampleScreenPreElement = exampleScreenContainer.querySelector("pre");
+      if (exampleScreenContainer !== null) {
+          exampleScreenPreElement = exampleScreenContainer.querySelector("pre");
+      }
     }
 
     const code = phpcode.querySelector("code");


### PR DESCRIPTION
This manifested as every example after the first failing to show a Run button on (with interactives enabled) https://www.php.net/manual/en/datetimeimmutable.createfromformat.php