### PR TITLE
Remove X/Twitter link from homepage social media section

### DIFF
--- a/index.php
+++ b/index.php
@@ -182,12 +182,6 @@ $announcements
       <div class='body'>
         <ul>
           <li>
-            <a href="https://twitter.com/official_php" target="_blank" rel="noopener noreferrer">
-              <i class="icon-x-twitter"></i>
-              @official_php
-            </a>
-          </li>
-          <li>
             <a href="https://fosstodon.org/@php" target="_blank" rel="noopener noreferrer">
               <i class="icon-mastodon"></i>
               @php@fosstodon.org


### PR DESCRIPTION
Removes the X/Twitter link from the homepage social media sidebar.
Mastodon and LinkedIn links stay as they are.

I noticed the `icon-x-twitter` class is still defined in the fontello
CSS files but no longer referenced anywhere after this change — might
be worth cleaning that up separately.

I also considered pulling the social links into a config array so they
could be toggled on/off by setting the URL to empty — that way if an
account gets abandoned in the future, it's just a value change instead
of editing HTML. Ended up keeping this PR minimal but figured I'd
mention it in case that's something worth doing down the line.

Closes #1877