### PR TITLE
Add betterCode() PHP 2025

### DIFF
--- a/archive/archive.xml
+++ b/archive/archive.xml
@@ -9,6 +9,7 @@
     <uri>http://php.net/contact</uri>
     <email>php-webmaster@lists.php.net</email>
   </author>
+  <xi:include href="entries/2025-10-31-1.xml"/>
   <xi:include href="entries/2025-10-23-3.xml"/>
   <xi:include href="entries/2025-10-23-2.xml"/>
   <xi:include href="entries/2025-10-23-1.xml"/>

--- a/archive/entries/2025-10-31-1.xml
+++ b/archive/entries/2025-10-31-1.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<entry xmlns="http://www.w3.org/2005/Atom" xmlns:default="http://php.net/ns/news">
+    <title>betterCode() PHP 2025</title>
+    <id>https://www.php.net/archive/2025.php#2025-10-13-1</id>
+    <published>2025-10-31T12:00:00+00:00</published>
+    <updated>2025-10-31T12:00:00+00:00</updated>
+    <link href="https://www.php.net/conferences/index.php#id2025-10-31-1" rel="alternate" type="text/html"/>
+    <link href="https://php.bettercode.eu/" rel="via" type="text/html"/>
+    <default:finalTeaserDate xmlns="http://php.net/ns/news">2025-11-25</default:finalTeaserDate>
+    <category term="conferences" label="Conference announcement"/>
+    <content type="xhtml">
+        <div xmlns="http://www.w3.org/1999/xhtml">
+            <p>With version 8.5, PHP continues to evolve in its thirtieth year: the new pipe operator and numerous performance improvements make your development more efficient. At the same time, FrankenPHP is establishing itself in Caddy Server, a European open-source solution, as a modern alternative to Nginx.</p>
+            <p>betterCode() PHP supports you in using PHP 8.5, switching to FrankenPHP and the Caddy Server. Artificial intelligence is also part of the software development toolkit today: if you want to use it effectively, you need clear architectures, clean code, and solid patterns.</p>
+            <p><a href="https://php.bettercode.eu/">betterCode() PHP 2025</a> is an online conference lasting one day, with most of the presentations delivered in German.</p>
+        </div>
+    </content>
+</entry>


### PR DESCRIPTION
**Untested** because I could not figure out how.

I checked out `git@github.com:php/web-php.git` and ran `php -S localhost:8080 .router.php` as documented in `README.md`. I then see the website on `localhost:8080` with news from 2019. What am I missing? What do I need to do to see up-to-date news? Thanks!