### PR TITLE
Grammar edits, move paragraph, removed div in docs.php

### DIFF
--- a/docs.php
+++ b/docs.php
@@ -10,20 +10,10 @@ site_header("Documentation", ["current" => "docs"]);
 ?>
 
 <h1>Documentation</h1>
-<div class="content-box">
-
 <p>
  The PHP Manual is available online in a selection of languages.
  Please pick a language from the list below.
 </p>
-
-<p>
- Note, that many languages are just under translation, and
- the untranslated parts are still in English. Also some translated
- parts might be outdated. The translation teams are
- <a href="https://doc.php.net/">open to contributions</a>.
-</p>
-</div>
 
 <p>
   View Online:
@@ -46,6 +36,13 @@ foreach (Languages::ACTIVE_ONLINE_LANGUAGES as $langcode => $langname) {
 }
 
 ?>
+</p>
+
+<p>
+ Note that many languages are still being translated, and
+ the untranslated parts are still in English. Some translated
+ parts might be outdated. The translation teams are
+ <a href="https://doc.php.net/">open to contributions</a>.
 </p>
 
 <p>

--- a/urlhowto.php
+++ b/urlhowto.php
@@ -32,17 +32,17 @@ function a($href): void {
 
 ?>
 
-<h1>Navigation tips&tricks</h1>
+<h1>Navigation tips & tricks</h1>
 
 <p>
- When using the PHP.net website, there is even no need to get to
+ When using the PHP.net website, there is no need to use
  a search box to access the content you would like to see quickly.
- You can use short PHP.net URLs to access pages directly.
+ You can instead use short PHP.net URLs to access pages directly.
 </p>
 
 <p>
- Note, that these shortcuts are expected to work on all mirror
- sites, not just at the main site. If you find that some of these
+ Note that these shortcuts are expected to work on all mirror
+ sites, not just on the main site. If you find that some of these
  shortcuts are not working on your mirror site, please report them
  as a "PHP.net Website Problem" at
  <a href="https://bugs.php.net/">https://bugs.php.net/</a>.

--- a/urlhowto.php
+++ b/urlhowto.php
@@ -41,14 +41,6 @@ function a($href): void {
 </p>
 
 <p>
- Note that these shortcuts are expected to work on all mirror
- sites, not just on the main site. If you find that some of these
- shortcuts are not working on your mirror site, please report them
- as a "PHP.net Website Problem" at
- <a href="https://bugs.php.net/">https://bugs.php.net/</a>.
-</p>
-
-<p>
  There are currently three types of URLs you can use this way.
 </p>
 


### PR DESCRIPTION
Swapped order of the "translation disclaimer/contribution" paragraph and the list of languages to make page easier to navigate. Also, cleaned up language in the paragraph. Also, removed unnecessary div surrounding first two paragraphs. Styles are identical, could not determine any reason for them to be in their own div.