### PR TITLE
Search: Reject old format indexes (forcing refetch)

### DIFF
--- a/js/search.js
+++ b/js/search.js
@@ -28,6 +28,13 @@ const initPHPSearch = async (language) => {
 
         const expireDate = cachedDate + CACHE_DAYS * MILLISECONDS_PER_DAY;
 
+        // Reject old format indexes
+        if (
+          (typeof data[0] !== 'object')
+          || Array.isArray(data[0])
+        ) {
+          return null;
+        }
         if (Date.now() > expireDate) {
             return null;
         }


### PR DESCRIPTION
Fixes #1589 

This change will reject cached indexes not in the expected format. This should fix issues for users who cached the old format indexes under the new key.