### PR TITLE
Fix example code block padding for PHP 8.3+

### DIFF
--- a/styles/theme-base.css
+++ b/styles/theme-base.css
@@ -948,7 +948,7 @@ div.tip p:first-child {
     overflow-x: auto;
 }
 
-.docs .example-contents > .phpcode > pre,
+.docs .example-contents > .phpcode > pre > code,
 .docs .example-contents > .phpcode > code {
     padding: .75rem;
 }


### PR DESCRIPTION
This pull request fixes the missing padding in example code blocks introduced by changes in PHP 8.3+.  
Since `highlight_string()` now returns `<pre><code>...</code></pre>` instead of `<code>...</code>`, the existing CSS rule targeting only `<code>` no longer applied.  

<img width="406" height="253" alt="截屏2025-10-09 19 46 40" src="https://github.com/user-attachments/assets/89b726af-7b08-48e3-beca-e103ed76b613" />


The fix adds `<pre>` to the selector so both cases are covered:

```diff
+.docs .example-contents > .phpcode > pre,
 .docs .example-contents > .phpcode > code {
     padding: .75rem;
 }
```

This ensures that the padding style is correctly applied to all example code blocks.