### PR TITLE
Downloads: Add `winget` download instrunctions

### DIFF
--- a/downloads.php
+++ b/downloads.php
@@ -88,6 +88,7 @@ $os = [
             'windows-native' => 'Single Line Installer',
             'windows-chocolatey' => 'Chocolatey',
             'windows-scoop' => 'Scoop',
+            'windows-winget' => 'Winget',
             'windows-docker' => 'Docker',
             'windows-wsl-debian' => 'WSL/Debian',
             'windows-wsl-ubuntu' => 'WSL/Ubuntu',

--- a/include/download-instructions/windows-winget.php
+++ b/include/download-instructions/windows-winget.php
@@ -1,0 +1,20 @@
+<p>
+On the command line, run the following commands:
+</p>
+<?php
+
+$wingetPackageName = 'PHP.PHP.' . $version;
+$wingetPackageDescription = 'PHP ' . $version . ' - Thread-safe';
+
+if (isset($options['usage']) && $options['usage'] === 'cli') {
+    $wingetPackageName = 'PHP.PHP.NTS.' . $version;
+    $wingetPackageDescription = 'PHP ' . $version . ' - Not-Thread safe';
+}
+?>
+<pre><code class="language-powershell line-numbers">
+# Download and install <?= $wingetPackageDescription ?>
+
+winget install <?= $wingetPackageName ?>
+</code></pre>
+<?php
+unset($wingetPackageDescription, $wingetPackageName);


### PR DESCRIPTION
Adds support for downloading Windows PHP binaries using `winget`.

Both TS and NTS builds are now available on `microsoft/winget-pkgs`[1] repo, and I have been maintaining them for a while now.

When a new PHP release is found, the manifests are automatically[^2] built and the manifests are attested[^3]. I submit PRs[^4] after manually checking if everything is in order.

This PR updates the new `downloads.php` page with `winget`-specific download instructions.

 - When the Usage field is set to CLI, the winget instructions refer to NTS builds (e.g `PHP.PHP.NTS.8.4`)
 - Other Usage values use the TS builds (e.g. `PHP.PHP.8.4`).

[^1]: https://github.com/microsoft/winget-pkgs/tree/master/manifests/p/PHP/PHP
[^2]: https://github.com/PHPWatch/php-winget-manifest/
[^3]: https://github.com/PHPWatch/php-winget-manifest/attestations
[^4]: https://github.com/microsoft/winget-pkgs/pulls?q=is%3Apr+%5BPHP%5D