### PR TITLE
Fix mobile navbar sizing

### DIFF
--- a/styles/php85.css
+++ b/styles/php85.css
@@ -44,7 +44,6 @@
 
 .php85 .navbar .navbar__nav {
     margin: 0;
-    margin-left: 24px;
 }
 
 .php85 #layout-content a:link,

--- a/styles/theme-medium.css
+++ b/styles/theme-medium.css
@@ -203,6 +203,7 @@ div.warning a:focus {
 
 .navbar__inner {
   display: flex;
+  gap: 24px;
   height: 64px;
   padding: 0px 16px;
   margin: 0 auto;
@@ -221,7 +222,6 @@ div.warning a:focus {
 .navbar__nav {
   display: flex;
   margin: 0;
-  margin-left: 24px;
 }
 
 .navbar__item {
@@ -279,6 +279,7 @@ div.warning a:focus {
   flex-grow: 1;
 
   max-width: 300px;
+  margin-right: 12px;
   padding: 8px 8px;
 
   background-color: #404f82;
@@ -330,6 +331,7 @@ div.warning a:focus {
   display: flex;
   flex-grow: 1;
   justify-content: end;
+  min-width: 0;
   padding: 12px 0px;
 }
 
@@ -450,6 +452,10 @@ div.warning a:focus {
     display: flex;
     align-items: center;
     text-align: left;
+  }
+
+  .navbar__theme {
+    margin-right: 0 !important;
   }
 }
 
@@ -1123,6 +1129,7 @@ div.elephpants img:focus {
     background-color: rgba(64, 79, 130, 0.7);
     border-radius: 8px;
     margin-right: 12px;
+    min-width: 0;
 }
 
 .navbar__languages:hover {
@@ -1131,6 +1138,7 @@ div.elephpants img:focus {
 
 .navbar__languages select {
     color: hsla(230, 72%, 84%);
+    max-width: 100%;
 }
 
 .navbar__languages option {
@@ -1138,7 +1146,6 @@ div.elephpants img:focus {
 }
 
 .navbar__theme {
-    margin-left: 12px;
     border: 1px solid #6a78be;
     color: hsla(230, 72%, 84%);
     background-color: #404f82;
@@ -1149,6 +1156,7 @@ div.elephpants img:focus {
     display: flex;
     align-items: center;
     justify-content: center;
+    flex-shrink: 0;
 }
 
 .navbar__theme:hover {


### PR DESCRIPTION
On smaller screen sizes the logo on the PHP 8.5 page gets squished:
<img width="384" height="331" alt="Screenshot 2025-11-24 at 11 40 43 AM" src="https://github.com/user-attachments/assets/e3404656-566b-4ba0-8938-e46801b569f1" />


This PR cleans up the sizing and spacing of flex items in the navbar so that they maintain their proportions as the navbar shrinks:
<img width="385" height="330" alt="Screenshot 2025-11-24 at 10 21 14 AM" src="https://github.com/user-attachments/assets/80e672db-1ed7-4676-8491-6cda41f4a02a" />


The theme button also had and extra right margin on the desktop breakpoint, I removed that so the navbar margin is consistent with other pages.
<img width="556" height="103" alt="Screenshot 2025-11-24 at 10 22 10 AM" src="https://github.com/user-attachments/assets/7fcc6a6b-33da-4bed-97f2-8e8f55fb466f" />
