### PR TITLE
docs(download): Change `apt-get` to `apt` for Debian installation

### DIFF
--- a/include/download-instructions/linux-debian-cli-community.php
+++ b/include/download-instructions/linux-debian-cli-community.php
@@ -3,8 +3,8 @@ On the command line, run the following commands:
 </p>
 <pre><code class="language-bash line-numbers">
 # Add the packages.sury.org/php repository.
-sudo apt-get update
-sudo apt-get install -y lsb-release ca-certificates curl
+sudo apt update
+sudo apt install -y lsb-release ca-certificates curl
 sudo curl -sSLo /tmp/debsuryorg-archive-keyring.deb https://packages.sury.org/debsuryorg-archive-keyring.deb
 sudo dpkg -i /tmp/debsuryorg-archive-keyring.deb
 sudo tee /etc/apt/sources.list.d/php.sources &lt;&lt;EOF
@@ -14,8 +14,8 @@ Suites: $(lsb_release -sc)
 Components: main
 Signed-By: /usr/share/keyrings/debsuryorg-archive-keyring.gpg
 EOF
-sudo apt-get update
+sudo apt update
 
 # Install PHP.
-sudo apt-get install -y php<?= $version; ?>
+sudo apt install -y php<?= $version; ?>
 </code></pre>


### PR DESCRIPTION
Closes  #1840

Changing `apt-get` to `apt` to make the installation code more readable and cleaner.