### PR TITLE
Update the Installation Instructions for Debian

### DIFF
--- a/include/download-instructions/linux-debian-cli-community.php
+++ b/include/download-instructions/linux-debian-cli-community.php
@@ -7,7 +7,13 @@ sudo apt-get update
 sudo apt-get install -y lsb-release ca-certificates curl
 sudo curl -sSLo /tmp/debsuryorg-archive-keyring.deb https://packages.sury.org/debsuryorg-archive-keyring.deb
 sudo dpkg -i /tmp/debsuryorg-archive-keyring.deb
-sudo sh -c 'echo "deb [signed-by=/usr/share/keyrings/debsuryorg-archive-keyring.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list'
+sudo tee /etc/apt/sources.list.d/php.sources &lt;&lt;EOF
+Types: deb
+URIs: https://packages.sury.org/php/
+Suites: $(lsb_release -sc)
+Components: main
+Signed-By: /usr/share/keyrings/debsuryorg-archive-keyring.gpg
+EOF
 sudo apt-get update
 
 # Install PHP.


### PR DESCRIPTION
Closes #1833
- Update Debian source list from `.list` to `.sources` format.
- Drop `apt-transport-https` package.