### PR TITLE
Strip leading/trailing whitespace whitespace from interactive examples

### DIFF
--- a/js/interactive-examples.js
+++ b/js/interactive-examples.js
@@ -94,11 +94,13 @@ async function main() {
 
       const runPhp = await PHP.loadPhp();
       runPhp(phpcode.innerText);
+      const output = PHP.buffer.join("").replace(/^\n+|\n+$/g, "");
+
       if (exampleScreenPreElement !== null) {
         exampleTitleParagraphElement.innerText = generateExampleOutputTitle(PHP.version);
-        exampleScreenPreElement.innerText = PHP.buffer.join("");
+        exampleScreenPreElement.innerText = output;
       } else {
-        lastOutput = createOutput(PHP.buffer.join(""));
+        lastOutput = createOutput(output);
         phpcode.parentNode.appendChild(lastOutput);
       }
       PHP.buffer.length = 0;


### PR DESCRIPTION
This should make interactive examples more in line with existing `<screen>` output. Resulting in less layout shifting when doing `Run code`.

Live action (Example #3 DateTimeInterface::diff() range):
https://www.php.net/manual/en/datetime.diff.php

It doesn't happen always. It depends on the output.
 - E.g `var_dump()`. Leading `<br>`
 - `throw new Exception()`. Trailing `<br>`
 - When manually given in examples. In `<screen>` output we don't usually do this. 

Before:

<img height="300" alt="image" src="https://github.com/user-attachments/assets/4ffc312e-0f32-42b2-81ff-adea4013fb93" />

After: 
<img height="300" alt="image" src="https://github.com/user-attachments/assets/22ff2334-c01d-4e4a-9e59-9d63d3187ccf" />


