### PR TITLE
Optimize display of trick

### DIFF
--- a/include/layout.inc
+++ b/include/layout.inc
@@ -566,7 +566,7 @@ function get_news_changes()
 function doc_toc($lang): void {
     $file = __DIR__ . "/../manual/$lang/toc/index.inc";
     if (!file_exists($file)) {
-        $lang = "en"; // Fallback on english if the translation doesn't exist
+        $lang = "en"; // Fallback on English if the translation doesn't exist
         $file = __DIR__ . "/../manual/en/toc/index.inc";
     }
     require __DIR__ . "/../manual/$lang/toc/index.inc";

--- a/styles/theme-base.css
+++ b/styles/theme-base.css
@@ -1337,7 +1337,10 @@ div.soft-deprecation-notice blockquote.sidebar {
     height: 100%;
     width: 100%;
     position: fixed;
-    top: 64px;
+    top: 0;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+    overscroll-behavior: contain;
     z-index: 5000;
 }
 #goto div,
@@ -1350,6 +1353,14 @@ div.soft-deprecation-notice blockquote.sidebar {
 #trick dl {
     display: inline-block;
     vertical-align: top;
+}
+#trick dt {
+    margin: .5rem 0 .25rem;
+    line-height: 1.4;
+}
+#trick dd {
+    margin: 0 0 .75rem 1rem;
+    line-height: 1.6;
 }
 #trick a {
     color: #E6E6E6;

--- a/styles/theme-medium.css
+++ b/styles/theme-medium.css
@@ -467,7 +467,7 @@ div.warning a:focus {
   right: 0;
   bottom: 0;
   left: 0;
-  z-index: 1030;
+  z-index: 5001;
 
   justify-content: center;
 


### PR DESCRIPTION
🚀 Preview for commit 8283df76cb7dbada41502c0527ac7f1e83c5165d is available at https://web-php-pr-1908.preview.thephp.foundation/

Pressing `?` will display information about the trick.

This PR makes the following changes: It overlays the top navigation bar when displayed and supports vertical scrolling to show the full information.

| before | after | note |
| --- | --- | --- |
| <img width="2974" height="662" alt="image" src="https://github.com/user-attachments/assets/175fd519-9906-4fdc-9330-0657a8b0dd98" /> |  <img width="2716" height="944" alt="image" src="https://github.com/user-attachments/assets/64f7ae26-fa87-4c3a-a9f5-a206abe2e0d6" /> | Previously, when it wasn't at the top, the background content would be displayed. |
| <img width="1882" height="1006" alt="image" src="https://github.com/user-attachments/assets/79720bdb-975e-4d37-bff1-f696318b8155" /> | <img width="1758" height="592" alt="image" src="https://github.com/user-attachments/assets/3aada9ea-7d8b-4c3a-a0b0-a96630171e1d" /> | When the trick is activated, triggering the search again will cause the content to be obscured |
