### PR TITLE
Remove submodule directory from git

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "distributions"]
-	path = distributions
-	url = git@github.com:php/web-php-distributions.git


### PR DESCRIPTION
This is part one to address https://github.com/php/infrastructure/issues/13 as requested by @theodorejb 

It will also require changes to https://github.com/php/infrastructure/blob/main/roles/properties/rsync/templates/update-mirrors#L12 and https://github.com/php/infrastructure/blob/main/roles/properties/rsync/templates/git-clone#L6 with some logic similar to https://github.com/php/infrastructure/blob/main/roles/properties/rsync/templates/git-clone#L36 and https://github.com/php/infrastructure/blob/main/roles/properties/rsync/templates/update-mirrors#L31 to get the distributions updated.

In the future, we probably ought to not store these tarballs in GIT, but instead follow a similar procedure as we do for our (automated) Windows builds: https://github.com/php/web-downloads/blob/main/API.md#post-apiphp