### PR TITLE
Update gtk.php.net and museum.php.net links to https

### DIFF
--- a/archive/2001.php
+++ b/archive/2001.php
@@ -43,10 +43,10 @@ site_header("News Archive - 2001", ["cache" => true]);
 
 <p>
  <span class="newsdate">[18-Oct-2001]</span>
- <a href="http://gtk.php.net/">PHP-GTK</a>
- <a href="http://gtk.php.net/docs.php">documentation</a> is starting
+ <a href="https://gtk.php.net/">PHP-GTK</a>
+ <a href="https://gtk.php.net/manual/en/html/index.html">documentation</a> is starting
  to be more filled out. The manual is now rebuilt every night and
- <a href="http://gtk.php.net/download-docs.php">downloadable versions</a>
+ <a href="https://gtk.php.net/documentation.php">downloadable versions</a>
  of it in different formats are also available. If you have been working with
  PHP-GTK and would like to contribute to the documentation effort, please
  let us know.
@@ -105,7 +105,7 @@ site_header("News Archive - 2001", ["cache" => true]);
 
 <hr>
 
-<?php news_image("http://gtk.php.net/", "php-gtk-white.gif", "PHP-GTK"); ?>
+<?php news_image("https://gtk.php.net/", "php-gtk-white.gif", "PHP-GTK"); ?>
 <h1>PHP-GTK version 0.1 released</h1>
 
 <p>
@@ -123,7 +123,7 @@ site_header("News Archive - 2001", ["cache" => true]);
  A talk on PHP-GTK was presented by Andrei Zmievski and Frank Kromann at the 2001
  O'Reilly Open Source Conference in San Diego. The slides from the talk can be
  <a href="http://conf.php.net/sd-gtk">viewed online</a>.
- For more information, visit <a href="http://gtk.php.net/">the PHP-GTK website</a>.
+ For more information, visit <a href="https://gtk.php.net/">the PHP-GTK website</a>.
 </p>
 
 <hr>
@@ -294,14 +294,14 @@ site_header("News Archive - 2001", ["cache" => true]);
 
 <hr>
 
-<?php news_image("http://gtk.php.net/", "php-gtk-white.gif", "PHP-GTK"); ?>
+<?php news_image("https://gtk.php.net/", "php-gtk-white.gif", "PHP-GTK"); ?>
 <h1>Announcing PHP-GTK</h1>
 <p>
  <span class="newsdate">[01-Mar-2001]</span>
  The first release of PHP-GTK is now available. PHP-GTK is a PHP extension that
  provides an object-oriented interface to the GTK+ toolkit and enables you to write
  client-side cross-platform GUI applications. For more information, visit
- <a href="http://gtk.php.net/">http://gtk.php.net/</a>.
+ <a href="https://gtk.php.net/">https://gtk.php.net/</a>.
 </p>
 
 <hr>

--- a/archive/2002.php
+++ b/archive/2002.php
@@ -568,7 +568,7 @@ site_header("News Archive - 2002", ["cache" => true]);
 
 <p>
  <span class="newsdate">[24-Jan-2002]</span>
- <a href="http://gtk.php.net/">PHP-GTK</a> has reached version
+ <a href="https://gtk.php.net/">PHP-GTK</a> has reached version
  0.5.0, also known as <em>"monday starts on saturday"</em>. The version number
  was bumped from 0.1.1 to this one to indicate that PHP-GTK is now a fairly
  mature and stable extension and can be used for a variety of applications

--- a/manual/php3.php
+++ b/manual/php3.php
@@ -29,7 +29,7 @@ site_header('PHP Version 3 Documentation');
 </p>
 
 <p>
- See the <a href="http://museum.php.net/">PHP Museum</a> for downloads, and
+ See the <a href="https://museum.php.net/">PHP Museum</a> for downloads, and
  also read the <a href="http://php.net/history">history</a> for further
  information about PHP 3.
 </p>

--- a/releases/4_3_0.php
+++ b/releases/4_3_0.php
@@ -20,7 +20,7 @@ site_header("PHP 4.3.0 Release Announcement");
 <p>
  This version finalizes the separate command line interface (CLI) that can be
  used for developing shell and desktop applications (with
- <a href="http://gtk.php.net/">PHP-GTK</a>). The CLI is always built, but
+ <a href="https://gtk.php.net/">PHP-GTK</a>). The CLI is always built, but
  installed automatically only if CGI version is disabled via --disable-cgi
  switch during configuration. Alternatively, one can use <strong>make
  install-cli</strong> target. On Windows CLI can be found in

--- a/releases/4_3_0_fr.php
+++ b/releases/4_3_0_fr.php
@@ -23,7 +23,7 @@ site_header("Annonce de publication de PHP 4.3.0", ["lang" => "fr"]);
 <p>
  PHP 4.3.0 ach&egrave;ve la s&eacute;paration du mode d'utilisation en
  ligne de commande (dit CLI) qui permet de d&eacute;velopper des
- applications shell ou graphiques (avec <a href="http://gtk.php.net/">PHP-GTK</a>).
+ applications shell ou graphiques (avec <a href="https://gtk.php.net/">PHP-GTK</a>).
  La version CLI de PHP est toujours compil&eacute;es, mais elle n'est
  install&eacute;e que si la version CGI est d&eacute;sactiv&eacute;e
  avec l'option --disable-cgi. De plus, vous pouvez utilisez la commande

--- a/releases/index.php
+++ b/releases/index.php
@@ -140,7 +140,7 @@ site_footer(['sidebar' =>
 </p>
 
 <div class="panel">
- <a href="http://museum.php.net/">PHP Museum</a>
+ <a href="https://museum.php.net/">PHP Museum</a>
 </div>
 
 <div class="panel">
@@ -237,11 +237,11 @@ function mk_rel(int $major,
             if (!isset($src["filename"])) {
                 continue;
             }
-            printf('<li><a href="http://museum.php.net/php%d/%s">%s</a></li>',
+            printf('<li><a href="https://museum.php.net/php%d/%s">%s</a></li>',
                    $major, $src["filename"], $src["name"]);
         }
         foreach ($windows as $src) {
-            printf('<li><a href="http://museum.php.net/%s/%s">%s</a></li>',
+            printf('<li><a href="https://museum.php.net/%s/%s">%s</a></li>',
                    ($major == 5 ? "php5" : "win32"), $src["filename"], $src["name"]);
         }
     }

--- a/sites.php
+++ b/sites.php
@@ -25,7 +25,7 @@ site_header("A Tourist's Guide", ["current" => "help"]);
  This is the home of the <a href="/downloads.php">download page</a>, for
  everyone to get the latest version of the PHP source code and binaries
  for Windows. The current and next-to-current versions are available there.
- (There is also a <a href="http://museum.php.net/">PHP Museum</a>, which has
+ (There is also a <a href="https://museum.php.net/">PHP Museum</a>, which has
  all of the source distributions since June 1996.)
 </p>
 


### PR DESCRIPTION
 - Replace http://gtk.php.net URLs with https://gtk.php.net.
 - Replace http://museum.php.net URLs with https://museum.php.net.
 
Side note:
 - The documentation links have been updated to the new formats for online & download.