### PR TITLE
Add missing trigger_error() deprecation to PHP 8.4 release page

### DIFF
--- a/releases/8.4/languages/en.php
+++ b/releases/8.4/languages/en.php
@@ -51,6 +51,7 @@ return [
     'bc_standard' => '<code>stream_bucket_make_writeable()</code> and <code>stream_bucket_new()</code> now return an instance of <code>StreamBucket</code> instead of <code>stdClass</code>.',
     'bc_core' => '<a href="/manual/en/migration84.incompatible.php#migration84.incompatible.core.exit"><code>exit()</code> behavioral change</a>.',
     'bc_warnings' => '<code>E_STRICT</code> constant has been deprecated.',
+    'bc_trigger_error' => 'Passing <code>E_USER_ERROR</code> to <code>trigger_error()</code> is now deprecated.',
 
     'footer_title' => 'Better performance, better syntax, improved type safety.',
     'footer_description' => '<p>For source downloads of PHP 8.4 please visit the <a href="/downloads">downloads</a> page. Windows binaries can be found on the <a href="https://windows.php.net/download">PHP for Windows</a> site. The list of changes is recorded in the <a href="/ChangeLog-8.php#PHP_8_4">ChangeLog</a>.</p>

--- a/releases/8.4/release.inc
+++ b/releases/8.4/release.inc
@@ -568,6 +568,7 @@ PHP
                     <li><?= message('bc_standard', $lang) ?></li>
                     <li><?= message('bc_core', $lang) ?></li>
                     <li><?= message('bc_warnings', $lang) ?></li>
+                    <li><?= message('bc_trigger_error', $lang) ?></li>
                 </ul>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- Fixes #1233
- The deprecation of passing `E_USER_ERROR` to `trigger_error()` was documented in the ChangeLog but missing from the PHP 8.4 release announcement page
- Added `bc_trigger_error` entry to `releases/8.4/languages/en.php` and the corresponding `<li>` in `release.inc`