### PR TITLE
Update qa.php.net links to https

### DIFF
--- a/archive/2001.php
+++ b/archive/2001.php
@@ -62,7 +62,7 @@ site_header("News Archive - 2001", ["cache" => true]);
  Thanks to the generous folks at <a
  href="http://www.rackspace.com/?supbid=php.net">Rackspace</a>, we have added additional
  capacity for hosting the PHP project's efforts. Currently, the machine they
- have provided is serving downloads for www.php.net and snaps.php.net. We will
+ have provided is serving downloads for www.php.net. We will
  continue to re-balance our resource needs across all of the machines provided
  by our supporters.
 </p>

--- a/archive/2005.php
+++ b/archive/2005.php
@@ -240,7 +240,7 @@ For changes in PHP 4.4.0 since PHP 4.3.11, please consult the
  applications - in cases where PHP formerly just silently ignored this
  and often causing memory corruptions - we also recommend to test PHP
  4.4.0RC2 with your applications. The final release is planned for July
- 11th. PHP 4.4.0RC2 can be found <a href="http://qa.php.net/~derick/">here</a>.
+ 11th. PHP 4.4.0RC2 can be found <a href="https://downloads.php.net/~derick/">here</a>.
 </p>
 
 <hr>

--- a/archive/2008.php
+++ b/archive/2008.php
@@ -442,7 +442,7 @@ site_header("News Archive - 2008", ["cache" => true]);
     <div class="entry-content description">
         <abbr class="published newsdate" title="2008-08-01T08:50:37+02:00">[01-Aug-2008]</abbr>
         <div>
-        <p>The PHP development team is proud to announce the <a href="https://qa.php.net/">first alpha release</a> of the upcoming minor version update of PHP. <a href="http://windows.php.net/download/">Windows binaries</a> will be available starting with alpha2 (intermediate snapshots available at <a href="http://snaps.php.net">snaps.php.net</a>). The new version PHP 5.3 is expected to improve stability and performance as well as add new language syntax and extensions. Several new features have already been documented in the <a href="http://php.net/docs.php">official documentation</a>, others are listed on the <a href="https://wiki.php.net/doc/scratchpad/upgrade/53">wiki</a> in preparation of getting documented. Please also review the <a href="http://php.net/php5news">NEWS</a> file.</p>
+        <p>The PHP development team is proud to announce the <a href="https://qa.php.net/">first alpha release</a> of the upcoming minor version update of PHP. <a href="http://windows.php.net/download/">Windows binaries</a> will be available starting with alpha2. The new version PHP 5.3 is expected to improve stability and performance as well as add new language syntax and extensions. Several new features have already been documented in the <a href="http://php.net/docs.php">official documentation</a>, others are listed on the <a href="https://wiki.php.net/doc/scratchpad/upgrade/53">wiki</a> in preparation of getting documented. Please also review the <a href="http://php.net/php5news">NEWS</a> file.</p>
 
         <strong>THIS IS A DEVELOPMENT PREVIEW - DO NOT USE IT IN PRODUCTION!</strong>
         <p>The purpose of this alpha release is to encourage users to not only actively
@@ -482,7 +482,7 @@ site_header("News Archive - 2008", ["cache" => true]);
     <div class="entry-content description">
         <abbr class="published newsdate" title="2008-07-30T00:23:14+01:00">[30-Jul-2008]</abbr>
         <div>
-        <p>Overall 158 tests have been submitted as part of <a href="https://phptestfest.org">TestFest 2008</a> since the launch of the <a href="http://testfest.php.net">TestFest submission site</a> by 30 different people from people all over the world. Actually this is not counting the various submissions by existing core developers, who also took this opportunity to add some more tests. This has actually increased total <a href="http://gcov.php.net/" target="_new">test coverage</a> for ext/reflection, ext/dom and ext/exif by about 10% each. While the organization of the TestFest was a bit adhoc, there were numerous TestFest events in local user groups. So the number of people exposed to the PHP test framework is much greater. Hopefully this will lead to more people submitting bug reports with an accompanying <a href="https://qa.php.net/write-test.php">phpt</a> test file!</p>
+        <p>Overall 158 tests have been submitted as part of TestFest 2008 since the launch of the TestFest submission site by 30 different people from people all over the world. Actually this is not counting the various submissions by existing core developers, who also took this opportunity to add some more tests. This has actually increased total <a href="http://gcov.php.net/" target="_new">test coverage</a> for ext/reflection, ext/dom and ext/exif by about 10% each. While the organization of the TestFest was a bit adhoc, there were numerous TestFest events in local user groups. So the number of people exposed to the PHP test framework is much greater. Hopefully this will lead to more people submitting bug reports with an accompanying <a href="https://qa.php.net/write-test.php">phpt</a> test file!</p>
 
         <p>Our top submitter Felix De Vliegher has actually committed his last submissions himself since, based on the high quality of his submissions, he has been granted commit rights to the PHP repository. We have not heard back from all participants, but we encourage everybody to <a href="http://www.deshong.net/?p=76" target="_new">blog</a> about their experience and provide us with feedback on how to improve future events.</p>
         <p>Now better late than never, here are the 10 winners of the promised <a href="http://flickr.com/groups/elephpants/pool/">elePHPant</a> raffle sponsored by <a href="http://www.nexen.net">Nexen</a>. Note that Felix asked me not to include him in the raffle, since he is already herding quite a number of elePHPants at home.</p>
@@ -795,8 +795,7 @@ and join the <a href="http://www.flickr.com/photos/tags/elephpant/">world of blu
     <div class="entry-content description">
         <abbr class="published newsdate" title="2008-03-30T21:06:55+01:00">[30-Mar-2008]</abbr>
         <div>
-        <p>The PHP-QA team would like to announce the
-        <a href="https://phptestfest.org">TestFest</a> for the month of
+        <p>The PHP-QA team would like to announce the TestFest for the month of
         May 2008. The TestFest is an event that aims at improving the
         <a href="http://gcov.php.net">code coverage</a> of the
         <a href="https://qa.php.net/running-tests.php">test suite</a> for the PHP
@@ -811,8 +810,7 @@ and join the <a href="http://www.flickr.com/photos/tags/elephpant/">world of blu
         to get others involved in
         <a href="https://qa.php.net/write-test.php">writing phpt tests</a>.
         The submissions will then be reviewed by members of php.net before
-        getting included in the official test suite. Please visit the
-        <a href="https://phptestfest.org">TestFest homepage</a> to get
+        getting included in the official test suite. Please visit the TestFest homepage to get
         additional details on the TestFest on how to get involved, either as a
         UG or by setting up the necessary infrastructure.</p>
       </div>

--- a/archive/2008.php
+++ b/archive/2008.php
@@ -134,7 +134,7 @@ site_header("News Archive - 2008", ["cache" => true]);
     <div class="entry-content description">
         <abbr class="published newsdate" title="2008-12-04T17:00:32+01:00">[04-Dec-2008]</abbr>
         <div>
-        <p>The PHP development team is proud to announce the <a href="http://qa.php.net/">third alpha release</a>
+        <p>The PHP development team is proud to announce the <a href="https://qa.php.net/">third alpha release</a>
 
         of the upcoming PHP 5.3.0 minor version update of PHP.
         Several new features have already been documented in the <a href="http://php.net/docs.php">official documentation</a>,
@@ -442,7 +442,7 @@ site_header("News Archive - 2008", ["cache" => true]);
     <div class="entry-content description">
         <abbr class="published newsdate" title="2008-08-01T08:50:37+02:00">[01-Aug-2008]</abbr>
         <div>
-        <p>The PHP development team is proud to announce the <a href="http://qa.php.net/">first alpha release</a> of the upcoming minor version update of PHP. <a href="http://windows.php.net/download/">Windows binaries</a> will be available starting with alpha2 (intermediate snapshots available at <a href="http://snaps.php.net">snaps.php.net</a>). The new version PHP 5.3 is expected to improve stability and performance as well as add new language syntax and extensions. Several new features have already been documented in the <a href="http://php.net/docs.php">official documentation</a>, others are listed on the <a href="https://wiki.php.net/doc/scratchpad/upgrade/53">wiki</a> in preparation of getting documented. Please also review the <a href="http://php.net/php5news">NEWS</a> file.</p>
+        <p>The PHP development team is proud to announce the <a href="https://qa.php.net/">first alpha release</a> of the upcoming minor version update of PHP. <a href="http://windows.php.net/download/">Windows binaries</a> will be available starting with alpha2 (intermediate snapshots available at <a href="http://snaps.php.net">snaps.php.net</a>). The new version PHP 5.3 is expected to improve stability and performance as well as add new language syntax and extensions. Several new features have already been documented in the <a href="http://php.net/docs.php">official documentation</a>, others are listed on the <a href="https://wiki.php.net/doc/scratchpad/upgrade/53">wiki</a> in preparation of getting documented. Please also review the <a href="http://php.net/php5news">NEWS</a> file.</p>
 
         <strong>THIS IS A DEVELOPMENT PREVIEW - DO NOT USE IT IN PRODUCTION!</strong>
         <p>The purpose of this alpha release is to encourage users to not only actively
@@ -482,7 +482,7 @@ site_header("News Archive - 2008", ["cache" => true]);
     <div class="entry-content description">
         <abbr class="published newsdate" title="2008-07-30T00:23:14+01:00">[30-Jul-2008]</abbr>
         <div>
-        <p>Overall 158 tests have been submitted as part of <a href="http://qa.php.net/testfest.php">TestFest 2008</a> since the launch of the <a href="http://testfest.php.net">TestFest submission site</a> by 30 different people from people all over the world. Actually this is not counting the various submissions by existing core developers, who also took this opportunity to add some more tests. This has actually increased total <a href="http://gcov.php.net/" target="_new">test coverage</a> for ext/reflection, ext/dom and ext/exif by about 10% each. While the organization of the TestFest was a bit adhoc, there were numerous TestFest events in local user groups. So the number of people exposed to the PHP test framework is much greater. Hopefully this will lead to more people submitting bug reports with an accompanying <a href="http://qa.php.net/write-test.php">phpt</a> test file!</p>
+        <p>Overall 158 tests have been submitted as part of <a href="https://phptestfest.org">TestFest 2008</a> since the launch of the <a href="http://testfest.php.net">TestFest submission site</a> by 30 different people from people all over the world. Actually this is not counting the various submissions by existing core developers, who also took this opportunity to add some more tests. This has actually increased total <a href="http://gcov.php.net/" target="_new">test coverage</a> for ext/reflection, ext/dom and ext/exif by about 10% each. While the organization of the TestFest was a bit adhoc, there were numerous TestFest events in local user groups. So the number of people exposed to the PHP test framework is much greater. Hopefully this will lead to more people submitting bug reports with an accompanying <a href="https://qa.php.net/write-test.php">phpt</a> test file!</p>
 
         <p>Our top submitter Felix De Vliegher has actually committed his last submissions himself since, based on the high quality of his submissions, he has been granted commit rights to the PHP repository. We have not heard back from all participants, but we encourage everybody to <a href="http://www.deshong.net/?p=76" target="_new">blog</a> about their experience and provide us with feedback on how to improve future events.</p>
         <p>Now better late than never, here are the 10 winners of the promised <a href="http://flickr.com/groups/elephpants/pool/">elePHPant</a> raffle sponsored by <a href="http://www.nexen.net">Nexen</a>. Note that Felix asked me not to include him in the raffle, since he is already herding quite a number of elePHPants at home.</p>
@@ -796,10 +796,10 @@ and join the <a href="http://www.flickr.com/photos/tags/elephpant/">world of blu
         <abbr class="published newsdate" title="2008-03-30T21:06:55+01:00">[30-Mar-2008]</abbr>
         <div>
         <p>The PHP-QA team would like to announce the
-        <a href="http://qa.php.net/testfest.php">TestFest</a> for the month of
+        <a href="https://phptestfest.org">TestFest</a> for the month of
         May 2008. The TestFest is an event that aims at improving the
         <a href="http://gcov.php.net">code coverage</a> of the
-        <a href="http://qa.php.net/running-tests.php">test suite</a> for the PHP
+        <a href="https://qa.php.net/running-tests.php">test suite</a> for the PHP
         language itself. As part of this event, local User Groups (UG) are
         invited to join the TestFest. These UGs can meet physically or come
         together virtually. The point however is that people network to learn
@@ -809,10 +809,10 @@ and join the <a href="http://www.flickr.com/photos/tags/elephpant/">world of blu
 
         <p>All it takes is someone to organize a UG to spearhead the event and
         to get others involved in
-        <a href="http://qa.php.net/write-test.php">writing phpt tests</a>.
+        <a href="https://qa.php.net/write-test.php">writing phpt tests</a>.
         The submissions will then be reviewed by members of php.net before
         getting included in the official test suite. Please visit the
-        <a href="http://qa.php.net/testfest.php">TestFest homepage</a> to get
+        <a href="https://phptestfest.org">TestFest homepage</a> to get
         additional details on the TestFest on how to get involved, either as a
         UG or by setting up the necessary infrastructure.</p>
       </div>

--- a/archive/2008.xml
+++ b/archive/2008.xml
@@ -128,7 +128,7 @@
     <link href="http://www.php.net/archive/2008.php#id2008-12-04-2" rel="via" type="text/html"/>
     <content type="xhtml">
       <div xmlns="http://www.w3.org/1999/xhtml">
-        <p>The PHP development team is proud to announce the <a href="http://qa.php.net/">third alpha release</a>
+        <p>The PHP development team is proud to announce the <a href="https://qa.php.net/">third alpha release</a>
         of the upcoming PHP 5.3.0 minor version update of PHP.
         Several new features have already been documented in the <a href="http://php.net/docs.php">official documentation</a>,
         others are listed on the <a href="https://wiki.php.net/doc/scratchpad/upgrade/53">wiki</a>
@@ -463,7 +463,7 @@
     <link href="http://www.php.net/archive/2008.php#id2008-08-01-1" rel="via" type="text/html"/>
     <content type="xhtml">
       <div xmlns="http://www.w3.org/1999/xhtml">
-        <p>The PHP development team is proud to announce the <a href="http://qa.php.net/">first alpha release</a> of the upcoming minor version update of PHP. <a href="http://windows.php.net/download/">Windows binaries</a> will be available starting with alpha2 (intermediate snapshots available at <a href="http://snaps.php.net">snaps.php.net</a>). The new version PHP 5.3 is expected to improve stability and performance as well as add new language syntax and extensions. Several new features have already been documented in the <a href="http://php.net/docs.php">official documentation</a>, others are listed on the <a href="https://wiki.php.net/doc/scratchpad/upgrade/53">wiki</a> in preparation of getting documented. Please also review the <a href="http://php.net/php5news">NEWS</a> file.</p>
+        <p>The PHP development team is proud to announce the <a href="https://qa.php.net/">first alpha release</a> of the upcoming minor version update of PHP. <a href="http://windows.php.net/download/">Windows binaries</a> will be available starting with alpha2 (intermediate snapshots available at <a href="http://snaps.php.net">snaps.php.net</a>). The new version PHP 5.3 is expected to improve stability and performance as well as add new language syntax and extensions. Several new features have already been documented in the <a href="http://php.net/docs.php">official documentation</a>, others are listed on the <a href="https://wiki.php.net/doc/scratchpad/upgrade/53">wiki</a> in preparation of getting documented. Please also review the <a href="http://php.net/php5news">NEWS</a> file.</p>
         <strong>THIS IS A DEVELOPMENT PREVIEW - DO NOT USE IT IN PRODUCTION!</strong>
         <p>The purpose of this alpha release is to encourage users to not only actively
          participate in identifying bugs, but also in ensuring that all new features or
@@ -498,7 +498,7 @@
     <link href="http://www.php.net/archive/2008.php#id2008-07-30-1" rel="via" type="text/html"/>
     <content type="xhtml">
       <div xmlns="http://www.w3.org/1999/xhtml">
-        <p>Overall 158 tests have been submitted as part of <a href="http://qa.php.net/testfest.php">TestFest 2008</a> since the launch of the <a href="http://testfest.php.net">TestFest submission site</a> by 30 different people from people all over the world. Actually this is not counting the various submissions by existing core developers, who also took this opportunity to add some more tests. This has actually increased total <a href="http://gcov.php.net/" target="_new">test coverage</a> for ext/reflection, ext/dom and ext/exif by about 10% each. While the organization of the TestFest was a bit adhoc, there were numerous TestFest events in local user groups. So the number of people exposed to the PHP test framework is much greater. Hopefully this will lead to more people submitting bug reports with an accompanying <a href="http://qa.php.net/write-test.php">phpt</a> test file!</p>
+        <p>Overall 158 tests have been submitted as part of <a href="https://phptestfest.org">TestFest 2008</a> since the launch of the <a href="http://testfest.php.net">TestFest submission site</a> by 30 different people from people all over the world. Actually this is not counting the various submissions by existing core developers, who also took this opportunity to add some more tests. This has actually increased total <a href="http://gcov.php.net/" target="_new">test coverage</a> for ext/reflection, ext/dom and ext/exif by about 10% each. While the organization of the TestFest was a bit adhoc, there were numerous TestFest events in local user groups. So the number of people exposed to the PHP test framework is much greater. Hopefully this will lead to more people submitting bug reports with an accompanying <a href="https://qa.php.net/write-test.php">phpt</a> test file!</p>
         <p>Our top submitter Felix De Vliegher has actually committed his last submissions himself since, based on the high quality of his submissions, he has been granted commit rights to the PHP repository. We have not heard back from all participants, but we encourage everybody to <a href="http://www.deshong.net/?p=76" target="_new">blog</a> about their experience and provide us with feedback on how to improve future events.</p>
         <p>Now better late than never, here are the 10 winners of the promised <a href="http://flickr.com/groups/elephpants/pool/">elePHPant</a> raffle sponsored by <a href="http://www.nexen.net">Nexen</a>. Note that Felix asked me not to include him in the raffle, since he is already herding quite a number of elePHPants at home.</p>
         <ul>
@@ -872,10 +872,10 @@ and join the <a href="http://www.flickr.com/photos/tags/elephpant/">world of blu
     <content type="xhtml">
       <div xmlns="http://www.w3.org/1999/xhtml">
         <p>The PHP-QA team would like to announce the
-        <a href="http://qa.php.net/testfest.php">TestFest</a> for the month of
+        <a href="https://phptestfest.org">TestFest</a> for the month of
         May 2008. The TestFest is an event that aims at improving the
         <a href="http://gcov.php.net">code coverage</a> of the
-        <a href="http://qa.php.net/running-tests.php">test suite</a> for the PHP
+        <a href="https://qa.php.net/running-tests.php">test suite</a> for the PHP
         language itself. As part of this event, local User Groups (UG) are
         invited to join the TestFest. These UGs can meet physically or come
         together virtually. The point however is that people network to learn
@@ -884,10 +884,10 @@ and join the <a href="http://www.flickr.com/photos/tags/elephpant/">world of blu
         hopefully reduce the work load for the PHP.net mentors.</p>
         <p>All it takes is someone to organize a UG to spearhead the event and
         to get others involved in
-        <a href="http://qa.php.net/write-test.php">writing phpt tests</a>.
+        <a href="https://qa.php.net/write-test.php">writing phpt tests</a>.
         The submissions will then be reviewed by members of php.net before
         getting included in the official test suite. Please visit the
-        <a href="http://qa.php.net/testfest.php">TestFest homepage</a> to get
+        <a href="https://phptestfest.org">TestFest homepage</a> to get
         additional details on the TestFest on how to get involved, either as a
         UG or by setting up the necessary infrastructure.</p>
       </div>

--- a/archive/2008.xml
+++ b/archive/2008.xml
@@ -463,7 +463,7 @@
     <link href="http://www.php.net/archive/2008.php#id2008-08-01-1" rel="via" type="text/html"/>
     <content type="xhtml">
       <div xmlns="http://www.w3.org/1999/xhtml">
-        <p>The PHP development team is proud to announce the <a href="https://qa.php.net/">first alpha release</a> of the upcoming minor version update of PHP. <a href="http://windows.php.net/download/">Windows binaries</a> will be available starting with alpha2 (intermediate snapshots available at <a href="http://snaps.php.net">snaps.php.net</a>). The new version PHP 5.3 is expected to improve stability and performance as well as add new language syntax and extensions. Several new features have already been documented in the <a href="http://php.net/docs.php">official documentation</a>, others are listed on the <a href="https://wiki.php.net/doc/scratchpad/upgrade/53">wiki</a> in preparation of getting documented. Please also review the <a href="http://php.net/php5news">NEWS</a> file.</p>
+        <p>The PHP development team is proud to announce the <a href="https://qa.php.net/">first alpha release</a> of the upcoming minor version update of PHP. <a href="http://windows.php.net/download/">Windows binaries</a> will be available starting with alpha2. The new version PHP 5.3 is expected to improve stability and performance as well as add new language syntax and extensions. Several new features have already been documented in the <a href="http://php.net/docs.php">official documentation</a>, others are listed on the <a href="https://wiki.php.net/doc/scratchpad/upgrade/53">wiki</a> in preparation of getting documented. Please also review the <a href="http://php.net/php5news">NEWS</a> file.</p>
         <strong>THIS IS A DEVELOPMENT PREVIEW - DO NOT USE IT IN PRODUCTION!</strong>
         <p>The purpose of this alpha release is to encourage users to not only actively
          participate in identifying bugs, but also in ensuring that all new features or
@@ -498,7 +498,7 @@
     <link href="http://www.php.net/archive/2008.php#id2008-07-30-1" rel="via" type="text/html"/>
     <content type="xhtml">
       <div xmlns="http://www.w3.org/1999/xhtml">
-        <p>Overall 158 tests have been submitted as part of <a href="https://phptestfest.org">TestFest 2008</a> since the launch of the <a href="http://testfest.php.net">TestFest submission site</a> by 30 different people from people all over the world. Actually this is not counting the various submissions by existing core developers, who also took this opportunity to add some more tests. This has actually increased total <a href="http://gcov.php.net/" target="_new">test coverage</a> for ext/reflection, ext/dom and ext/exif by about 10% each. While the organization of the TestFest was a bit adhoc, there were numerous TestFest events in local user groups. So the number of people exposed to the PHP test framework is much greater. Hopefully this will lead to more people submitting bug reports with an accompanying <a href="https://qa.php.net/write-test.php">phpt</a> test file!</p>
+        <p>Overall 158 tests have been submitted as part of TestFest 2008 since the launch of the TestFest submission site by 30 different people from people all over the world. Actually this is not counting the various submissions by existing core developers, who also took this opportunity to add some more tests. This has actually increased total <a href="http://gcov.php.net/" target="_new">test coverage</a> for ext/reflection, ext/dom and ext/exif by about 10% each. While the organization of the TestFest was a bit adhoc, there were numerous TestFest events in local user groups. So the number of people exposed to the PHP test framework is much greater. Hopefully this will lead to more people submitting bug reports with an accompanying <a href="https://qa.php.net/write-test.php">phpt</a> test file!</p>
         <p>Our top submitter Felix De Vliegher has actually committed his last submissions himself since, based on the high quality of his submissions, he has been granted commit rights to the PHP repository. We have not heard back from all participants, but we encourage everybody to <a href="http://www.deshong.net/?p=76" target="_new">blog</a> about their experience and provide us with feedback on how to improve future events.</p>
         <p>Now better late than never, here are the 10 winners of the promised <a href="http://flickr.com/groups/elephpants/pool/">elePHPant</a> raffle sponsored by <a href="http://www.nexen.net">Nexen</a>. Note that Felix asked me not to include him in the raffle, since he is already herding quite a number of elePHPants at home.</p>
         <ul>
@@ -871,8 +871,7 @@ and join the <a href="http://www.flickr.com/photos/tags/elephpant/">world of blu
     <link href="http://www.php.net/archive/2008.php#2008-03-30-1" rel="via" type="text/html"/>
     <content type="xhtml">
       <div xmlns="http://www.w3.org/1999/xhtml">
-        <p>The PHP-QA team would like to announce the
-        <a href="https://phptestfest.org">TestFest</a> for the month of
+        <p>The PHP-QA team would like to announce the TestFest for the month of
         May 2008. The TestFest is an event that aims at improving the
         <a href="http://gcov.php.net">code coverage</a> of the
         <a href="https://qa.php.net/running-tests.php">test suite</a> for the PHP
@@ -886,8 +885,7 @@ and join the <a href="http://www.flickr.com/photos/tags/elephpant/">world of blu
         to get others involved in
         <a href="https://qa.php.net/write-test.php">writing phpt tests</a>.
         The submissions will then be reviewed by members of php.net before
-        getting included in the official test suite. Please visit the
-        <a href="https://phptestfest.org">TestFest homepage</a> to get
+        getting included in the official test suite. Please visit the TestFest homepage to get
         additional details on the TestFest on how to get involved, either as a
         UG or by setting up the necessary infrastructure.</p>
       </div>

--- a/archive/2009.php
+++ b/archive/2009.php
@@ -482,8 +482,7 @@ site_header("News Archive - 2009", ["cache" => true]);
      <p>
       The keynote speaker is Jan Schneider, who will also
       talk about the Horde project. In addition, we will
-      have sessions about other frameworks and include a
-      <a href="https://phptestfest.org">PHP TestFest</a>.
+      have sessions about other frameworks and include a PHP TestFest.
      </p>
      <p>
       PHP'n Rio sessions go from 6-9 pm. Then the PHP TestFest follows up
@@ -665,8 +664,7 @@ site_header("News Archive - 2009", ["cache" => true]);
         have 2 months left to go.
       </p>
       <p>
-        Getting involved couldn't be simpler. Visit the
-        <a href="https://phptestfest.org">QA TestFest page</a> to
+        Getting involved couldn't be simpler. Visit the QA TestFest page to
         find out how you can organize a TestFest event in your community.
         We are looking forward to seeing your communities tests being
         committed into PHP.
@@ -695,16 +693,8 @@ site_header("News Archive - 2009", ["cache" => true]);
      </p>
      <p>
       Please download and test this release candidate, and report any issues found.
-<<<<<<< HEAD
-      Downloads and further information is available at <a href="http://qa.php.net/">qa.php.net</a>.
-      See also the work in progress <a href="https://wiki.php.net/doc/scratchpad/upgrade/53">5.3 upgrade guide</a>.
-||||||| parent of c89eec8e (fix: update qa.php.net links to https)
-      Downloads and further information is available at <a href="http://qa.php.net/">qa.php.net</a>.
-      See also the work in progress <a href="http://wiki.php.net/doc/scratchpad/upgrade/53">5.3 upgrade guide</a>.
-=======
-      Downloads and further information is available at <a href="https://qa.php.net/">qa.php.net</a>.
-      See also the work in progress <a href="http://wiki.php.net/doc/scratchpad/upgrade/53">5.3 upgrade guide</a>.
->>>>>>> c89eec8e (fix: update qa.php.net links to https)
+       Downloads and further information is available at <a href="https://qa.php.net/">qa.php.net</a>.
+       See also the work in progress <a href="https://wiki.php.net/doc/scratchpad/upgrade/53">5.3 upgrade guide</a>.
      </p>
     </div>
 

--- a/archive/2009.php
+++ b/archive/2009.php
@@ -483,7 +483,7 @@ site_header("News Archive - 2009", ["cache" => true]);
       The keynote speaker is Jan Schneider, who will also
       talk about the Horde project. In addition, we will
       have sessions about other frameworks and include a
-      <a href="http://qa.php.net/testfest.php">PHP TestFest</a>.
+      <a href="https://phptestfest.org">PHP TestFest</a>.
      </p>
      <p>
       PHP'n Rio sessions go from 6-9 pm. Then the PHP TestFest follows up
@@ -522,7 +522,7 @@ site_header("News Archive - 2009", ["cache" => true]);
       Please download and test these release candidates, and report any issues
       found. A stable release is expected next week . In case of critical
       issues we will continue producing weekly RCs. Downloads and further
-      information is available at <a href="http://qa.php.net/">qa.php.net</a>.
+      information is available at <a href="https://qa.php.net/">qa.php.net</a>.
       See also the work in progress
       <a href="http://cvs.php.net/viewvc.cgi/php-src/UPGRADING?revision=PHP_5_3">5.3 upgrade guide</a>.
      </p>
@@ -565,7 +565,7 @@ site_header("News Archive - 2009", ["cache" => true]);
     <h1 class="summary entry-title"><a id="id2009-06-12-1" href="http://www.php.net/archive/2009.php#id2009-06-12-1" rel="bookmark" class="bookmark">PHP 5.2.10RC2 and PHP 5.3.0RC3 Release Announcements</a></h1>
     <div class="entry-content description">
         <abbr class="published newsdate" title="2009-06-12T17:39:42+02:00">[12-Jun-2009]</abbr>
-        <div>     <p>      The PHP development team is proud to announce the second release candidate of PHP 5.2.10 (PHP 5.2.10RC2) and      the third release candidate of PHP 5.3.0 (PHP 5.3.0RC3).      These RCs focuses on bug fixes and stability improvements, and we hope only minimal changes are required      for the next candidate or final stable releases.     </p>     <p>      PHP 5.2.10 is a pure maintenance release for providing bugfixes and stability updates. PHP 5.3.0      is a newly developed version of PHP featuring long-awaited features like namespaces, late      static binding, closures and much more.     </p>     <p>      Please download and test these release candidates, and report any issues found.      Downloads and further information is available at <a href="http://qa.php.net/">qa.php.net</a>.      See also the work in progress <a href="https://wiki.php.net/doc/scratchpad/upgrade/53">5.3 upgrade guide</a>.     </p></div>
+        <div>     <p>      The PHP development team is proud to announce the second release candidate of PHP 5.2.10 (PHP 5.2.10RC2) and      the third release candidate of PHP 5.3.0 (PHP 5.3.0RC3).      These RCs focuses on bug fixes and stability improvements, and we hope only minimal changes are required      for the next candidate or final stable releases.     </p>     <p>      PHP 5.2.10 is a pure maintenance release for providing bugfixes and stability updates. PHP 5.3.0      is a newly developed version of PHP featuring long-awaited features like namespaces, late      static binding, closures and much more.     </p>     <p>      Please download and test these release candidates, and report any issues found.      Downloads and further information is available at <a href="https://qa.php.net/">qa.php.net</a>.      See also the work in progress <a href="https://wiki.php.net/doc/scratchpad/upgrade/53">5.3 upgrade guide</a>.     </p></div>
 
     </div>
 </div>
@@ -666,7 +666,7 @@ site_header("News Archive - 2009", ["cache" => true]);
       </p>
       <p>
         Getting involved couldn't be simpler. Visit the
-        <a href="http://qa.php.net/testfest.php">QA TestFest page</a> to
+        <a href="https://phptestfest.org">QA TestFest page</a> to
         find out how you can organize a TestFest event in your community.
         We are looking forward to seeing your communities tests being
         committed into PHP.
@@ -695,8 +695,16 @@ site_header("News Archive - 2009", ["cache" => true]);
      </p>
      <p>
       Please download and test this release candidate, and report any issues found.
+<<<<<<< HEAD
       Downloads and further information is available at <a href="http://qa.php.net/">qa.php.net</a>.
       See also the work in progress <a href="https://wiki.php.net/doc/scratchpad/upgrade/53">5.3 upgrade guide</a>.
+||||||| parent of c89eec8e (fix: update qa.php.net links to https)
+      Downloads and further information is available at <a href="http://qa.php.net/">qa.php.net</a>.
+      See also the work in progress <a href="http://wiki.php.net/doc/scratchpad/upgrade/53">5.3 upgrade guide</a>.
+=======
+      Downloads and further information is available at <a href="https://qa.php.net/">qa.php.net</a>.
+      See also the work in progress <a href="http://wiki.php.net/doc/scratchpad/upgrade/53">5.3 upgrade guide</a>.
+>>>>>>> c89eec8e (fix: update qa.php.net links to https)
      </p>
     </div>
 

--- a/archive/2011.php
+++ b/archive/2011.php
@@ -20,7 +20,7 @@ site_header("News Archive - 2011", ["cache" => true]);
         <div>
      <p>
        The PHP development team is proud to announce the 4th
-       <a href="http://qa.php.net">release candidate</a> of PHP 5.4.
+       <a href="https://qa.php.net">release candidate</a> of PHP 5.4.
        PHP 5.4 includes new language features and removes several legacy
        (deprecated) behaviours. Windows binaries can be downloaded from the
        <a href="http://windows.php.net/qa/">Windows QA site</a>.
@@ -85,7 +85,7 @@ site_header("News Archive - 2011", ["cache" => true]);
         <div>
       <p>
         The PHP development team is proud to announce the third
-        <a href="http://qa.php.net">release candidate</a> of PHP 5.4.
+        <a href="https://qa.php.net">release candidate</a> of PHP 5.4.
         PHP 5.4 includes new language features and removes several legacy
         (deprecated) behaviours. Windows binaries can be downloaded from the
         <a href="http://windows.php.net/qa/">Windows QA site</a>.
@@ -131,7 +131,7 @@ site_header("News Archive - 2011", ["cache" => true]);
         <div>
       <p>
         The PHP development team is proud to announce the second
-        <a href="http://qa.php.net">release candidate</a> of PHP 5.4.
+        <a href="https://qa.php.net">release candidate</a> of PHP 5.4.
         PHP 5.4 includes new language features and removes several legacy
         (deprecated) behaviours. Windows binaries can be downloaded from the
         <a href="http://windows.php.net/qa/">Windows QA site</a>.
@@ -208,7 +208,7 @@ site_header("News Archive - 2011", ["cache" => true]);
         <div>
      <p>
       The PHP development team is proud to announce the first
-      <a href="http://qa.php.net/">release candidate</a> of PHP 5.4.
+      <a href="https://qa.php.net/">release candidate</a> of PHP 5.4.
       PHP 5.4 includes new language features and removes several legacy
       (deprecated) behaviours. Windows binaries can be downloaded from the
       <a href="http://windows.php.net/qa/">Windows QA site</a>.
@@ -253,7 +253,7 @@ site_header("News Archive - 2011", ["cache" => true]);
         <abbr class="published newsdate" title="2011-10-26T19:16:50+00:00">[26-Oct-2011]</abbr>
         <div>
       <p>
-       The PHP development team is proud to announce the second <a href="http://qa.php.net/">beta release</a> of PHP 5.4.
+       The PHP development team is proud to announce the second <a href="https://qa.php.net/">beta release</a> of PHP 5.4.
        PHP 5.4 includes new language features and removes several legacy (deprecated) behaviours.
        Windows binaries can be downloaded from the <a href="http://windows.php.net/qa/">Windows QA site</a>.
       </p>
@@ -358,7 +358,7 @@ site_header("News Archive - 2011", ["cache" => true]);
         <abbr class="published newsdate" title="2011-09-27T01:05:49+02:00">[27-Sep-2011]</abbr>
         <div>
       <p>
-       The PHP development team is proud to announce the first <a href="http://qa.php.net/">beta release</a> of PHP 5.4.
+       The PHP development team is proud to announce the first <a href="https://qa.php.net/">beta release</a> of PHP 5.4.
        PHP 5.4 includes new language features and removes several legacy (deprecated) behaviors.
        Windows binaries can be downloaded from the <a href="http://windows.php.net/qa/"> Windows QA site</a>.
       </p>
@@ -649,7 +649,7 @@ site_header("News Archive - 2011", ["cache" => true]);
         <abbr class="published newsdate" title="2011-06-28T23:34:42+02:00">[28-Jun-2011]</abbr>
         <div>
      <p>
-      The PHP development team is proud to announce the first PHP 5.4 <a href="http://qa.php.net/">alpha release</a>.
+      The PHP development team is proud to announce the first PHP 5.4 <a href="https://qa.php.net/">alpha release</a>.
       PHP 5.4 includes new language features and removes several legacy (deprecated) behaviors.
       Read the <a href="/releases/NEWS_5_4_0_alpha1.txt">NEWS</a>
       file for a complete list of changes.

--- a/archive/2012.php
+++ b/archive/2012.php
@@ -823,7 +823,7 @@ site_header("News Archive - 2012", ["cache" => true]);
         <div>
       <p>
         The PHP development team would like to announce the 2nd
-        <a href="http://qa.php.net">release candidate</a> of PHP 5.4.1.
+        <a href="https://qa.php.net">release candidate</a> of PHP 5.4.1.
          Windows binaries can be downloaded from the
         <a href="http://windows.php.net/qa/">Windows QA site</a>.
       </p>

--- a/archive/2014.php
+++ b/archive/2014.php
@@ -674,7 +674,7 @@ The list of changes is recorded in the <a href="http://www.php.net/ChangeLog-5.p
 
       <p>
         For source downloads of PHP 5.6.0RC4 please visit
-        the <a href="http://qa.php.net/">download page</a>. Windows binaries
+        the <a href="https://qa.php.net/">download page</a>. Windows binaries
         can be found on <a href="http://windows.php.net/qa/">windows.php.net/qa/</a>.
       </p>
 
@@ -832,7 +832,7 @@ The list of changes is recorded in the <a href="http://www.php.net/ChangeLog-5.p
 
       <p>
         For source downloads of PHP 5.6.0RC3 please visit
-        the <a href="http://qa.php.net/">download page</a>. Windows binaries
+        the <a href="https://qa.php.net/">download page</a>. Windows binaries
         can be found on <a href="http://windows.php.net/qa/">windows.php.net/qa/</a>.
       </p>
 
@@ -965,7 +965,7 @@ The list of changes is recorded in the <a href="http://www.php.net/ChangeLog-5.p
 
       <p>
         For source downloads of PHP 5.6.0RC2 please visit
-        the <a href="http://qa.php.net/">download page</a>. Windows binaries
+        the <a href="https://qa.php.net/">download page</a>. Windows binaries
         can be found on <a href="http://windows.php.net/qa/">windows.php.net/qa/</a>.
       </p>
 
@@ -1155,7 +1155,7 @@ The list of changes is recorded in the <a href="http://www.php.net/ChangeLog-5.p
 
       <p>
         For source downloads of PHP 5.6.0RC1 please visit
-        the <a href="http://qa.php.net/">download page</a>. Windows binaries
+        the <a href="https://qa.php.net/">download page</a>. Windows binaries
         can be found on <a href="http://windows.php.net/qa/">windows.php.net/qa/</a>.
       </p>
 
@@ -1204,7 +1204,7 @@ The list of changes is recorded in the <a href="http://www.php.net/ChangeLog-5.p
 
       <p>
         For source downloads of PHP 5.6.0beta4 please visit
-        the <a href="http://qa.php.net/">download page</a>. Windows binaries
+        the <a href="https://qa.php.net/">download page</a>. Windows binaries
         can be found on <a href="http://windows.php.net/qa/">windows.php.net/qa/</a>.
       </p>
 
@@ -1403,7 +1403,7 @@ The list of changes is recorded in the <a href="http://www.php.net/ChangeLog-5.p
 
      <p>
       For source downloads of PHP 5.6.0beta3 please visit
-      the <a href="http://qa.php.net/">download page</a>. Windows binaries
+      the <a href="https://qa.php.net/">download page</a>. Windows binaries
       can be found on <a href="http://windows.php.net/qa/">windows.php.net/qa/</a>.
      </p>
 
@@ -1453,7 +1453,7 @@ The list of changes is recorded in the <a href="http://www.php.net/ChangeLog-5.p
 
      <p>
       For source downloads of PHP 5.6.0beta2 please visit
-      the <a href="http://qa.php.net/">download page</a>. Windows binaries
+      the <a href="https://qa.php.net/">download page</a>. Windows binaries
       can be found on <a href="http://windows.php.net/qa/">windows.php.net/qa/</a>.
      </p>
 
@@ -1548,7 +1548,7 @@ The list of changes is recorded in the <a href="http://www.php.net/ChangeLog-5.p
 
      <p>
       For source downloads of PHP 5.6.0beta1 please visit
-      the <a href="http://qa.php.net/">download page</a>. Windows binaries
+      the <a href="https://qa.php.net/">download page</a>. Windows binaries
       can be found on <a href="http://windows.php.net/qa/">windows.php.net/qa/</a>.
      </p>
 

--- a/releases/feed.php
+++ b/releases/feed.php
@@ -30,7 +30,7 @@ foreach ($RELEASED_VERSIONS as $version => $release) {
     if ($release["announcement"]) {
         $id = "http://php.net/releases/" . str_replace(".", "_", $version) . ".php";
     } else {
-        $id = "http://qa.php.net/#$version";
+        $id = "https://qa.php.net/#$version";
     }
 
     echo <<<XML


### PR DESCRIPTION
Replace http://qa.php.net URLs with https://qa.php.net.


Side notes:
 - The URL http://qa.php.net/~derick/ has been changed to http://downloads.php.net/~derick/ even though both URLs don't include 4.4.0RC2. My assumption is that if we ever restore old RC's it would be there.
 - http://qa.php.net/testfest.php has been changed to https://phptestfest.org. 