### PR TITLE
Fix: Resolve accessibility violation by adding explicit role to offcanvas menu

### DIFF
--- a/include/header.inc
+++ b/include/header.inc
@@ -149,6 +149,7 @@ if (!isset($config["languages"])) {
       tabindex="-1"
       class="navbar__offcanvas"
       aria-label="Menu"
+      role="navigation"
     >
       <button
         id="navbar__close-button"


### PR DESCRIPTION
## Description
This PR fixes an accessibility violation on [website homepage](https://www.php.net/) identified by the IBM Equal Access Accessibility Checker.

<img width="2560" height="918" alt="image" src="https://github.com/user-attachments/assets/ef1b13b1-bce8-49d7-8f6e-a2b7e0f6eac7" />

The offcanvas navigation container (`.navbar__offcanvas`) was using an `aria-label="Menu"` without an explicit ARIA role. According to WAI-ARIA standards, a `<div>` with a generic role should not typically have an accessible name.

**Violation Details**
- Tool: [IBM Equal Access Accessibility Checker]((https://github.com/IBMa/equal-access))
- Rule: ARIA attributes should be valid for the element and ARIA role to which they are assigned.
- Issue: The ARIA attribute aria-label is not valid for the element `<div>` with implicit ARIA role generic.

## Fix
By adding `role="navigation"`, we ensure that:

- The `aria-label` is valid and properly exposed to assistive technologies.
- Screen reader users can identify this section as a navigation landmark.

## Verify
- Open the website with the patched code.
- Run the IBM Equal Access Accessibility Checker (or Axe DevTools).
- Confirm that the violation "ARIA attributes should be valid for the element..." no longer appears for the .navbar__offcanvas element.

## Additional Info
The patch submitted in this PR was generated by [A11YRepair](https://sites.google.com/view/a11yrepair/home), an automated Web Accessibility repair tool that I developed to address common accessibility violations in web applications. The generated fixes were manually reviewed and validated before submission.