### PR TITLE
Fix LangChooserTest

### DIFF
--- a/tests/Unit/LangChooserTest.php
+++ b/tests/Unit/LangChooserTest.php
@@ -20,7 +20,7 @@ class LangChooserTest extends Framework\TestCase
 
     public function testChooseCodeWithLangParameter(): void
     {
-        $langChooser = new LangChooser(self::DEFAULT_LANGUAGE_LIST, [], '', '', 'en');
+        $langChooser = new LangChooser(self::DEFAULT_LANGUAGE_LIST, [], '',  'en');
         $result = $langChooser->chooseCode('de', '/', null);
 
         self::assertSame(['de', 'de'], $result);


### PR DESCRIPTION
fixes

> Class phpweb\LangChooser constructor invoked with 5 parameters, 4 required.  

(will PR a full PHPStan setup in a separate PR, when its done)