### PR TITLE
add instructions for fedora/redhat and multiple versions

### DIFF
--- a/include/download-instructions/linux-fedora-cli-community.php
+++ b/include/download-instructions/linux-fedora-cli-community.php
@@ -5,9 +5,15 @@ On the command line, run the following commands:
 # Add the Remi's RPM repository.
 sudo dnf install -y dnf-plugins-core
 sudo dnf install -y https://rpms.remirepo.net/fedora/remi-release-$(rpm -E %fedora).rpm
+<?php if ($multiversion) { ?>
+
+# Install PHP (multiple versions).
+sudo dnf install -y php<?= $versionNoDot; ?>
+<?php } else { ?>
 sudo dnf module reset php -y
 sudo dnf module enable php:remi-<?= $version; ?> -y
 
-# Install PHP.
+# Install PHP (single/default version).
 sudo dnf install -y php
+<?php } ?>
 </code></pre>

--- a/include/download-instructions/linux-redhat-cli-community.php
+++ b/include/download-instructions/linux-redhat-cli-community.php
@@ -7,9 +7,15 @@ sudo subscription-manager repos --enable codeready-builder-for-rhel-$(rpm -E %rh
 sudo dnf install -y dnf-plugins-core
 sudo dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-$(rpm -E %rhel).noarch.rpm
 sudo dnf install -y https://rpms.remirepo.net/enterprise/remi-release-$(rpm -E %rhel).rpm
+<?php if ($multiversion) { ?>
+
+# Install PHP (multiple versions).
+sudo dnf install -y php<?= $versionNoDot; ?>
+<?php } else { ?>
 sudo dnf module reset php -y
 sudo dnf module enable php:remi-<?= $version; ?> -y
 
-# Install PHP.
+# Install PHP (single/default version).
 sudo dnf install -y php
+<?php } ?>
 </code></pre>


### PR DESCRIPTION
As the download page have a "`I want to be able to use multiple PHP versions`" check-box
add instructions when it is checked.


Full instructions from https://rpms.remirepo.net/wizard/