### PR TITLE
Update bugs.php.net and wiki.php.net links to https

### DIFF
--- a/archive/2002.php
+++ b/archive/2002.php
@@ -157,7 +157,7 @@ site_header("News Archive - 2002", ["cache" => true]);
  browser specific magic you can now use our
  <a href="/sidebars.php">Search Bar</a> from the major browsers. Please help
  us to test this new service, and provide feedback via
- <a href="http://bugs.php.net/">the bug system</a> (categorize your bug
+ <a href="https://bugs.php.net/">the bug system</a> (categorize your bug
  as a PHP.net website bug please).
 </p>
 

--- a/archive/2003.php
+++ b/archive/2003.php
@@ -166,7 +166,7 @@ site_header("News Archive - 2003", ["cache" => true]);
  You can autocomplete the name with the space key and navigate in the dropdown
  with the up and down cursor keys. We welcome feedback on this feature at
  <a href="/contact.php">the webmasters email address</a>, but
- please submit any bugs you find <a href="http://bugs.php.net/">in the
+ please submit any bugs you find <a href="https://bugs.php.net/">in the
  bug system</a> classifying them as a "PHP.net website problem" and providing
  as much information as possible (OS, Browser version, Javascript errors, etc..).
 </p>
@@ -551,7 +551,7 @@ site_header("News Archive - 2003", ["cache" => true]);
  <strong>Note</strong>: <em>This is a beta version. It should not be used in
  production or even semi-production web sites.</em> There are known bugs in it,
  and in addition, some of the features may change (based on feedback). We
- encourage you to download and play with it (and <a href="http://bugs.php.net/">report
+ encourage you to download and play with it (and <a href="https://bugs.php.net/">report
  bugs</a> if you find any!), but please do not replace your production
  installations of PHP 4 at this time.
 </p>

--- a/archive/2007.php
+++ b/archive/2007.php
@@ -66,7 +66,7 @@ the new build system that generates the PHP Manual. Written in PHP, PhD
 (<em>[PH]P based [D]ocBook renderer</em>) builds are now available for
 viewing at <a href="http://docs.php.net/">docs.php.net</a>. Everyone is
 encouraged to test and use this system so
-that <a href="http://bugs.php.net/">bugs</a> will be found and squashed.
+that <a href="https://bugs.php.net/">bugs</a> will be found and squashed.
       </p>
 
   <p>
@@ -639,7 +639,7 @@ contributors.
     <li>... and more to come!</li>
   </ul>
 
-  <p>Please <a href="/about.howtohelp">help us improve the documentation</a> by <a href="http://bugs.php.net/">submitting bug reports</a>, and adding notes to undocumented functions.</p>
+  <p>Please <a href="/about.howtohelp">help us improve the documentation</a> by <a href="https://bugs.php.net/">submitting bug reports</a>, and adding notes to undocumented functions.</p>
 </div>
 </div>
 

--- a/archive/2007.xml
+++ b/archive/2007.xml
@@ -58,7 +58,7 @@ the new build system that generates the PHP Manual. Written in PHP, PhD
 (<em>[PH]P based [D]ocBook renderer</em>) builds are now available for
 viewing at <a href="http://docs.php.net/">docs.php.net</a>. Everyone is
 encouraged to test and use this system so
-that <a href="http://bugs.php.net/">bugs</a> will be found and squashed.
+that <a href="https://bugs.php.net/">bugs</a> will be found and squashed.
       </p>
         <p>
 Once the new build system is stable, expect additional changes to the PHP
@@ -867,7 +867,7 @@ contributors.
           <li>updated function version information and capture system (fewer "no version information, might be only in CVS" messages)</li>
           <li>... and more to come!</li>
         </ul>
-        <p>Please <a href="/about.howtohelp">help us improve the documentation</a> by <a href="http://bugs.php.net/">submitting bug reports</a>, and adding notes to undocumented functions.</p>
+        <p>Please <a href="/about.howtohelp">help us improve the documentation</a> by <a href="https://bugs.php.net/">submitting bug reports</a>, and adding notes to undocumented functions.</p>
       </div>
     </content>
   </entry>

--- a/archive/2008.php
+++ b/archive/2008.php
@@ -138,7 +138,7 @@ site_header("News Archive - 2008", ["cache" => true]);
 
         of the upcoming PHP 5.3.0 minor version update of PHP.
         Several new features have already been documented in the <a href="http://php.net/docs.php">official documentation</a>,
-        others are listed on the <a href="http://wiki.php.net/doc/scratchpad/upgrade/53">wiki</a>
+        others are listed on the <a href="https://wiki.php.net/doc/scratchpad/upgrade/53">wiki</a>
         in preparation of getting documented. It is imperative that more people
         join the effort to complete the documentation for PHP 5.3.0.
         Please also review the <a href="http://php.net/php5news">NEWS</a> file.</p>
@@ -148,14 +148,14 @@ site_header("News Archive - 2008", ["cache" => true]);
          necessary backwards compatibility breaks are noted in the documentation. Please
          report any findings to the <a href="mailto:php-qa@lists.php.net">QA mailinglist</a>
 
-         or the <a href="http://bugs.php.net">bug tracker</a>.</p>
+         or the <a href="https://bugs.php.net">bug tracker</a>.</p>
         <p>There have been a great number of other additions and improvements since the last alpha,
         but here is a short overview of the most important changes:</p>
         <ul>
           <li><a href="http://php.net/language.namespaces">Namespaces</a> (documentation has been updated to the current state)</li>
           <li>
 
-            <a href="http://wiki.php.net/rfc/rounding">Rounding behavior</a>
+            <a href="https://wiki.php.net/rfc/rounding">Rounding behavior</a>
           </li>
           <li>ext/msql has been removed, while ext/ereg will now raise E_DEPRECATED notices</li>
           <li>ext/mhash has been replaced by ext/hash but full BC is maintained</li>
@@ -165,7 +165,7 @@ site_header("News Archive - 2008", ["cache" => true]);
         </ul>
         <p>Several under the hood changes also require in depth testing with existing
         applications to ensure that any backwards compatibility breaks are minimized.</p>
-        <p>The current <a href="http://wiki.php.net/todo/php53">release plan</a> expects
+        <p>The current <a href="https://wiki.php.net/todo/php53">release plan</a> expects
         a stable release sometime around the end of Q1 2009.</p>
       </div>
 
@@ -442,33 +442,33 @@ site_header("News Archive - 2008", ["cache" => true]);
     <div class="entry-content description">
         <abbr class="published newsdate" title="2008-08-01T08:50:37+02:00">[01-Aug-2008]</abbr>
         <div>
-        <p>The PHP development team is proud to announce the <a href="http://qa.php.net/">first alpha release</a> of the upcoming minor version update of PHP. <a href="http://windows.php.net/download/">Windows binaries</a> will be available starting with alpha2 (intermediate snapshots available at <a href="http://snaps.php.net">snaps.php.net</a>). The new version PHP 5.3 is expected to improve stability and performance as well as add new language syntax and extensions. Several new features have already been documented in the <a href="http://php.net/docs.php">official documentation</a>, others are listed on the <a href="http://wiki.php.net/doc/scratchpad/upgrade/53">wiki</a> in preparation of getting documented. Please also review the <a href="http://php.net/php5news">NEWS</a> file.</p>
+        <p>The PHP development team is proud to announce the <a href="http://qa.php.net/">first alpha release</a> of the upcoming minor version update of PHP. <a href="http://windows.php.net/download/">Windows binaries</a> will be available starting with alpha2 (intermediate snapshots available at <a href="http://snaps.php.net">snaps.php.net</a>). The new version PHP 5.3 is expected to improve stability and performance as well as add new language syntax and extensions. Several new features have already been documented in the <a href="http://php.net/docs.php">official documentation</a>, others are listed on the <a href="https://wiki.php.net/doc/scratchpad/upgrade/53">wiki</a> in preparation of getting documented. Please also review the <a href="http://php.net/php5news">NEWS</a> file.</p>
 
         <strong>THIS IS A DEVELOPMENT PREVIEW - DO NOT USE IT IN PRODUCTION!</strong>
         <p>The purpose of this alpha release is to encourage users to not only actively
          participate in identifying bugs, but also in ensuring that all new features or
          necessary backwards compatibility breaks are noted in the documentation. Please
          report any findings to the <a href="mailto:php-qa@lists.php.net">QA mailinglist</a>
-         or the <a href="http://bugs.php.net">bug tracker</a>.</p>
+         or the <a href="https://bugs.php.net">bug tracker</a>.</p>
         <p>There have been a great number of other additions and improvements, but here is a short overview of the most important changes:</p>
         <ul>
 
           <li><a href="http://php.net/language.namespaces">Namespaces</a> (documentation maybe out dated)</li>
           <li><a href="http://php.net/oop5.late-static-bindings">Late static binding</a> and <a href="http://php.net/language.oop5.overloading">__callStatic</a></li>
           <li>
-            <a href="http://wiki.php.net/rfc/closures">Lambda functions and closures</a>
+            <a href="https://wiki.php.net/rfc/closures">Lambda functions and closures</a>
           </li>
 
           <li>Addition of the <a href="http://php.net/book.intl">intl</a>, <a href="http://php.net/book.phar">phar</a> (phar is scheduled for some more work a head of alpha2), <a href="http://php.net/book.fileinfo">fileinfo </a> and <a href="http://php.net/book.sqlite3">sqlite3</a> extensions</li>
           <li>Optional cyclic garbage collection</li>
 
           <li>Optional support for the <a href="http://forge.mysql.com/wiki/PHP_MYSQLND">MySQLnd</a> replacement driver for libmysql</li>
-          <li>Windows older than Windows 2000 (Windows 98, NT4, etc.) are not supported anymore (<a href="http://wiki.php.net/internals/windows/releasenotes">details</a>)</li>
+          <li>Windows older than Windows 2000 (Windows 98, NT4, etc.) are not supported anymore (<a href="https://wiki.php.net/internals/windows/releasenotes">details</a>)</li>
           <li>New syntax features like <a href="http://php.net/language.types.string#language.types.string.syntax.nowdoc">NOWDOC</a>, limited GOTO, ternary short cut "?:"</li>
         </ul>
 
         <p>Several under the hood changes also require in depth testing with existing applications to ensure that any backwards compatibility breaks are minimized. This is especially important for users that require the undocumented Zend engine multibyte support.</p>
-        <p>The current <a href="http://wiki.php.net/todo/php53">release plan</a> states that there will be alpha/beta/RC releases in 2-3 week intervals with an expected stable release of PHP 5.3 between mid September and mid October of 2008.</p>
+        <p>The current <a href="https://wiki.php.net/todo/php53">release plan</a> states that there will be alpha/beta/RC releases in 2-3 week intervals with an expected stable release of PHP 5.3 between mid September and mid October of 2008.</p>
       </div>
 
     </div>
@@ -534,7 +534,7 @@ site_header("News Archive - 2008", ["cache" => true]);
 
         <p>
         The upcomming PHP5.3 release introduces
-        <a href="http://wiki.php.net/doc/scratchpad/upgrade/53">several major features</a>
+        <a href="https://wiki.php.net/doc/scratchpad/upgrade/53">several major features</a>
         such as <a href="/namespaces">namespaces</a>, closures,
         <a href="/lsb">late static bindings</a>, <a href="/intl">internationalization functions</a>,
         <a href="/ini.sections">INI sections</a>, and <a href="/phar">Phar</a> among others.
@@ -829,7 +829,7 @@ and join the <a href="http://www.flickr.com/photos/tags/elephpant/">world of blu
         <div>
         <p>Once again we are glad to announce that we have been accepted to be a Google Summer of Code project. See <a href="http://code.google.com/soc/2008/php/about.html">our program</a> for this year's GSoC.</p>
 
-        <p>We would like to take this opportunity to say thanks to Google Inc. for this privilege to participate once again, and would like to invite everyone to look at our list of ideas: <a href="http://wiki.php.net/gsoc/2008">http://wiki.php.net/gsoc/2008</a>. Students are of course more than welcome to come up with their own ideas for their proposals and we will consider each and every application that we will receive.</p>
+        <p>We would like to take this opportunity to say thanks to Google Inc. for this privilege to participate once again, and would like to invite everyone to look at our list of ideas: <a href="https://wiki.php.net/gsoc/2008">https://wiki.php.net/gsoc/2008</a>. Students are of course more than welcome to come up with their own ideas for their proposals and we will consider each and every application that we will receive.</p>
         <p>So once again, thanks to everyone who is involved in this magnificent journey and we hope to see many of you great students and open source passionate join us in our most enjoyable <a href="http://code.google.com/soc/2008">Google Summer of Code</a> projects.</p>
       </div>
 

--- a/archive/2008.xml
+++ b/archive/2008.xml
@@ -131,7 +131,7 @@
         <p>The PHP development team is proud to announce the <a href="http://qa.php.net/">third alpha release</a>
         of the upcoming PHP 5.3.0 minor version update of PHP.
         Several new features have already been documented in the <a href="http://php.net/docs.php">official documentation</a>,
-        others are listed on the <a href="http://wiki.php.net/doc/scratchpad/upgrade/53">wiki</a>
+        others are listed on the <a href="https://wiki.php.net/doc/scratchpad/upgrade/53">wiki</a>
         in preparation of getting documented. It is imperative that more people
         join the effort to complete the documentation for PHP 5.3.0.
         Please also review the <a href="http://php.net/php5news">NEWS</a> file.</p>
@@ -140,13 +140,13 @@
          participate in identifying bugs, but also in ensuring that all new features or
          necessary backwards compatibility breaks are noted in the documentation. Please
          report any findings to the <a href="mailto:php-qa@lists.php.net">QA mailinglist</a>
-         or the <a href="http://bugs.php.net">bug tracker</a>.</p>
+         or the <a href="https://bugs.php.net">bug tracker</a>.</p>
         <p>There have been a great number of other additions and improvements since the last alpha,
         but here is a short overview of the most important changes:</p>
         <ul>
           <li><a href="http://php.net/language.namespaces">Namespaces</a> (documentation has been updated to the current state)</li>
           <li>
-            <a href="http://wiki.php.net/rfc/rounding">Rounding behavior</a>
+            <a href="https://wiki.php.net/rfc/rounding">Rounding behavior</a>
           </li>
           <li>ext/msql has been removed, while ext/ereg will now raise E_DEPRECATED notices</li>
           <li>ext/mhash has been replaced by ext/hash but full BC is maintained</li>
@@ -155,7 +155,7 @@
         </ul>
         <p>Several under the hood changes also require in depth testing with existing
         applications to ensure that any backwards compatibility breaks are minimized.</p>
-        <p>The current <a href="http://wiki.php.net/todo/php53">release plan</a> expects
+        <p>The current <a href="https://wiki.php.net/todo/php53">release plan</a> expects
         a stable release sometime around the end of Q1 2009.</p>
       </div>
     </content>
@@ -463,28 +463,28 @@
     <link href="http://www.php.net/archive/2008.php#id2008-08-01-1" rel="via" type="text/html"/>
     <content type="xhtml">
       <div xmlns="http://www.w3.org/1999/xhtml">
-        <p>The PHP development team is proud to announce the <a href="http://qa.php.net/">first alpha release</a> of the upcoming minor version update of PHP. <a href="http://windows.php.net/download/">Windows binaries</a> will be available starting with alpha2 (intermediate snapshots available at <a href="http://snaps.php.net">snaps.php.net</a>). The new version PHP 5.3 is expected to improve stability and performance as well as add new language syntax and extensions. Several new features have already been documented in the <a href="http://php.net/docs.php">official documentation</a>, others are listed on the <a href="http://wiki.php.net/doc/scratchpad/upgrade/53">wiki</a> in preparation of getting documented. Please also review the <a href="http://php.net/php5news">NEWS</a> file.</p>
+        <p>The PHP development team is proud to announce the <a href="http://qa.php.net/">first alpha release</a> of the upcoming minor version update of PHP. <a href="http://windows.php.net/download/">Windows binaries</a> will be available starting with alpha2 (intermediate snapshots available at <a href="http://snaps.php.net">snaps.php.net</a>). The new version PHP 5.3 is expected to improve stability and performance as well as add new language syntax and extensions. Several new features have already been documented in the <a href="http://php.net/docs.php">official documentation</a>, others are listed on the <a href="https://wiki.php.net/doc/scratchpad/upgrade/53">wiki</a> in preparation of getting documented. Please also review the <a href="http://php.net/php5news">NEWS</a> file.</p>
         <strong>THIS IS A DEVELOPMENT PREVIEW - DO NOT USE IT IN PRODUCTION!</strong>
         <p>The purpose of this alpha release is to encourage users to not only actively
          participate in identifying bugs, but also in ensuring that all new features or
          necessary backwards compatibility breaks are noted in the documentation. Please
          report any findings to the <a href="mailto:php-qa@lists.php.net">QA mailinglist</a>
-         or the <a href="http://bugs.php.net">bug tracker</a>.</p>
+         or the <a href="https://bugs.php.net">bug tracker</a>.</p>
         <p>There have been a great number of other additions and improvements, but here is a short overview of the most important changes:</p>
         <ul>
           <li><a href="http://php.net/language.namespaces">Namespaces</a> (documentation maybe out dated)</li>
           <li><a href="http://php.net/oop5.late-static-bindings">Late static binding</a> and <a href="http://php.net/language.oop5.overloading">__callStatic</a></li>
           <li>
-            <a href="http://wiki.php.net/rfc/closures">Lambda functions and closures</a>
+            <a href="https://wiki.php.net/rfc/closures">Lambda functions and closures</a>
           </li>
           <li>Addition of the <a href="http://php.net/book.intl">intl</a>, <a href="http://php.net/book.phar">phar</a> (phar is scheduled for some more work a head of alpha2), <a href="http://php.net/book.fileinfo">fileinfo </a> and <a href="http://php.net/book.sqlite3">sqlite3</a> extensions</li>
           <li>Optional cyclic garbage collection</li>
           <li>Optional support for the <a href="http://forge.mysql.com/wiki/PHP_MYSQLND">MySQLnd</a> replacement driver for libmysql</li>
-          <li>Windows older than Windows 2000 (Windows 98, NT4, etc.) are not supported anymore (<a href="http://wiki.php.net/internals/windows/releasenotes">details</a>)</li>
+          <li>Windows older than Windows 2000 (Windows 98, NT4, etc.) are not supported anymore (<a href="https://wiki.php.net/internals/windows/releasenotes">details</a>)</li>
           <li>New syntax features like <a href="http://php.net/language.types.string#language.types.string.syntax.nowdoc">NOWDOC</a>, limited GOTO, ternary short cut "?:"</li>
         </ul>
         <p>Several under the hood changes also require in depth testing with existing applications to ensure that any backwards compatibility breaks are minimized. This is especially important for users that require the undocumented Zend engine multibyte support.</p>
-        <p>The current <a href="http://wiki.php.net/todo/php53">release plan</a> states that there will be alpha/beta/RC releases in 2-3 week intervals with an expected stable release of PHP 5.3 between mid September and mid October of 2008.</p>
+        <p>The current <a href="https://wiki.php.net/todo/php53">release plan</a> states that there will be alpha/beta/RC releases in 2-3 week intervals with an expected stable release of PHP 5.3 between mid September and mid October of 2008.</p>
       </div>
     </content>
   </entry>
@@ -544,7 +544,7 @@
        </p>
         <p>
         The upcomming PHP5.3 release introduces
-        <a href="http://wiki.php.net/doc/scratchpad/upgrade/53">several major features</a>
+        <a href="https://wiki.php.net/doc/scratchpad/upgrade/53">several major features</a>
         such as <a href="/namespaces">namespaces</a>, closures,
         <a href="/lsb">late static bindings</a>, <a href="/intl">internationalization functions</a>,
         <a href="/ini.sections">INI sections</a>, and <a href="/phar">Phar</a> among others.
@@ -921,7 +921,7 @@ and join the <a href="http://www.flickr.com/photos/tags/elephpant/">world of blu
     <content type="xhtml">
       <div xmlns="http://www.w3.org/1999/xhtml">
         <p>Once again we are glad to announce that we have been accepted to be a Google Summer of Code project. See <a href="http://code.google.com/soc/2008/php/about.html">our program</a> for this year's GSoC.</p>
-        <p>We would like to take this opportunity to say thanks to Google Inc. for this privilege to participate once again, and would like to invite everyone to look at our list of ideas: <a href="http://wiki.php.net/gsoc/2008">http://wiki.php.net/gsoc/2008</a>. Students are of course more than welcome to come up with their own ideas for their proposals and we will consider each and every application that we will receive.</p>
+        <p>We would like to take this opportunity to say thanks to Google Inc. for this privilege to participate once again, and would like to invite everyone to look at our list of ideas: <a href="https://wiki.php.net/gsoc/2008">https://wiki.php.net/gsoc/2008</a>. Students are of course more than welcome to come up with their own ideas for their proposals and we will consider each and every application that we will receive.</p>
         <p>So once again, thanks to everyone who is involved in this magnificent journey and we hope to see many of you great students and open source passionate join us in our most enjoyable <a href="http://code.google.com/soc/2008">Google Summer of Code</a> projects.</p>
       </div>
     </content>

--- a/archive/2009.php
+++ b/archive/2009.php
@@ -260,7 +260,7 @@ site_header("News Archive - 2009", ["cache" => true]);
       or <a href="http://www.flickr.com/search/?w=all&amp;q=testfest+mug&amp;m=tags">TestFest mugs</a>
       have been picked at random from the people that contributed the
       <a href="http://testfest.php.net/repos/testfest/">887 tests</a>
-      during the <a href="http://wiki.php.net/qa/testfest">2009 PHP TestFest</a>.
+      during the <a href="https://wiki.php.net/qa/testfest">2009 PHP TestFest</a>.
      </p>
      <h2>Winners of elePHPhants</h2>
      <ul>
@@ -345,13 +345,13 @@ site_header("News Archive - 2009", ["cache" => true]);
       The migration from CVS to Subversion is complete.  The web interface is at
       <a href="http://svn.php.net">svn.php.net</a>.  You can read about it at
       <a href="http://php.net/svn.php">php.net/svn.php</a>,
-      <a href="http://wiki.php.net/vcs/svnfaq">wiki.php.net/vcs/svnfaq</a>.  The
+      <a href="https://wiki.php.net/vcs/svnfaq">wiki.php.net/vcs/svnfaq</a>.  The
       URL to feed to your svn client is http://svn.php.net/repository.
      </p>
      <p>
       There is also a <a href="http://github.com/php">github mirror</a>.  Please
       use that instead of trying to do a full git clone from the svn repository.  See
-      the instructions at <a href="http://wiki.php.net/vcs/svnfaq#git">wiki.php.net/vcs/svnfaq#git</a>
+      the instructions at <a href="https://wiki.php.net/vcs/svnfaq#git">wiki.php.net/vcs/svnfaq#git</a>
      </p>
      <p>
       Many thanks to Gwynne who did the bulk of the work and also all the other folks who pitched in.
@@ -371,14 +371,14 @@ site_header("News Archive - 2009", ["cache" => true]);
         <div>
      <p>
       So finally we are at the end of the
-      <a href="http://wiki.php.net/qa/testfest">2009 PHP TestFest</a>.
+      <a href="https://wiki.php.net/qa/testfest">2009 PHP TestFest</a>.
       It has been an outstanding success with the
       <a href="http://gcov.php.net/PHP_5_3/lcov_html/">coverage increasing</a>
       by about 2.5% overall and 887 new tests contributed in the TestFest SVN
       repository of which 637 have already been added to PHP CVS.
      </p>
      <p>
-      <a href="http://wiki.php.net/usergroups">User groups</a> from all
+      <a href="https://wiki.php.net/usergroups">User groups</a> from all
       over the world have worked hard to make this happen and we thank
       <a href="http://results.testfest.php.net">each and every one of you</a>
       for your contribution to PHP!
@@ -565,7 +565,7 @@ site_header("News Archive - 2009", ["cache" => true]);
     <h1 class="summary entry-title"><a id="id2009-06-12-1" href="http://www.php.net/archive/2009.php#id2009-06-12-1" rel="bookmark" class="bookmark">PHP 5.2.10RC2 and PHP 5.3.0RC3 Release Announcements</a></h1>
     <div class="entry-content description">
         <abbr class="published newsdate" title="2009-06-12T17:39:42+02:00">[12-Jun-2009]</abbr>
-        <div>     <p>      The PHP development team is proud to announce the second release candidate of PHP 5.2.10 (PHP 5.2.10RC2) and      the third release candidate of PHP 5.3.0 (PHP 5.3.0RC3).      These RCs focuses on bug fixes and stability improvements, and we hope only minimal changes are required      for the next candidate or final stable releases.     </p>     <p>      PHP 5.2.10 is a pure maintenance release for providing bugfixes and stability updates. PHP 5.3.0      is a newly developed version of PHP featuring long-awaited features like namespaces, late      static binding, closures and much more.     </p>     <p>      Please download and test these release candidates, and report any issues found.      Downloads and further information is available at <a href="http://qa.php.net/">qa.php.net</a>.      See also the work in progress <a href="http://wiki.php.net/doc/scratchpad/upgrade/53">5.3 upgrade guide</a>.     </p></div>
+        <div>     <p>      The PHP development team is proud to announce the second release candidate of PHP 5.2.10 (PHP 5.2.10RC2) and      the third release candidate of PHP 5.3.0 (PHP 5.3.0RC3).      These RCs focuses on bug fixes and stability improvements, and we hope only minimal changes are required      for the next candidate or final stable releases.     </p>     <p>      PHP 5.2.10 is a pure maintenance release for providing bugfixes and stability updates. PHP 5.3.0      is a newly developed version of PHP featuring long-awaited features like namespaces, late      static binding, closures and much more.     </p>     <p>      Please download and test these release candidates, and report any issues found.      Downloads and further information is available at <a href="http://qa.php.net/">qa.php.net</a>.      See also the work in progress <a href="https://wiki.php.net/doc/scratchpad/upgrade/53">5.3 upgrade guide</a>.     </p></div>
 
     </div>
 </div>
@@ -696,7 +696,7 @@ site_header("News Archive - 2009", ["cache" => true]);
      <p>
       Please download and test this release candidate, and report any issues found.
       Downloads and further information is available at <a href="http://qa.php.net/">qa.php.net</a>.
-      See also the work in progress <a href="http://wiki.php.net/doc/scratchpad/upgrade/53">5.3 upgrade guide</a>.
+      See also the work in progress <a href="https://wiki.php.net/doc/scratchpad/upgrade/53">5.3 upgrade guide</a>.
      </p>
     </div>
 
@@ -806,7 +806,7 @@ site_header("News Archive - 2009", ["cache" => true]);
        at this years GSoC.
       </p>
       <p>
-       We invite everyone to look at the <a href="http://wiki.php.net/gsoc/2009">list of ideas</a> for
+       We invite everyone to look at the <a href="https://wiki.php.net/gsoc/2009">list of ideas</a> for
        this years GSoC, and get involved. Students are welcome to propose their own ideas, and we
        will consider all applications that are received before the April 3rd deadline. So, thanks to
        everyone involved and we look forward to seeing many students join us on this great adventure!

--- a/archive/2010.php
+++ b/archive/2010.php
@@ -520,7 +520,7 @@ class Bar {<br>
         tools as well as screencasts showing those build tools in action.
       </p>
       <p>
-        Please visit the <a href="http://wiki.php.net/qa/testfest-2010">TestFest
+        Please visit the <a href="https://wiki.php.net/qa/testfest-2010">TestFest
         2010</a> wiki page for all the details on events being organized in your area,
         or find out how you can organize your own event.
       </p>

--- a/archive/2013.php
+++ b/archive/2013.php
@@ -87,7 +87,7 @@ site_header("News Archive - 2013", ["cache" => true]);
       Bootstrap for our theme base.</p>
 
       <p>To provide valuable feedback, you can use the 'Feedback' widget on the side of the page (not visible
-      on smartphones) and to report bugs, you can make use of the <a href="http://bugs.php.net" title="PHP Bug Tracker">bugs.php.net</a>
+      on smartphones) and to report bugs, you can make use of the <a href="https://bugs.php.net" title="PHP Bug Tracker">bugs.php.net</a>
       tracker. Despite our extensive multi-device/multi-browser testing, we may have missed something. So, if you
       spot any issues please do get in touch.</p>
 

--- a/archive/entries/2018-06-07-1.xml
+++ b/archive/entries/2018-06-07-1.xml
@@ -18,7 +18,7 @@
      <p>For source downloads of PHP 7.3.0 Alpha 1 please visit the <a href="https://downloads.php.net/~stas/">download page</a>.</p>
 
      <p>
-     Please carefully test this version and report any issues found in the <a href=" http://bugs.php.net">bug reporting system</a>.
+     Please carefully test this version and report any issues found in the <a href=" https://bugs.php.net">bug reporting system</a>.
      </p>
 
      <p>

--- a/archive/entries/2018-06-21-1.xml
+++ b/archive/entries/2018-06-21-1.xml
@@ -21,7 +21,7 @@
      </p>
 
      <p>
-      Please carefully test this version and report any issues found in the <a href=" http://bugs.php.net">bug reporting system</a>.
+      Please carefully test this version and report any issues found in the <a href=" https://bugs.php.net">bug reporting system</a>.
      </p>
 
      <p>

--- a/archive/entries/2018-07-05-1.xml
+++ b/archive/entries/2018-07-05-1.xml
@@ -21,7 +21,7 @@
      </p>
 
      <p>
-      Please carefully test this version and report any issues found in the <a href=" http://bugs.php.net">bug reporting system</a>.
+      Please carefully test this version and report any issues found in the <a href=" https://bugs.php.net">bug reporting system</a>.
      </p>
 
      <p>

--- a/archive/entries/2019-06-13-1.xml
+++ b/archive/entries/2019-06-13-1.xml
@@ -18,7 +18,7 @@
      <p>For source downloads of PHP 7.4.0 Alpha 1 please visit the <a href="https://downloads.php.net/~derick">download page</a>.</p>
      
      <p>
-     Please carefully test this version and report any issues found in the <a href=" http://bugs.php.net">bug reporting system</a>.
+     Please carefully test this version and report any issues found in the <a href=" https://bugs.php.net">bug reporting system</a>.
      </p>
      
      <p>

--- a/archive/entries/2019-06-26-1.xml
+++ b/archive/entries/2019-06-26-1.xml
@@ -18,7 +18,7 @@
      <p>For source downloads of PHP 7.4.0 Alpha 2 please visit the <a href="https://downloads.php.net/~derick">download page</a>.</p>
      
      <p>
-     Please carefully test this version and report any issues found in the <a href="http://bugs.php.net">bug reporting system</a>.
+     Please carefully test this version and report any issues found in the <a href="https://bugs.php.net">bug reporting system</a>.
      </p>
      
      <p>

--- a/archive/entries/2019-07-11-1.xml
+++ b/archive/entries/2019-07-11-1.xml
@@ -19,7 +19,7 @@
      <p>For source downloads of PHP 7.4.0 Alpha 3 please visit the <a href="https://downloads.php.net/~derick">download page</a>.</p>
      
      <p>
-     Please carefully test this version and report any issues found in the <a href="http://bugs.php.net">bug reporting system</a>.
+     Please carefully test this version and report any issues found in the <a href="https://bugs.php.net">bug reporting system</a>.
      </p>
      
      <p>

--- a/archive/entries/2019-07-25-1.xml
+++ b/archive/entries/2019-07-25-1.xml
@@ -22,7 +22,7 @@
      </p>
      
      <p>
-     Please carefully test this version and report any issues found in the <a href="http://bugs.php.net">bug reporting system</a>.
+     Please carefully test this version and report any issues found in the <a href="https://bugs.php.net">bug reporting system</a>.
      </p>
      
      <p>

--- a/archive/entries/2020-06-25-1.xml
+++ b/archive/entries/2020-06-25-1.xml
@@ -17,7 +17,7 @@
      
      <p>For source downloads of PHP 8.0.0 Alpha 1 please visit the <a href="https://downloads.php.net/~pollita">download page</a>.</p>
      
-     <p>Please carefully test this version and report any issues found in the <a href="http://bugs.php.net">bug reporting system</a>.</p>
+     <p>Please carefully test this version and report any issues found in the <a href="https://bugs.php.net">bug reporting system</a>.</p>
      
      <p><b>Please DO NOT use this version in production, it is an early test version.</b></p>
      

--- a/archive/entries/2020-07-09-1.xml
+++ b/archive/entries/2020-07-09-1.xml
@@ -17,7 +17,7 @@
         
         <p>For source downloads of PHP 8.0.0 Alpha 2 please visit the <a href="https://downloads.php.net/~carusogabriel">download page</a>.</p>
         
-        <p>Please carefully test this version and report any issues found in the <a href="http://bugs.php.net">bug reporting system</a>.</p>
+        <p>Please carefully test this version and report any issues found in the <a href="https://bugs.php.net">bug reporting system</a>.</p>
         
         <p><b>Please DO NOT use this version in production, it is an early test version.</b></p>
         

--- a/archive/entries/2020-07-23-1.xml
+++ b/archive/entries/2020-07-23-1.xml
@@ -17,7 +17,7 @@
 
       <p>For source downloads of PHP 8.0.0 Alpha 3 please visit the <a href="https://downloads.php.net/~carusogabriel">download page</a>.</p>
 
-      <p>Please carefully test this version and report any issues found in the <a href="http://bugs.php.net">bug reporting system</a>.</p>
+      <p>Please carefully test this version and report any issues found in the <a href="https://bugs.php.net">bug reporting system</a>.</p>
 
       <p><b>Please DO NOT use this version in production, it is an early test version.</b></p>
 

--- a/archive/entries/2020-08-06-3.xml
+++ b/archive/entries/2020-08-06-3.xml
@@ -17,7 +17,7 @@
 
       <p>For source downloads of PHP 8.0.0 Beta 1 please visit the <a href="https://downloads.php.net/~carusogabriel">download page</a>.</p>
 
-      <p>Please carefully test this version and report any issues found in the <a href="http://bugs.php.net">bug reporting system</a>.</p>
+      <p>Please carefully test this version and report any issues found in the <a href="https://bugs.php.net">bug reporting system</a>.</p>
 
       <p><b>Please DO NOT use this version in production, it is an early test version.</b></p>
 

--- a/archive/entries/2020-08-21-1.xml
+++ b/archive/entries/2020-08-21-1.xml
@@ -17,7 +17,7 @@
 
       <p>For source downloads of PHP 8.0.0 Beta 2 please visit the <a href="https://downloads.php.net/~pollita/">download page</a>.</p>
 
-      <p>Please carefully test this version and report any issues found in the <a href="http://bugs.php.net">bug reporting system</a>.</p>
+      <p>Please carefully test this version and report any issues found in the <a href="https://bugs.php.net">bug reporting system</a>.</p>
 
       <p><b>Please DO NOT use this version in production, it is an early test version.</b></p>
 

--- a/archive/entries/2020-09-03-3.xml
+++ b/archive/entries/2020-09-03-3.xml
@@ -17,7 +17,7 @@
 
       <p>For source downloads of PHP 8.0.0 Beta 3 please visit the <a href="https://downloads.php.net/~carusogabriel">download page</a>.</p>
 
-      <p>Please carefully test this version and report any issues found in the <a href="http://bugs.php.net">bug reporting system</a>.</p>
+      <p>Please carefully test this version and report any issues found in the <a href="https://bugs.php.net">bug reporting system</a>.</p>
 
       <p><b>Please DO NOT use this version in production, it is an early test version.</b></p>
 

--- a/archive/entries/2020-09-17-1.xml
+++ b/archive/entries/2020-09-17-1.xml
@@ -25,7 +25,7 @@
 
       <p>For source downloads of PHP 8.0.0 Beta 4 please visit the <a href="https://downloads.php.net/~pollita">download page</a>.</p>
 
-      <p>Please carefully test this version and report any issues found in the <a href="http://bugs.php.net">bug reporting system</a>.</p>
+      <p>Please carefully test this version and report any issues found in the <a href="https://bugs.php.net">bug reporting system</a>.</p>
 
       <p><b>Please DO NOT use this version in production, it is an early test version.</b></p>
 

--- a/archive/entries/2020-10-01-4.xml
+++ b/archive/entries/2020-10-01-4.xml
@@ -22,7 +22,7 @@
 
       <p>For source downloads of PHP 8.0.0 Release Candidate 1 please visit the <a href="https://downloads.php.net/~carusogabriel">download page</a>.</p>
 
-      <p>Please carefully test this version and report any issues found in the <a href="http://bugs.php.net">bug reporting system</a>.</p>
+      <p>Please carefully test this version and report any issues found in the <a href="https://bugs.php.net">bug reporting system</a>.</p>
 
       <p><b>Please DO NOT use this version in production, it is an early test version.</b></p>
 

--- a/archive/entries/2020-10-16-1.xml
+++ b/archive/entries/2020-10-16-1.xml
@@ -22,7 +22,7 @@
 
       <p>For source downloads of PHP 8.0.0 Release Candidate 2 please visit the <a href="https://downloads.php.net/~pollita">download page</a>.</p>
 
-      <p>Please carefully test this version and report any issues found in the <a href="http://bugs.php.net">bug reporting system</a>.</p>
+      <p>Please carefully test this version and report any issues found in the <a href="https://bugs.php.net">bug reporting system</a>.</p>
 
       <p><b>Please DO NOT use this version in production, it is an early test version.</b></p>
 

--- a/archive/entries/2020-10-29-2.xml
+++ b/archive/entries/2020-10-29-2.xml
@@ -22,7 +22,7 @@
 
       <p>For source downloads of PHP 8.0.0 Release Candidate 3 please visit the <a href="https://downloads.php.net/~carusogabriel">download page</a>.</p>
 
-      <p>Please carefully test this version and report any issues found in the <a href="http://bugs.php.net">bug reporting system</a>.</p>
+      <p>Please carefully test this version and report any issues found in the <a href="https://bugs.php.net">bug reporting system</a>.</p>
 
       <p><b>Please DO NOT use this version in production, it is an early test version.</b></p>
 

--- a/archive/entries/2020-11-12-1.xml
+++ b/archive/entries/2020-11-12-1.xml
@@ -22,7 +22,7 @@
 
       <p>For source downloads of PHP 8.0.0 Release Candidate 4 please visit the <a href="https://downloads.php.net/~carusogabriel">download page</a>.</p>
 
-      <p>Please carefully test this version and report any issues found in the <a href="http://bugs.php.net">bug reporting system</a>.</p>
+      <p>Please carefully test this version and report any issues found in the <a href="https://bugs.php.net">bug reporting system</a>.</p>
 
       <p><b>Please DO NOT use this version in production, it is an early test version.</b></p>
 

--- a/archive/entries/2020-11-19-1.xml
+++ b/archive/entries/2020-11-19-1.xml
@@ -22,7 +22,7 @@
 
       <p>For source downloads of PHP 8.0.0 Release Candidate 5 please visit the <a href="https://downloads.php.net/~carusogabriel">download page</a>.</p>
 
-      <p>Please carefully test this version and report any issues found in the <a href="http://bugs.php.net">bug reporting system</a>.</p>
+      <p>Please carefully test this version and report any issues found in the <a href="https://bugs.php.net">bug reporting system</a>.</p>
 
       <p><b>Please DO NOT use this version in production, it is an early test version.</b></p>
 

--- a/archive/entries/2021-06-10-1.xml
+++ b/archive/entries/2021-06-10-1.xml
@@ -11,7 +11,7 @@
     <div xmlns="http://www.w3.org/1999/xhtml">
      <p>The PHP team is pleased to announce the first testing release of PHP 8.1.0, Alpha 1. This starts the PHP 8.1 release cycle, the rough outline of which is specified in the <a href="https://wiki.php.net/todo/php81">PHP Wiki</a>.</p>
      <p>For source downloads of PHP 8.1.0 Alpha 1 please visit the <a href="https://downloads.php.net/~patrickallaert/">download page</a>.</p>
-     <p>Please carefully test this version and report any issues found in the <a href="http://bugs.php.net/">bug reporting system</a>.</p>
+     <p>Please carefully test this version and report any issues found in the <a href="https://bugs.php.net/">bug reporting system</a>.</p>
      <p><strong>Please DO NOT use this version in production, it is an early test version.</strong></p>
      <p>For more information on the new features and other changes, you can read the <a href="https://github.com/php/php-src/blob/php-8.1.0alpha1/NEWS">NEWS</a> file, or the <a href="https://github.com/php/php-src/blob/php-8.1.0alpha1/UPGRADING">UPGRADING</a> file for a complete list of upgrading notes. These files can also be found in the release archive.</p>
      <p>The next release will be Alpha 2, planned for 24 Jun 2021.</p>

--- a/archive/entries/2021-06-24-1.xml
+++ b/archive/entries/2021-06-24-1.xml
@@ -13,7 +13,7 @@
      
      <p>For source downloads of PHP 8.1.0 Alpha 2 please visit the <a href="https://downloads.php.net/~patrickallaert/">download page</a>.</p>
      
-     <p>Please carefully test this version and report any issues found in the <a href="http://bugs.php.net">bug reporting system</a>.</p>
+     <p>Please carefully test this version and report any issues found in the <a href="https://bugs.php.net">bug reporting system</a>.</p>
      
      <p><strong>Please DO NOT use this version in production, it is an early test version.</strong></p>
      

--- a/archive/entries/2021-07-08-1.xml
+++ b/archive/entries/2021-07-08-1.xml
@@ -15,7 +15,7 @@
         <a href="https://wiki.php.net/todo/php81">PHP Wiki</a>.
       </p>
       <p>For source downloads of PHP 8.1.0 Alpha 3 please visit the <a href="https://downloads.php.net/~ramsey">download page</a>.</p>
-      <p>Please carefully test this version and report any issues found in the <a href="http://bugs.php.net">bug reporting system</a>.</p>
+      <p>Please carefully test this version and report any issues found in the <a href="https://bugs.php.net">bug reporting system</a>.</p>
       <p><b>Please DO NOT use this version in production, it is an early test version.</b></p>
       <p>
         For more information on the new features and other changes, you can read the

--- a/archive/entries/2021-07-22-1.xml
+++ b/archive/entries/2021-07-22-1.xml
@@ -15,7 +15,7 @@
         <a href="https://wiki.php.net/todo/php81">PHP Wiki</a>.
       </p>
       <p>For source downloads of PHP 8.1.0 Beta 1 please visit the <a href="https://downloads.php.net/~ramsey">download page</a>.</p>
-      <p>Please carefully test this version and report any issues found in the <a href="http://bugs.php.net">bug reporting system</a>.</p>
+      <p>Please carefully test this version and report any issues found in the <a href="https://bugs.php.net">bug reporting system</a>.</p>
       <p><b>Please DO NOT use this version in production, it is an early test version.</b></p>
       <p>
         For more information on the new features and other changes, you can read the

--- a/archive/entries/2021-08-05-2.xml
+++ b/archive/entries/2021-08-05-2.xml
@@ -15,7 +15,7 @@
         <a href="https://wiki.php.net/todo/php81">PHP Wiki</a>.
       </p>
       <p>For source downloads of PHP 8.1.0, Beta 2 please visit the <a href="https://downloads.php.net/~ramsey">download page</a>.</p>
-      <p>Please carefully test this version and report any issues found in the <a href="http://bugs.php.net">bug reporting system</a>.</p>
+      <p>Please carefully test this version and report any issues found in the <a href="https://bugs.php.net">bug reporting system</a>.</p>
       <p><b>Please DO NOT use this version in production, it is an early test version.</b></p>
       <p>
         For more information on the new features and other changes, you can read the

--- a/archive/entries/2021-08-19-1.xml
+++ b/archive/entries/2021-08-19-1.xml
@@ -21,7 +21,7 @@
       </p>
       <p>
         Please carefully test this version and report any issues found in the
-        <a href="http://bugs.php.net">bug reporting system</a>.
+        <a href="https://bugs.php.net">bug reporting system</a>.
       </p>
       <p><b>Please DO NOT use this version in production, it is an early test version.</b></p>
       <p>

--- a/archive/entries/2021-09-02-1.xml
+++ b/archive/entries/2021-09-02-1.xml
@@ -21,7 +21,7 @@
       </p>
       <p>
         Please carefully test this version and report any issues found in the
-        <a href="http://bugs.php.net">bug reporting system</a>.
+        <a href="https://bugs.php.net">bug reporting system</a>.
       </p>
       <p><b>Please DO NOT use this version in production, it is an early test version.</b></p>
       <p>

--- a/archive/entries/2021-09-16-1.xml
+++ b/archive/entries/2021-09-16-1.xml
@@ -21,7 +21,7 @@
       </p>
       <p>
         Please carefully test this version and report any issues found in the
-        <a href="http://bugs.php.net">bug reporting system</a>.
+        <a href="https://bugs.php.net">bug reporting system</a>.
       </p>
       <p><b>Please DO NOT use this version in production, it is an early test version.</b></p>
       <p>

--- a/archive/entries/2021-09-30-1.xml
+++ b/archive/entries/2021-09-30-1.xml
@@ -21,7 +21,7 @@
       </p>
       <p>
         Please carefully test this version and report any issues found in the
-        <a href="http://bugs.php.net">bug reporting system</a>.
+        <a href="https://bugs.php.net">bug reporting system</a>.
       </p>
       <p><b>Please DO NOT use this version in production, it is an early test version.</b></p>
       <p>

--- a/archive/entries/2021-10-14-1.xml
+++ b/archive/entries/2021-10-14-1.xml
@@ -21,7 +21,7 @@
       </p>
       <p>
         Please carefully test this version and report any issues found in the
-        <a href="http://bugs.php.net">bug reporting system</a>.
+        <a href="https://bugs.php.net">bug reporting system</a>.
       </p>
       <p><b>Please DO NOT use this version in production, it is an early test version.</b></p>
       <p>

--- a/archive/entries/2021-10-28-2.xml
+++ b/archive/entries/2021-10-28-2.xml
@@ -21,7 +21,7 @@
       </p>
       <p>
         Please carefully test this version and report any issues found in the
-        <a href="http://bugs.php.net">bug reporting system</a>.
+        <a href="https://bugs.php.net">bug reporting system</a>.
       </p>
       <p><b>Please DO NOT use this version in production, it is an early test version.</b></p>
       <p>

--- a/archive/entries/2021-11-11-1.xml
+++ b/archive/entries/2021-11-11-1.xml
@@ -21,7 +21,7 @@
        </p>
        <p>
          Please carefully test this version and report any issues found in the
-         <a href="http://bugs.php.net">bug reporting system</a>.
+         <a href="https://bugs.php.net">bug reporting system</a>.
        </p>
        <p><b>Please DO NOT use this version in production, it is an early test version.</b></p>
        <p>

--- a/archive/entries/2023-08-31-1.xml
+++ b/archive/entries/2023-08-31-1.xml
@@ -21,7 +21,7 @@
       </p>
       <p>
         Please carefully test this version and report any issues found in the
-        <a href="http://bugs.php.net">bug reporting system</a>.
+        <a href="https://bugs.php.net">bug reporting system</a>.
       </p>
       <p><b>Please DO NOT use this version in production, it is an early test version.</b></p>
       <p>

--- a/archive/entries/2023-09-14-1.xml
+++ b/archive/entries/2023-09-14-1.xml
@@ -16,7 +16,7 @@
              For source downloads of PHP 8.3.0, RC 2 please visit the <a href="https://downloads.php.net/~eric/">download page</a>.
            </p>
            <p>
-             Please carefully test this version and report any issues found in the <a href="http://bugs.php.net">bug reporting system</a>.
+             Please carefully test this version and report any issues found in the <a href="https://bugs.php.net">bug reporting system</a>.
            </p>
            <p><b>Please DO NOT use this version in production, it is an early test version.</b></p>
            <p>

--- a/archive/entries/2023-11-09-1.xml
+++ b/archive/entries/2023-11-09-1.xml
@@ -17,7 +17,7 @@
          For source downloads of PHP 8.3.0, RC 6 please visit the <a href="https://downloads.php.net/~eric">download page</a>.
        </p>
        <p>
-         Please carefully test this version and report any issues found in the <a href="http://bugs.php.net">bug reporting system</a>.
+         Please carefully test this version and report any issues found in the <a href="https://bugs.php.net">bug reporting system</a>.
        </p>
        <p><b>Please DO NOT use this version in production, it is an early test version.</b></p>
        <p>

--- a/build-setup.php
+++ b/build-setup.php
@@ -7,7 +7,7 @@ $SIDEBAR_DATA = '
   <div class="body">
     <p>
       This page is intended to help setup a development environment for PHP, if mistakes are found
-      please <a href="http://bugs.php.net">report</a> them.
+      please <a href="https://bugs.php.net">report</a> them.
     </p>
   </div>
 </div>

--- a/error.php
+++ b/error.php
@@ -170,7 +170,7 @@ if (preg_match("!^get/([^/]+)/from/([^/]+)(/mirror)?$!", $URI, $dlinfo)) {
 
 // php.net/42 --> likely a bug number
 if (is_numeric($URI)) {
-    mirror_redirect("http://bugs.php.net/bug.php?id=$URI");
+    mirror_redirect("https://bugs.php.net/bug.php?id=$URI");
 }
 
 // php.net/GH-123 -> php-src GH issue #123
@@ -564,7 +564,7 @@ $external_redirects = [
     "phpdochowto" => "https://doc.php.net/guide/",
     "rev" => "https://doc.php.net/revcheck.php?p=graph&lang=$LANG",
     "release/5_3_0.php" => "/releases/5_3_0.php", // PHP 5.3.0 release announcement had a typo
-    "ideas.php" => "http://wiki.php.net/ideas", // BC
+    "ideas.php" => "https://wiki.php.net/ideas", // BC
     "releases.atom" => "/releases/feed.php", // BC, No need to pre-generate it
     "spec" => "https://github.com/php/php-langspec",
     "sunglasses" => "https://www.youtube.com/watch?v=dQw4w9WgXcQ", // Temporary easter egg for bug#66144

--- a/git-php.php
+++ b/git-php.php
@@ -304,7 +304,7 @@ EOT;
  patient!), gives you access to a number of things. First, and most
  importantly, it gives you access to modify those parts of the PHP Git tree for
  which you have requested and been granted access. It also allows you to comment
- on and close bugs in our <a href="http://bugs.php.net/">bug database</a>, and
+ on and close bugs in our <a href="https://bugs.php.net/">bug database</a>, and
  allows you to modify the documentation notes in the <a href="/manual/">annotated
  manual</a>. Your Git account also translates into a foo@php.net forwarding email
  address where <strong>foo</strong> is your Git user id. Feel free to use it!

--- a/include/changelogs.inc
+++ b/include/changelogs.inc
@@ -5,7 +5,7 @@ function bugfix($number): void {
 }
 
 function bugl($number): void {
-    echo "<a href=\"http://bugs.php.net/$number\">#$number</a>";
+    echo "<a href=\"https://bugs.php.net/$number\">#$number</a>";
 }
 
 function implemented($number): void {

--- a/include/pregen-news.inc
+++ b/include/pregen-news.inc
@@ -861,7 +861,7 @@ Sorry for the inconvenience.</p>
      </p>
      
      <p>
-     Please carefully test this version and report any issues found in the <a href="http://bugs.php.net">bug reporting system</a>.
+     Please carefully test this version and report any issues found in the <a href="https://bugs.php.net">bug reporting system</a>.
      </p>
      
      <p>
@@ -992,7 +992,7 @@ Sorry for the inconvenience.</p>
      <p>For source downloads of PHP 7.4.0 Alpha 3 please visit the <a href="https://downloads.php.net/~derick">download page</a>.</p>
      
      <p>
-     Please carefully test this version and report any issues found in the <a href="http://bugs.php.net">bug reporting system</a>.
+     Please carefully test this version and report any issues found in the <a href="https://bugs.php.net">bug reporting system</a>.
      </p>
      
      <p>
@@ -1207,7 +1207,7 @@ Sorry for the inconvenience.</p>
      <p>For source downloads of PHP 7.4.0 Alpha 2 please visit the <a href="https://downloads.php.net/~derick">download page</a>.</p>
      
      <p>
-     Please carefully test this version and report any issues found in the <a href="http://bugs.php.net">bug reporting system</a>.
+     Please carefully test this version and report any issues found in the <a href="https://bugs.php.net">bug reporting system</a>.
      </p>
      
      <p>
@@ -1386,7 +1386,7 @@ Sorry for the inconvenience.</p>
      <p>For source downloads of PHP 7.4.0 Alpha 1 please visit the <a href="https://downloads.php.net/~derick">download page</a>.</p>
      
      <p>
-     Please carefully test this version and report any issues found in the <a href=" http://bugs.php.net">bug reporting system</a>.
+     Please carefully test this version and report any issues found in the <a href=" https://bugs.php.net">bug reporting system</a>.
      </p>
      
      <p>
@@ -6308,7 +6308,7 @@ the upgrade
      </p>
 
      <p>
-      Please carefully test this version and report any issues found in the <a href=" http://bugs.php.net">bug reporting system</a>.
+      Please carefully test this version and report any issues found in the <a href=" https://bugs.php.net">bug reporting system</a>.
      </p>
 
      <p>
@@ -6704,7 +6704,7 @@ the upgrade
      </p>
 
      <p>
-      Please carefully test this version and report any issues found in the <a href=" http://bugs.php.net">bug reporting system</a>.
+      Please carefully test this version and report any issues found in the <a href=" https://bugs.php.net">bug reporting system</a>.
      </p>
 
      <p>
@@ -7017,7 +7017,7 @@ the upgrade
      <p>For source downloads of PHP 7.3.0 Alpha 1 please visit the <a href="https://downloads.php.net/~stas/">download page</a>.</p>
 
      <p>
-     Please carefully test this version and report any issues found in the <a href=" http://bugs.php.net">bug reporting system</a>.
+     Please carefully test this version and report any issues found in the <a href=" https://bugs.php.net">bug reporting system</a>.
      </p>
 
      <p>

--- a/releases/4_2_1.php
+++ b/releases/4_2_1.php
@@ -41,7 +41,7 @@ site_header("PHP 4.2.1 Release Announcement");
 <p>
  PHP 4.2.1 also has improved (but still experimental) support for Apache version 2.
  We do <strong>not</strong> recommend that you use this in a production environment,
- but feel free to test it and report bugs to the <a href="http://bugs.php.net">bug
+ but feel free to test it and report bugs to the <a href="https://bugs.php.net">bug
  system</a>.
 </p>
 

--- a/releases/4_2_1_fr.php
+++ b/releases/4_2_1_fr.php
@@ -54,7 +54,7 @@ site_header("Annonce de publication de PHP 4.2.1", ["lang" => "fr"]);
  (mais toujours exp&eacute;rimentale) avec Apache 2. Nous <strong>ne
  recommandons pas</strong> son utilisation dans un environnement de
  production. Testez-le intensivement, et rapportez tous les bugs dans le
- <a href="http://bugs.php.net">syst&egrave;me</a>.
+ <a href="https://bugs.php.net">syst&egrave;me</a>.
 </p>
 
 <h2>Variables externes</h2>

--- a/releases/4_4_1.php
+++ b/releases/4_4_1.php
@@ -41,7 +41,7 @@ security issues that this release fixes are:
 <p>
 This release also fixes 35 other defects, where the most important is the
 the fix that removes a notice when passing a by-reference result of a function
-as a by-reference value to another function. (Bug #<a href='http://bugs.php.net/33558'>33558</a>).
+as a by-reference value to another function. (Bug #<a href='https://bugs.php.net/33558'>33558</a>).
 </p>
 <p>
  For a full list of changes in PHP 4.4.1, see the

--- a/sitemap.php
+++ b/sitemap.php
@@ -30,8 +30,8 @@ site_header("Sitemap", ["current" => "help"]);
 <h2>PHP Bugs</h2>
 
 <ul>
- <li><a href="http://bugs.php.net/">Submit a bug or a feature request</a></li>
- <li><a href="http://bugs.php.net/search.php">Search for bugs</a></li>
+ <li><a href="https://bugs.php.net/">Submit a bug or a feature request</a></li>
+ <li><a href="https://bugs.php.net/search.php">Search for bugs</a></li>
 </ul>
 
 <h2>PHP Support</h2>

--- a/urlhowto.php
+++ b/urlhowto.php
@@ -45,7 +45,7 @@ function a($href): void {
  sites, not just at the main site. If you find that some of these
  shortcuts are not working on your mirror site, please report them
  as a "PHP.net Website Problem" at
- <a href="http://bugs.php.net/">http://bugs.php.net/</a>.
+ <a href="https://bugs.php.net/">https://bugs.php.net/</a>.
 </p>
 
 <p>


### PR DESCRIPTION
Replacements done by:
```bash
find . -path ./.git -prune -o -type f -print0 \                                                                                                                                      
| xargs -0 perl -pi -e 's{http://bugs\.php\.net}{https://bugs.php.net}g'
```

```bash
find . -path ./.git -prune -o -type f -print0 \                                                                                                                                      
| xargs -0 perl -pi -e 's{http://wiki\.php\.net}{https://wiki.php.net}g'
```