### PR TITLE
Fix broken relative links on manual pages

### DIFF
--- a/include/header.inc
+++ b/include/header.inc
@@ -61,7 +61,7 @@ if (!isset($config["languages"])) {
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-  <base href="https://www.php.net">
+  <base href="https://www.php.net/<?php echo $_SERVER['BASE_PAGE'] ?? '' ?>">
 
   <title><?php echo $title ?></title>
 


### PR DESCRIPTION
f8821252 dropped the page path from the `<base>` href, so relative links on
manual pages now resolve against the site root: in-page links on localized
pages land on the English version. Fixes php/doc-ja#395.

<img width="973" height="886" alt="image" src="https://github.com/user-attachments/assets/8497b531-5964-4f20-91a3-89f1a899eda0" />

This restores the path part only, mirroring the canonical link below it; the
host stays hardcoded, keeping the #1917 fix. On production the output is
identical to pre f8821252.

Manual pages appear to be served through a CDN, so the fix may not be
visible everywhere until the cache is purged.
