### PR TITLE
Fix weekday dropdown mismatch in submit-event form

### DIFF
--- a/submit-event.php
+++ b/submit-event.php
@@ -152,7 +152,7 @@ if (count($errors)) { display_errors($errors); }
 
 // Generate days and months arrays for form
 for ($i = 1; $i <= 7; $i++) {
-    $days[$i] = date('l', mktime(12, 0, 0, 4, $i));
+    $days[$i] = date('l', mktime(12, 0, 0, 4, $i, 2012));
 }
 for ($i = 1; $i <= 12; $i++) {
     $months[$i] = date('F', mktime(12, 0, 0, $i, 1));


### PR DESCRIPTION
## Summary
- Fixes #1218
- The `$days` array in `submit-event.php` used `mktime()` without a year parameter (defaulting to the current year), while `layout.inc` hardcoded 2012
- April 1st falls on different weekdays each year, causing the form dropdown and preview to show mismatched weekday names
- Fix: use the same hardcoded year (2012) in both locations