### PR TITLE
Change language code to lowercase for translation file

### DIFF
--- a/include/shared-manual.inc
+++ b/include/shared-manual.inc
@@ -292,7 +292,7 @@ function autogen(string $text, string $lang) {
         throw new \InvalidArgumentException("Cannot autogenerate text for '$text'");
     }
 
-    $translationFile = __DIR__ . \DIRECTORY_SEPARATOR . "ui_translation" . \DIRECTORY_SEPARATOR . $lang . ".ini";
+    $translationFile = __DIR__ . \DIRECTORY_SEPARATOR . "ui_translation" . \DIRECTORY_SEPARATOR . strtolower($lang) . ".ini";
 
     if (!\file_exists($translationFile)) {
         if ($lang !== "en") {


### PR DESCRIPTION
For languages like 'pt_BR', the filename is 'pt_br.ini' in lowercase.

The headers and footers of pt_BR pages are not being translated.