### PR TITLE
Add support for @ and magic constants in search

### DIFF
--- a/include/errors.inc
+++ b/include/errors.inc
@@ -473,6 +473,16 @@ function is_known_term(string $term): ?string {
         'yield from' => 'language.generators.syntax.php#control-structures.yield.from',
         'yield' => 'language.generators.syntax.php#control-structures.yield',
 
+        '__line__' => 'language.constants.magic.php',
+        '__file__' => 'language.constants.magic.php',
+        '__dir__' => 'language.constants.magic.php',
+        '__function__' => 'language.constants.magic.php',
+        '__class__' => 'language.constants.magic.php',
+        '__trait__' => 'language.constants.magic.php',
+        '__method__' => 'language.constants.magic.php',
+        '__property__' => 'language.constants.magic.php',
+        '__namespace__' => 'language.constants.magic.php',
+
         '__COMPILER_HALT_OFFSET__' => 'function.halt-compiler.php',
         'DEFAULT_INCLUDE_PATH' => 'reserved.constants.php',
         'E_ALL' => 'errorfunc.constants.php',

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1815,7 +1815,7 @@ parameters:
 		-
 			message: '#^Variable \$LANG might not be defined\.$#'
 			identifier: variable.undefined
-			count: 1
+			count: 2
 			path: public/manual-lookup.php
 
 		-

--- a/public/error.php
+++ b/public/error.php
@@ -493,6 +493,16 @@ $uri_aliases = [
     "language.oop5.reflection" => "book.reflection", // BC
     "::" => "language.oop5.paamayim-nekudotayim",
 
+    "__line__" => "language.constants.magic",
+    "__file__" => "language.constants.magic",
+    "__dir__" => "language.constants.magic",
+    "__function__" => "language.constants.magic",
+    "__class__" => "language.constants.magic",
+    "__trait__" => "language.constants.magic",
+    "__method__" => "language.constants.magic",
+    "__property__" => "language.constants.magic",
+    "__namespace__" => "language.constants.magic",
+
     "__construct" => "language.oop5.decon",
     "__destruct" => "language.oop5.decon",
     "__call" => "language.oop5.overloading",

--- a/public/manual-lookup.php
+++ b/public/manual-lookup.php
@@ -27,6 +27,12 @@ if (!empty($_GET['scope']) && is_string($_GET['scope'])) {
 if ($function) {
     $function = strtolower($function);
 
+    // Check known terms and variables (operators like @, magic constants, etc.)
+    $path = is_known_variable(str_replace('_', '-', $function)) ?? is_known_term($function);
+    if ($path !== null) {
+        mirror_redirect("/manual/$LANG/$path");
+    }
+
     // Try to find appropriate manual page
     if ($file = find_manual_page($LANG, $function)) {
         mirror_redirect($file);


### PR DESCRIPTION
## Summary
- Fixes #974
- `manual-lookup.php` now checks `is_known_term()` and `is_known_variable()` before falling back to `find_manual_page()`, so searching for `@` now resolves to the error control operator page
- Adds all magic constants (`__LINE__`, `__FILE__`, `__DIR__`, `__FUNCTION__`, `__CLASS__`, `__TRAIT__`, `__METHOD__`, `__PROPERTY__`, `__NAMESPACE__`) to both `$uri_aliases` in `error.php` and `is_known_term()` in `errors.inc`