### PR TITLE
Update meta redirect to link directly to index.php

### DIFF
--- a/license/ZendGrant/index.html
+++ b/license/ZendGrant/index.html
@@ -1,10 +1,10 @@
 <html lang="en">
     <head>
-        <meta http-equiv="Refresh" content="15; url='/license/ZendGrant/'">
+        <meta http-equiv="Refresh" content="5; url='/license/ZendGrant/index.php'">
         <title>Zend Grant</title>
     </head>
     <body>
         <h1>This page has moved</h1>
-        <p>If you are not redirected within 15 seconds, please <a href="/license/ZendGrant/">click here</a>.</p>
+        <p>If you are not redirected within 5 seconds, please <a href="/license/ZendGrant/index.php">click here</a>.</p>
     </body>
 </html>


### PR DESCRIPTION
When I committed 5cdd1dd73615f8f5ad84df9da0cacae39adbe9f9, the web server appeared to prefer loading the `index.php` file over `index.html` when requesting `/license/ZendGrant/`. I left `index.html` in place because there were direct links to it from around the web, and I didn't want those links to end at 404 pages, so I set it up to redirect to the cleaner `/license/ZendGrant/` URL, thinking `index.php` would load every time.

Now, the web server appears to prefer `index.html` over `index.php`, so landing on this page, either from `/license/ZendGrant/` or `/license/ZendGrant/index.html` results in an endless redirection loop. The easy solution is to make `index.html` redirect directly to `/license/ZendGrant/index.php` instead.