### PR TITLE
Remove error suppression operator (@) and add proper error handling

### DIFF
--- a/bin/news2html
+++ b/bin/news2html
@@ -11,7 +11,7 @@ if (count($_SERVER['argv']) < 2) {
 }
 $news_file = array_shift($_SERVER['argv']);
 $version = array_shift($_SERVER['argv']);
-$changelog = @array_shift($_SERVER['argv']);
+$changelog = array_shift($_SERVER['argv']);
 
 // find NEWS entry
 $fp = fopen($news_file, "r");

--- a/cal.php
+++ b/cal.php
@@ -253,8 +253,11 @@ function display_events_for_day($day, $events): void
 // Find a single event in the events file by ID
 function load_event($id)
 {
+    $path = "backend/events.csv";
+    if (!file_exists($path) || !is_readable($path)) { return false; }
+
     // Open events CSV file, return on error
-    $fp = @fopen("backend/events.csv",'r');
+    $fp = fopen($path,'r');
     if (!$fp) { return false; }
 
     // Read as we can, event by event
@@ -289,7 +292,10 @@ function load_events($from, $whole_month = false)
     $events = $seen = [];
 
     // Try to open the events file for reading, return if unable to
-    $fp = @fopen("backend/events.csv",'r');
+    $path = "backend/events.csv";
+    if (!file_exists($path) || !is_readable($path)) { return false; }
+
+    $fp = fopen($path,'r');
     if (!$fp) { return false; }
 
     // For all events, read in the event and check it if fits our scope
@@ -357,7 +363,9 @@ function read_event($fp)
     ] = $linearr;
 
     // Get info on recurring event
-    @[$recur, $recur_day] = explode(":", $recur, 2);
+    $recurParts = explode(":", $recur, 2);
+    $recur = $recurParts[0];
+    $recur_day = $recurParts[1] ?? null;
 
     // Return with SQL-resultset like array
     return [

--- a/download-docs.php
+++ b/download-docs.php
@@ -114,8 +114,8 @@ foreach (Languages::LANGUAGES as $langcode => $language) {
             $link_to = "/distributions/manual/$filename";
 
             // Try to get size and changed date
-            $size = @filesize($filepath);
-            $changed = @filemtime($filepath);
+            $size = file_get_size($filepath);
+            $changed = file_get_size($filepath);
 
             // Size available, collect information
             if ($size !== false) {
@@ -138,8 +138,8 @@ $formats['<a href="/docs-echm.php">Extended HTML Help</a>'] = "zip"; // Add a li
 $actual_file = $_SERVER['DOCUMENT_ROOT'] . "/distributions/manual/php_manual_chm.zip";
 if (file_exists($actual_file)) {
     $link_to = "/get/php_manual_chm.zip/from/a/mirror";
-    $size    = @filesize($actual_file);
-    $changed = @filemtime($actual_file);
+    $size    = file_get_size($actual_file);
+    $changed = filemtime($actual_file);
     if ($size !== FALSE) {
         $files["en"]["zip"] = array(
             $link_to,

--- a/images/elephpants.php
+++ b/images/elephpants.php
@@ -47,7 +47,7 @@ if (isset($_REQUEST['count'])) {
 
 // read out photo metadata
 $path = __DIR__ . '/elephpants';
-$json = @file_get_contents($path . '/flickr.json');
+$json = file_get_contents_if_exists($path . '/flickr.json');
 $photos = json_decode($json, true);
 
 // if no photo data, respond with an error.

--- a/include/do-download.inc
+++ b/include/do-download.inc
@@ -14,7 +14,7 @@ function get_actual_download_file($file)
     // Find out what is the exact file requested
     $found = false;
     foreach ($possible_files as $name => $log) {
-        if (@file_exists($_SERVER['DOCUMENT_ROOT'] . '/distributions/' . $name)) {
+        if (file_exists($_SERVER['DOCUMENT_ROOT'] . '/distributions/' . $name)) {
             $found = $name;
             break;
         }

--- a/include/download-instructions/windows-downloads.php
+++ b/include/download-instructions/windows-downloads.php
@@ -1,7 +1,7 @@
 <?php
 $baseDownloads  = 'https://downloads.php.net/~windows/releases/archives/';
 
-$dataStr = @file_get_contents(__DIR__ . '/../../backend/win-releases.json');
+$dataStr = file_get_contents_if_exists(__DIR__ . '/../../backend/win-releases.json');
 $releases = $dataStr ? json_decode($dataStr, true) : null;
 
 if (!is_array($releases)) {

--- a/include/file.inc
+++ b/include/file.inc
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ *
+*/
+
+function file_get_size(string $filename): int|false
+{
+    if (!file_exists($filename) || !is_readable($filename)) {
+        return false;
+    }
+
+    return filesize($filename);
+}
+
+function file_get_mtime(string $filename): int|false
+{
+    if (!file_exists($filename) || !is_readable($filename)) {
+        return false;
+    }
+
+    return filemtime($filename);
+}
+
+function file_get_contents_if_exists(string $filename): string|false
+{
+    if (!file_exists($filename) || !is_readable($filename)) {
+        return false;
+    }
+
+    return file_get_contents($filename);
+}
+{
+
+}

--- a/include/file.inc
+++ b/include/file.inc
@@ -1,7 +1,9 @@
 <?php
 
 /*
- *
+ * This file contains helper functions to deal with files in a safe manner.
+ * These functions check for file existence and readability before performing
+ * any operations on them.
 */
 
 function file_get_size(string $filename): int|false
@@ -29,7 +31,4 @@ function file_get_contents_if_exists(string $filename): string|false
     }
 
     return file_get_contents($filename);
-}
-{
-
 }

--- a/include/footer.inc
+++ b/include/footer.inc
@@ -101,14 +101,14 @@ if (!empty($_SERVER['BASE_PAGE'])
  $jsfiles = ["ext/jquery-3.6.0.min.js", "ext/FuzzySearch.min.js", "ext/mousetrap.min.js", "ext/jquery.scrollTo.min.js", "search.js", "common.js"];
  foreach ($jsfiles as $filename) {
    $path = dirname(__DIR__) . '/js/' . $filename;
-   echo '<script src="/cached.php?t=' . @filemtime($path) . '&amp;f=/js/' . $filename . '"></script>' . "\n";
+   echo '<script src="/cached.php?t=' . filemtime($path) . '&amp;f=/js/' . $filename . '"></script>' . "\n";
  }
 ?>
 <?php
  $jsfiles = ["interactive-examples.js"];
  foreach ($jsfiles as $filename) {
    $path = dirname(__DIR__) . '/js/' . $filename;
-   echo '<script type="module" src="/cached.php?t=' . @filemtime($path) . '&amp;f=/js/' . $filename . '"></script>' . "\n";
+   echo '<script type="module" src="/cached.php?t=' . filemtime($path) . '&amp;f=/js/' . $filename . '"></script>' . "\n";
  }
 ?>
 

--- a/include/get-download.inc
+++ b/include/get-download.inc
@@ -18,7 +18,7 @@ $site_config = [
 // Find out what is the exact file requested
 $file = false;
 foreach ($possible_files as $name) {
-    if (@file_exists($_SERVER['DOCUMENT_ROOT'] . '/distributions/' . $name)) {
+    if (file_exists($_SERVER['DOCUMENT_ROOT'] . '/distributions/' . $name)) {
         $file = $name;
         break;
     }
@@ -43,7 +43,7 @@ EOT;
     // Set local file name
     $local_file = $_SERVER['DOCUMENT_ROOT'] . '/distributions/' . $file;
     // Try to get filesize to display
-    $size = @filesize($local_file);
+    $size = file_get_size($local_file);
 }
 ?>
 </div>

--- a/include/header.inc
+++ b/include/header.inc
@@ -20,14 +20,14 @@ foreach($css_files as $filename) {
         $filename = "/styles/$filename";
     }
     $path = dirname(__DIR__) . $filename;
-    $CSS[$filename] = @filemtime($path);
+    $CSS[$filename] = filemtime($path);
 }
 
 $JS = [];
 if (isset($config["js_files"])) {
     foreach($config['js_files'] as $filename) {
         $path = dirname(__DIR__) . '/' . $filename;
-        $JS[$filename] = @filemtime($path);
+        $JS[$filename] = filemtime($path);
     }
 }
 

--- a/include/layout.inc
+++ b/include/layout.inc
@@ -94,8 +94,11 @@ function make_image($file, $alt = false, $align = false, $extras = false,
     // If no / was provided at the start of $dir, add it
     $webdir = $_SERVER['MYSITE'] . ($dir[0] == '/' ? '' : '/') . $dir;
 
-    // Get width and height values if possible
-    if ($addsize && ($size = @getimagesize($_SERVER['DOCUMENT_ROOT'] . "$dir/$file"))) {
+  // Get width and height values if possible
+    $filePath = $_SERVER['DOCUMENT_ROOT'] . "$dir/$file";
+    if (!file_exists($filePath)) {
+        $sizeparams = '';
+    } else if ($addsize && ($size = getimagesize($filePath))) {
         $sizeparams = ' ' . trim($size[3]);
     } else {
         $sizeparams = '';
@@ -194,14 +197,14 @@ function download_link($file, $title): void
         $local_file = "distributions/$file";
     }
 
-    if (@file_exists($local_file . ".asc")) {
+    if (file_exists($local_file . ".asc")) {
         echo " ";
         $sig_link = "/distributions/$file.asc";
         echo make_link($sig_link, "(sig)");
     }
 
     // Try to get the size of the file
-    $size = @filesize($local_file);
+    $size = file_get_size($local_file);
 
     // Print out size in bytes (if size is
     // less then 1Kb, or else in Kb)

--- a/include/manual-lookup.inc
+++ b/include/manual-lookup.inc
@@ -14,27 +14,27 @@ function tryprefix($lang, $keyword, $prefix)
 
     // Try the keyword with the prefix
     $try = "/manual/{$lang}/{$prefix}{$keyword}.php";
-    if (@file_exists($_SERVER['DOCUMENT_ROOT'] . $try)) { return $try; }
+    if (file_exists($_SERVER['DOCUMENT_ROOT'] . $try)) { return $try; }
 
     // Drop out spaces, and try that keyword (if different)
     $nosp = str_replace(" ", "", $keyword);
     if ($nosp != $keyword) {
         $try = "/manual/{$lang}/{$prefix}{$nosp}.php";
-        if (@file_exists($_SERVER['DOCUMENT_ROOT'] . $try)) { return $try; }
+        if (file_exists($_SERVER['DOCUMENT_ROOT'] . $try)) { return $try; }
     }
 
     // Replace spaces with hyphens, and try that (if different)
     $dasp = str_replace(" ", "-", $keyword);
     if ($dasp != $keyword) {
         $try = "/manual/{$lang}/{$prefix}{$dasp}.php";
-        if (@file_exists($_SERVER['DOCUMENT_ROOT'] . $try)) { return $try; }
+        if (file_exists($_SERVER['DOCUMENT_ROOT'] . $try)) { return $try; }
     }
 
     // Remove hyphens (and underscores), and try that (if different)
     $noul = str_replace("-", "", $keyword);
     if ($noul != $keyword) {
         $try = "/manual/{$lang}/{$prefix}{$noul}.php";
-        if (@file_exists($_SERVER['DOCUMENT_ROOT'] . $try)) { return $try; }
+        if (file_exists($_SERVER['DOCUMENT_ROOT'] . $try)) { return $try; }
     }
 
     // urldecode() (%5C == \) Replace namespace sperators, and try that (if different)
@@ -42,7 +42,7 @@ function tryprefix($lang, $keyword, $prefix)
     $noul = str_replace("\\", "-", $keyword);
     if ($noul != $keyword) {
         $try = "/manual/{$lang}/{$prefix}{$noul}.php";
-        if (@file_exists($_SERVER['DOCUMENT_ROOT'] . $try)) { return $try; }
+        if (file_exists($_SERVER['DOCUMENT_ROOT'] . $try)) { return $try; }
     }
 
     // Replace first - with a dot and try that (for mysqli_ type entries)
@@ -53,7 +53,7 @@ function tryprefix($lang, $keyword, $prefix)
             $keyword[$pos] = '.';
 
             $try = "/manual/{$lang}/{$prefix}{$keyword}.php";
-            if (@file_exists($_SERVER['DOCUMENT_ROOT'] . $try)) { return $try; }
+            if (file_exists($_SERVER['DOCUMENT_ROOT'] . $try)) { return $try; }
         }
     }
 

--- a/include/prepend.inc
+++ b/include/prepend.inc
@@ -79,6 +79,9 @@ $userPreferences = new UserPreferences();
 // Load the My PHP.net settings before any includes
 $userPreferences->load();
 
+// Import functions to deal with files in a safe manner
+include_once __DIR__ . '/file.inc';
+
 // Site details (mirror site information)
 include __DIR__ . '/site.inc';
 

--- a/include/shared-manual.inc
+++ b/include/shared-manual.inc
@@ -101,11 +101,11 @@ function manual_notes_load(string $id): array
 
     // Open the note file for reading and get the data (12KB)
     // ..if it exists
-    if (!file_exists($notes_file)) {
+//    if (!file_exists($notes_file) || !is_readable($notes_file)) {
         return [];
     }
     $notes = [];
-    if ($fp = @fopen($notes_file, "r")) {
+    if ($fp = fopen($notes_file, "r")) {
         while (!feof($fp)) {
             $line = chop(fgets($fp, 12288));
             if ($line == "") { continue; }

--- a/index.php
+++ b/index.php
@@ -15,8 +15,11 @@ use phpweb\News\NewsHandler;
     }
 })($_SERVER['REQUEST_URI'] ?? '');
 
+// Import functions to deal with files in a safe manner
+include_once __DIR__ . '/include/file.inc';
+
 // Get the modification date of this PHP file
-$timestamps = [@getlastmod()];
+$timestamps = [getlastmod()];
 
 /*
    The date of prepend.inc represents the age of ALL
@@ -25,13 +28,13 @@ $timestamps = [@getlastmod()];
    the display of the index page). The cost of stat'ing
    them all is prohibitive.
 */
-$timestamps[] = @filemtime("include/prepend.inc");
+$timestamps[] = file_get_mtime("include/prepend.inc");
 
 // These are the only dynamic parts of the frontpage
-$timestamps[] = @filemtime("include/pregen-confs.inc");
-$timestamps[] = @filemtime("include/pregen-news.inc");
-$timestamps[] = @filemtime("include/version.inc");
-$timestamps[] = @filemtime("js/common.js");
+$timestamps[] = file_get_mtime("include/pregen-confs.inc");
+$timestamps[] = file_get_mtime("include/pregen-news.inc");
+$timestamps[] = file_get_mtime("include/version.inc");
+$timestamps[] = file_get_mtime("js/common.js");
 
 // The latest of these modification dates is our real Last-Modified date
 $timestamp = max($timestamps);

--- a/manual/phpfi2.php
+++ b/manual/phpfi2.php
@@ -2927,7 +2927,7 @@ nibble, like 0?755:
   messages appear on the web screen. This can be done by putting
   the "@" character in front of the function call. ie.</p>
   <pre>
-    $err_code = @dbmopen($filename,"w");
+    $err_code = dbmopen($filename,"w");
 </pre>
 
   <p>The actual error message that would have been printed can be

--- a/pre-release-builds.php
+++ b/pre-release-builds.php
@@ -120,7 +120,7 @@ $winQaMessage = '';
 $winQaReleases = [];
 
 if (is_readable($winQaFile)) {
-  $raw = @file_get_contents($winQaFile);
+  $raw = file_get_contents_if_exists($winQaFile);
   $decoded = $raw ? json_decode($raw, true) : null;
   if (is_array($decoded)) {
     $allowedBranches = [];

--- a/quickref.php
+++ b/quickref.php
@@ -44,9 +44,9 @@ function quickref_table($functions, $sort = true): void
 
 // Open directory, fall back to English,
 // if there is no dir for that language
-$dirh = @opendir($_SERVER['DOCUMENT_ROOT'] . "/manual/$LANG");
-if (!$dirh) {
-    error_noservice();
+$path = $_SERVER['DOCUMENT_ROOT'] . "/manual/$LANG";
+if (!is_dir($path) || !is_readable($path) || !$dirh = opendir($path)) {
+  error_noservice();
 }
 
 $functions = $maybe = $temp = $parts = [];


### PR DESCRIPTION
At some places the `@` symbol was still used. This PR changes that behaviour with proper handling.

Since those checks are always (correct me if I am wrong) for internal paths. A simple file_exists & is_readable check is sufficient. If not we could override the error handler instead.