### PR TITLE
Fix changelog file reference in error.php

### DIFF
--- a/error.php
+++ b/error.php
@@ -542,6 +542,8 @@ $uri_aliases = [
     "tips.php" => "urlhowto",
     "tips" => "urlhowto",
     "release-candidates.php" => "pre-release-builds",
+
+    "changelog-8.php" => "ChangeLog-8",
 ];
 
 $external_redirects = [


### PR DESCRIPTION
searching for PHP changelog on google - the top result is: https://www.php.net/changelog-8.php  which doth not exist because it should be ChangeLog-8.php instead.