### PR TITLE
Remove obsolete crossdomain.xml file

### DIFF
--- a/crossdomain.xml
+++ b/crossdomain.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<cross-domain-policy xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.adobe.com/xml/schemas/PolicyFile.xsd">
-  <allow-access-from domain="*.php.net" />
-  <site-control permitted-cross-domain-policies="master-only"/>
-  <allow-http-request-headers-from domain="*.php.net" headers="*" secure="true"/>
-</cross-domain-policy>


### PR DESCRIPTION
The crossdomain.xml file is a legacy Adobe Flash cross-domain policy that is no longer needed in modern web applications. Flash has been deprecated and removed from browsers, making this configuration file unnecessary.