### PR TITLE
Fix PHP 8.4 property hooks example not being full width when wrapped

### DIFF
--- a/releases/8.4/release.inc
+++ b/releases/8.4/release.inc
@@ -101,9 +101,9 @@ PHP
                     </div>
                 </div>
                 <div class="php8-compare__arrow"></div>
-                <div class="php8-compare__block example-contents" style="display: table;">
+                <div class="php8-compare__block example-contents">
                     <div class="php8-compare__label php8-compare__label_new">PHP 8.4</div>
-                    <div class="php8-code phpcode" style="display: table-cell;">
+                    <div class="php8-code align-start phpcode">
                         <?php highlight_php_trimmed(
                             <<<'PHP'
 class Locale

--- a/styles/php8.css
+++ b/styles/php8.css
@@ -305,6 +305,10 @@
   margin: 0 !important;
 }
 
+.align-start {
+    align-items: start;
+}
+
 @media (max-width: 768px) {
   .php8-code {
     padding-left: 12px !important;


### PR DESCRIPTION
Previously overriding the display from `flex` to `table-cell` caused the width to be no wider than the contents:
<img width="1007" height="265" alt="Narrower code block 2" src="https://github.com/user-attachments/assets/08d0b5b9-4c48-4bb8-8042-cd4049610bb1" />




It's not very noticeable in this case since the contents are almost as wide as the page, but if we want to top-align other code blocks where the contents aren't as wide, the issue becomes much more obvious.