### PR TITLE
(Docs) CSS stylesheets: Fix for PHP 8.3+ highlight_string changes

### DIFF
--- a/styles/theme-base.css
+++ b/styles/theme-base.css
@@ -948,7 +948,7 @@ div.tip p:first-child {
     overflow-x: auto;
 }
 
-.docs .example-contents > .phpcode > code {
+.docs .example-contents > .phpcode > code, .docs .example-contents > .phpcode > pre {
     padding: .75rem;
 }
 


### PR DESCRIPTION
Related: https://github.com/php/phd/issues/208

When generating docs with PHP 8.3+, the examples have lost the padding due to changes in the code generated by highlight_string.

This currently only affects users generating their own docs, but will affect the web docs when the PHP version used to generate those is updated.

I tested these changes locally and with the current live web docs (using stylish) and did not find anywhere it interfered with the current styles.