### PR TITLE
fix(css): Override `.token.operator` bg to `trasnparent`

### DIFF
--- a/styles/code-syntax.css
+++ b/styles/code-syntax.css
@@ -43,6 +43,10 @@ pre.line-numbers .line-numbers-rows > span:before {
     padding-right: 1em !important;
 }
 
+.token.operator {
+    background: transparent !important;
+}
+
 div.code-toolbar > .toolbar > .toolbar-item > a, div.code-toolbar > .toolbar > .toolbar-item > button, div.code-toolbar > .toolbar > .toolbar-item > span {
     color: #000;
     background: transparent;


### PR DESCRIPTION
Fix visual error within the code block by removing `background` property from `.token.operator`.

Before:
<img width="168" height="116" alt="bg-before-fix" src="https://github.com/user-attachments/assets/65f1d2f2-3924-4988-86fe-b88bf24bd869" />

After:
<img width="167" height="120" alt="bg-after-fix" src="https://github.com/user-attachments/assets/0d43a8fa-6f15-4f4b-8572-f6440b029177" />

For anyone wondering `.token.operator` class is defined on `prism.css` line 3 column 1479.