### PR TITLE
Improve sidebar scroll behavior

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -104,7 +104,7 @@ Mousetrap.bind("b o r k", function () {
 function cycle(to, from) {
     from.removeClass("current");
     to.addClass("current");
-    $.scrollTo(to.offset().top);
+    to[0].scrollIntoView({ block: "center" });
 }
 
 function getNextOrPreviousSibling(node, forward) {

--- a/js/common.js
+++ b/js/common.js
@@ -145,7 +145,7 @@ function cycleHeaders(matches, forward) {
 
 function scrollToActiveItem() {
     const sidebar = document.querySelector(".layout-menu");
-    const activeItem = sidebar.querySelector(".current");
+    const activeItem = sidebar?.querySelector(".current");
 
     if (sidebar && activeItem) {
         sidebar.scrollTo({

--- a/js/common.js
+++ b/js/common.js
@@ -688,6 +688,11 @@ $(document).ready(function () {
         flashMessage($(this));
     });
     /* }}} */
+
+    const activeItem = document.querySelector(".layout-menu .current");
+    if (activeItem) {
+        activeItem.scrollIntoView({ block: "center" });
+    }
 });
 
 /* {{{ add-user.php animations */

--- a/js/common.js
+++ b/js/common.js
@@ -104,7 +104,7 @@ Mousetrap.bind("b o r k", function () {
 function cycle(to, from) {
     from.removeClass("current");
     to.addClass("current");
-    to[0].scrollIntoView({ block: "center" });
+    scrollToActiveItem();
 }
 
 function getNextOrPreviousSibling(node, forward) {
@@ -142,6 +142,18 @@ function cycleHeaders(matches, forward) {
         cycle($(matches[forward ? 0 : matches.length - 1]), $(matches[forward ? matches.length - 1 : 0]));
     }
 }
+
+function scrollToActiveItem() {
+    const sidebar = document.querySelector(".layout-menu");
+    const activeItem = sidebar.querySelector(".current");
+
+    if (sidebar && activeItem) {
+        sidebar.scrollTo({
+            top: activeItem.offsetTop - sidebar.offsetTop - (sidebar.clientHeight / 2) + (activeItem.clientHeight / 2)
+        });
+    }
+}
+
 Mousetrap.bind("j", function () {
     /* Doc page */
     var node = $(".layout-menu .current");
@@ -689,10 +701,7 @@ $(document).ready(function () {
     });
     /* }}} */
 
-    const activeItem = document.querySelector(".layout-menu .current");
-    if (activeItem) {
-        activeItem.scrollIntoView({ block: "center" });
-    }
+    scrollToActiveItem();
 });
 
 /* {{{ add-user.php animations */


### PR DESCRIPTION
This PR fixes a bug and adds a feature to the docs sidebar.

**Feature added:** When you visit a page such as https://www.php.net/manual/es/function.strlen.php, the side menu scrolls all the way to the top, which is awkward from a UX perspective. What I do is detect the active element (in this example, it would be strlen), and automatically scroll to that item. If I didn’t explain that clearly, here’s a video comparison:


https://github.com/user-attachments/assets/943a0e23-55e8-4938-9154-3866c7955ebe

**Bug fixed:** When using the J and K shortcuts to navigate through the items in the side menu, the scroll bar did not move. This PR fixes that!