### PR TITLE
make pipe operator discoverable from php.net/pipe + /|>

### DIFF
--- a/error.php
+++ b/error.php
@@ -410,6 +410,8 @@ $uri_aliases = [
     "splat" => "functions.arguments",
     "arrow" => "functions.arrow",
     "fn" => "functions.arrow",
+    "pipe" => "operators.functional",
+    "|>" => "operators.functional",
     // ?:, ??, ??=
     // These shortcuts can not be captured here since they
     // don't actually produce a 404 error.


### PR DESCRIPTION
Hello old friends. (-:

I believe this makes it possible to look up the pipe operator from `https://php.net/pipe` and `https://php.net/|>`.

ref https://scoat.es/@sean/115669097030558437
