### PR TITLE
interactive-examples.js: Fix handling on newlines (multiple newlines collapsed)

### DIFF
--- a/js/interactive-examples.js
+++ b/js/interactive-examples.js
@@ -36,22 +36,21 @@ class PHP {
     if (PHP.runPhp) {
       return PHP.runPhp;
     }
+    let initializing = true;
 
     const { ccall } = await phpBinary({
       print(data) {
-        if (!data) {
+        // The initial exec to get PHP version causes empty output we don't want
+        if (initializing) {
           return;
         }
-
-        if (PHP.buffer.length) {
-          PHP.buffer.push("\n");
-        }
-        PHP.buffer.push(data);
+        PHP.buffer.push(data + "\n");
       },
     });
 
     PHP.version = ccall("phpw_exec", "string", ["string"], ["phpversion();"]),
     console.log("PHP wasm %s loaded.", PHP.version);
+    initializing = false;
     PHP.runPhp = (code) => ccall("phpw_run", null, ["string"], ["?>" + code]);
     return PHP.runPhp;
   }

--- a/js/php-web-README.md
+++ b/js/php-web-README.md
@@ -1,0 +1,2 @@
+These files are built by [emcripten](https://github.com/emscripten-core/emscripten)
+via https://github.com/derickr/php-wasm-builder


### PR DESCRIPTION
In addition to the example #1 on htmlentities(), I tested this on several other examples that involve multiple newlines (mostly print_r) and found no issues.

FAO @derickr 