### PR TITLE
Search: Clear any old caches to free up quota

### DIFF
--- a/js/search.js
+++ b/js/search.js
@@ -35,12 +35,26 @@ const initPHPSearch = async (language) => {
         return data;
     };
 
+    const cleanupOld = async() => {
+        // Previously used cache key
+        const key = `search-${language}`;
+        const oldCache = window.localStorage.getItem(key);
+        if (!oldCache) {
+            return;
+        }
+
+        // Clear is used to clear all cached languages at the same time
+        // This reduces the chances of hitting quota
+        window.localStorage.clear();
+    }
+
     /**
      * Fetch the search index.
      *
      * @returns {Promise<Array>} The search index.
      */
     const fetchIndex = async () => {
+        await cleanupOld();
         const key = `search2-${language}`;
         let items;
         if (language === 'local') {
@@ -60,7 +74,7 @@ const initPHPSearch = async (language) => {
             } catch (e) {
                 // Local storage might be full, or other error.
                 // Just continue without caching.
-                console.error("Failed to cache search index", e);
+                console.info("Failed to cache search index", e);
             }
         }
 


### PR DESCRIPTION
Related to #1589 

This change removes any old caches before storing new data. This reduces the chances of hitting quota.

(This won't happen immediately for all users - this check is only done when either there is no current cached indexes or the cache expires and the script wants to fetch new data, which currently happens every 14 days.

I've also changed the message when quota is exceeded to an info message, since it doesn't actually affect functionality.

Note that it's still possible for users to hit quota even disregarding old cached values if they use the manual in multiple languages.

The search indexes are ~2.1 MB and localStorage quota is (generally) 5MB according to https://developer.mozilla.org/en-US/docs/Web/API/Storage_API/Storage_quotas_and_eviction_criteria

Based on this (any my own testing) users can store the indexes for 2 languages at most.

I further explore this issue in #1593