### PR TITLE
Replace docs hostname

### DIFF
--- a/archive/2007.php
+++ b/archive/2007.php
@@ -64,7 +64,7 @@ Visit <a href="http://www.prophp.com.br/phpconference.php">the website</a> for m
 The PHP documentation team is pleased to announce the initial release of
 the new build system that generates the PHP Manual. Written in PHP, PhD
 (<em>[PH]P based [D]ocBook renderer</em>) builds are now available for
-viewing at <a href="http://docs.php.net/">docs.php.net</a>. Everyone is
+viewing at <a href="https://www.php.net/">php.net</a>. Everyone is
 encouraged to test and use this system so
 that <a href="http://bugs.php.net/">bugs</a> will be found and squashed.
       </p>

--- a/archive/2007.xml
+++ b/archive/2007.xml
@@ -56,7 +56,7 @@ Visit <a href="http://www.prophp.com.br/phpconference.php">the website</a> for m
 The PHP documentation team is pleased to announce the initial release of
 the new build system that generates the PHP Manual. Written in PHP, PhD
 (<em>[PH]P based [D]ocBook renderer</em>) builds are now available for
-viewing at <a href="http://docs.php.net/">docs.php.net</a>. Everyone is
+viewing at <a href="https://www.php.net/">php.net</a>. Everyone is
 encouraged to test and use this system so
 that <a href="http://bugs.php.net/">bugs</a> will be found and squashed.
       </p>

--- a/archive/2009.php
+++ b/archive/2009.php
@@ -829,7 +829,7 @@ site_header("News Archive - 2009", ["cache" => true]);
         <li>Support for <a href="http://php.net/namespaces">namespaces</a></li>
         <li>Under the hood performance improvements</li>
         <li><a href="http://php.net/lsb">Late static binding</a></li>
-        <li><a href="http://docs.php.net/functions.anonymous">Lambda functions and closures</a></li>
+        <li><a href="https://www.php.net/functions.anonymous">Lambda functions and closures</a></li>
         <li>
          Syntax additions:
          <a href="http://php.net/manual/language.types.string.php#language.types.string.syntax.nowdoc">NOWDOC</a>, limited GOTO,

--- a/archive/2012.php
+++ b/archive/2012.php
@@ -607,7 +607,7 @@ site_header("News Archive - 2012", ["cache" => true]);
       encouraged to upgrade to PHP 5.4.4 or PHP 5.3.14.</p>
 
       <p>The release fixes multiple security issues: A weakness in the DES
-      implementation of <a href="http://docs.php.net/crypt">crypt</a> and a
+      implementation of <a href="https://www.php.net/crypt">crypt</a> and a
       heap overflow issue in the phar extension</p>
 
      <p>PHP 5.4.4 and PHP 5.3.14 fixes over 30 bugs. Please note that the
@@ -918,7 +918,7 @@ site_header("News Archive - 2012", ["cache" => true]);
      <p>
       Some of the key new features include:
       <a href="http://php.net/traits">traits</a>,
-      <a href="http://docs.php.net/manual/en/language.types.array.php">a shortened array syntax</a>,
+      <a href="https://www.php.net/manual/en/language.types.array.php">a shortened array syntax</a>,
       <a href="http://php.net/manual/en/features.commandline.webserver.php">
       a built-in webserver for testing purposes</a>
       and more. PHP 5.4.0 significantly improves performance, memory footprint and fixes over

--- a/archive/2014.php
+++ b/archive/2014.php
@@ -1196,7 +1196,7 @@ The list of changes is recorded in the <a href="http://www.php.net/ChangeLog-5.p
 
       <p>
         For more information about the new features you can check out the work-in-progress
-        <a href="http://docs.php.net/manual/en/migration56.new-features.php">documentation</a>
+        <a href="https://www.php.net/manual/en/migration56.new-features.php">documentation</a>
         or you can read the full list of changes in the
         <a href="https://github.com/php/php-src/blob/php-5.6.0beta4/NEWS">NEWS file</a>
         contained in the release archive.
@@ -1395,7 +1395,7 @@ The list of changes is recorded in the <a href="http://www.php.net/ChangeLog-5.p
      <strong>THIS IS A DEVELOPMENT PREVIEW - DO NOT USE IT IN PRODUCTION!</strong>
 
      <p>For more information about the new features you can check out the work-in-progress
-      <a href="http://docs.php.net/manual/en/migration56.new-features.php">documentation</a>
+      <a href="https://www.php.net/manual/en/migration56.new-features.php">documentation</a>
       or you can read the full list of changes in the
       <a href="https://github.com/php/php-src/blob/php-5.6.0beta3/NEWS">NEWS file</a> contained
       in the release archive.
@@ -1445,7 +1445,7 @@ The list of changes is recorded in the <a href="http://www.php.net/ChangeLog-5.p
      </ul>
 
      <p>For more information about the new features you can check out the work-in-progress
-      <a href="http://docs.php.net/manual/en/migration56.new-features.php">documentation</a>
+      <a href="https://www.php.net/manual/en/migration56.new-features.php">documentation</a>
       or you can read the full list of changes in the
       <a href="https://github.com/php/php-src/blob/php-5.6.0beta2/NEWS">NEWS file</a> contained
       in the release archive.
@@ -1540,7 +1540,7 @@ The list of changes is recorded in the <a href="http://www.php.net/ChangeLog-5.p
      </ul>
 
      <p>For more information about the new features you can check out the work-in-progress
-      <a href="http://docs.php.net/manual/en/migration56.new-features.php">documentation</a>
+      <a href="https://www.php.net/manual/en/migration56.new-features.php">documentation</a>
       or you can read the full list of changes in the
       <a href="https://github.com/php/php-src/blob/php-5.6.0beta1/NEWS">NEWS file</a> contained
       in the release archive.
@@ -1731,7 +1731,7 @@ The list of changes is recorded in the <a href="http://www.php.net/ChangeLog-5.p
      </ul>
 
      <p>For more information about the new features you can check out the work-in-progress
-      <a href="http://docs.php.net/manual/en/migration56.new-features.php">documentation</a>
+      <a href="https://www.php.net/manual/en/migration56.new-features.php">documentation</a>
       or you can read the full list of changes in the
       <a href="https://github.com/php/php-src/blob/php-5.6.0alpha3/NEWS">NEWS file</a> contained
       in the release archive.
@@ -1804,7 +1804,7 @@ The list of changes is recorded in the <a href="http://www.php.net/ChangeLog-5.p
      </ul>
 
      <p>For more information about the new features you can check out the work-in-progress
-      <a href="http://docs.php.net/manual/en/migration56.new-features.php">documentation</a>
+      <a href="https://www.php.net/manual/en/migration56.new-features.php">documentation</a>
       or you can read the full list of changes in the
       <a href="https://github.com/php/php-src/blob/php-5.6.0alpha2/NEWS">NEWS file</a> contained
       in the release archive.
@@ -1952,7 +1952,7 @@ The list of changes is recorded in the <a href="http://www.php.net/ChangeLog-5.p
      </ul>
 
      <p>For more information about the new features you can check out the work-in-progress
-      <a href="http://docs.php.net/manual/en/migration56.new-features.php">documentation</a>
+      <a href="https://www.php.net/manual/en/migration56.new-features.php">documentation</a>
       or you can read the full list of changes in the
       <a href="https://github.com/php/php-src/blob/php-5.6.0alpha1/NEWS">NEWS file</a> contained
       in the release archive.

--- a/download-docs.php
+++ b/download-docs.php
@@ -91,10 +91,6 @@ $filepath = $filename = '';
 
 // Go through all possible manual languages
 foreach (Languages::LANGUAGES as $langcode => $language) {
-    if (isset(Languages::INACTIVE_ONLINE_LANGUAGES[$langcode]) && $MYSITE !== 'http://docs.php.net/') {
-       continue;
-    }
-
     // Go through all possible manual formats
     foreach ($formats as $formatname => $extension) {
 

--- a/manual/help-translate.php
+++ b/manual/help-translate.php
@@ -32,7 +32,7 @@ $archived = ['da', 'kr', 'pl', 'tw'];
 foreach (Languages::INACTIVE_ONLINE_LANGUAGES as $cc => $lang) {
     $link = 'no archive';
     if (in_array($cc, $archived, true)) {
-        $link = '<a href="http://docs.php.net/manual/' . $cc . '">archive</a>';
+        $link = '<a href="https://www.php.net/manual/' . $cc . '">archive</a>';
     }
     echo '<li>', $lang, ': (', $link, ')</li>';
 }

--- a/releases/5_4_0.php
+++ b/releases/5_4_0.php
@@ -17,8 +17,8 @@ and includes a large number of new features and bug fixes.
 </p>
 <ul>
  <li>New language syntax including <a href="http://php.net/traits">Traits</a>,
-    <a href="http://docs.php.net/manual/language.types.array.php">shortened array syntax</a>
-    and <a href="http://docs.php.net/manual/migration54.new-features.php">more</a></li>
+    <a href="https://www.php.net/manual/language.types.array.php">shortened array syntax</a>
+    and <a href="https://www.php.net/manual/migration54.new-features.php">more</a></li>
  <li>Improved performance and reduced memory consumption</li>
  <li>Support for multibyte languages now available in all builds of PHP at the flip of a runtime switch</li>
  <li><a href="http://php.net/manual/features.commandline.webserver.php">


### PR DESCRIPTION
Replace outdated docs.php.net domain references with the current https://www.php.net domain across archive pages and documentation links.

Also remove legacy inactive language filtering logic from download-docs.php that was specific to the old docs domain.