### PR TITLE
Remove reference to the defunct "standards" list

### DIFF
--- a/mailing-lists.php
+++ b/mailing-lists.php
@@ -248,11 +248,6 @@ if (isset($_POST['action'])) {
           'General bug activity are posted here',
           false, false, false, "php.bugs",
       ],
-      [
-          'standards', 'PHP Standardization and interoperability list',
-          'Development of language standards',
-          false, false, false, "php.standards",
-      ],
 
       'PHP internal website mailing lists',
       [


### PR DESCRIPTION
This list was the precursor of what became PHP-FIG.  That was 17 years ago.  No one should be joining this list.