### PR TITLE
Fix the ReferenceError when using keyboard navigation

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -118,9 +118,6 @@ function cycleMenuItems(current, forward) {
     var nextOrPreviousSibling = getNextOrPreviousSibling(current, forward);
     if (nextOrPreviousSibling.length) {
         cycle(nextOrPreviousSibling, current);
-        curr.children("a").first().focus().css({
-            outline: "none"
-        });
     }
 }
 


### PR DESCRIPTION
`curr` was undefined - I guess it was meant to be `current`, but it also looks like the whole instruction isn't needed anymore.