### PR TITLE
Avoid wrapping PHP 8.5 release code blocks

### DIFF
--- a/releases/8.5/release.inc
+++ b/releases/8.5/release.inc
@@ -686,7 +686,7 @@ PHP
         <div class="release-notes-grid-container">
             <div class="release-notes-grid">
                 <div>
-                    <h2><?= message('new_classes_title', $lang) ?></h2>
+                    <h2 id="additional-improvements"><?= message('new_classes_title', $lang) ?></h2>
                     <ul class="new">
                         <li><?= message('fatal_error_backtrace', $lang) ?></li>
                         <li><?= message('const_attribute_target', $lang) ?></li>
@@ -712,7 +712,7 @@ PHP
                     </ul>
                 </div>
                 <div>
-                    <h2><?= message('bc_title', $lang) ?></h2>
+                    <h2 id="deprecations-and-bc-breaks"><?= message('bc_title', $lang) ?></h2>
                     <ul class="old">
                         <li><?= message('bc_backtick_operator', $lang, [
                                 '<a href="/manual/' . $documentation . '/function.shell-exec.php"><code>shell_exec()</code></a>'

--- a/styles/php85.css
+++ b/styles/php85.css
@@ -75,6 +75,7 @@ code[class*=language-], pre[class*=language-] {
 }
 
 .features-title h2,
+.release-notes h2,
 .before-and-after-title-and-description h2 {
     position: relative;
     overflow: visible;
@@ -82,6 +83,7 @@ code[class*=language-], pre[class*=language-] {
 }
 
 .features-title h2 .genanchor,
+.release-notes h2 .genanchor,
 .before-and-after-title-and-description h2 .genanchor {
     position: absolute;
     top: 4px;
@@ -97,11 +99,13 @@ code[class*=language-], pre[class*=language-] {
 }
 
 .dark .features-title h2 .genanchor,
+.dark .release-notes h2 .genanchor,
 .dark .before-and-after-title-and-description h2 .genanchor {
     background: url("/images/php8/anchor-white.svg") scroll no-repeat left center / 21px 16px transparent;
 }
 
 .features-title h2:hover .genanchor,
+.release-notes h2:hover .genanchor,
 .before-and-after-title-and-description h2:hover .genanchor {
     display: block;
 }
@@ -2170,7 +2174,6 @@ header nav {
 }
 
 .release-notes ul {
-    margin-top: calc(var(--spacing) * 6);
     margin-left: calc(var(--spacing) * 4);
     list-style-type: disc
 }

--- a/styles/php85.css
+++ b/styles/php85.css
@@ -1939,7 +1939,9 @@ header nav {
     border-color: var(--color-gray-200);
     background-color: var(--color-white);
     position: relative;
-    overflow: hidden
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
 }
 
 .code-container:where(.dark,.dark *) {
@@ -2051,13 +2053,17 @@ header nav {
     height: calc(var(--spacing) * 4)
 }
 
+.code-container .phpcode {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+}
+
 .code-container pre {
-    min-height: 100%;
+    flex: 1;
     font-size: var(--text-xs);
-    line-height: var(--tw-leading, var(--text-xs--line-height));
-    --tw-leading: var(--leading-loose);
     line-height: var(--leading-loose);
-    white-space: pre-wrap;
+    white-space: pre;
     display: flex
 }
 
@@ -2070,7 +2076,7 @@ header nav {
 
 .code-container code {
     height: 100%;
-    padding: var(--spacing);
+    padding: 1.25em;
     color: var(--color-gray-400);
     flex: 1;
     overflow: auto
@@ -3550,8 +3556,8 @@ footer p:where(.dark,.dark *) {
     color: var(--color-gray-400)
 }
 
-.php85 .phpcode {
-    padding: 1em;
+.php85 .phpcode code {
+    white-space: revert;
 }
 
 .dark .php85 .phpcode::selection {


### PR DESCRIPTION
This improves readability (particularly on smaller screens), since code blocks with overflow can be easily scrolled horizontally to read longer lines, rather than trying to visually parse syntax with line breaks in unintended places (which can even appear invalid when a line break is in the middle of a token).

Before:
<img width="1287" height="865" alt="before 2" src="https://github.com/user-attachments/assets/5720e3d2-d5bc-45f6-ae27-8bc5eacdaa87" />

After:
<img width="1287" height="865" alt="after 2" src="https://github.com/user-attachments/assets/49d1becc-c2a7-4286-b63e-c7562c97cc7b" />
