### PR TITLE
Add support for vs18 builds

### DIFF
--- a/include/download-instructions/windows-downloads.php
+++ b/include/download-instructions/windows-downloads.php
@@ -19,7 +19,9 @@ $fullVersion = isset($verBlock['version']) ? $verBlock['version'] : $version;
 
 function ws_build_label(string $k, array $entry): string {
 	$tool = 'VS';
-	if (strpos($k, 'vs17') !== false) {
+	if (strpos($k, 'vs18') !== false) {
+		$tool .= '18';
+	} elseif (strpos($k, 'vs17') !== false) {
 		$tool .= '17';
 	} elseif (strpos($k, 'vs16') !== false) {
 		$tool .= '16';

--- a/include/download-instructions/windows.ps1
+++ b/include/download-instructions/windows.ps1
@@ -216,6 +216,7 @@ Function Get-VSVersion {
         '7.2' = 'VC15'; '7.3' = 'VC15'; '7.4' = 'vc15'
         '8.0' = 'vs16'; '8.1' = 'vs16'; '8.2' = 'vs16'; '8.3' = 'vs16'
         '8.4' = 'vs17'; '8.5' = 'vs17'
+        '8.6' = 'vs18';
     }
 
     if ($map.ContainsKey($Version)) {

--- a/pre-release-builds.php
+++ b/pre-release-builds.php
@@ -136,7 +136,9 @@ if (is_readable($winQaFile)) {
 
     $buildLabel = static function (string $key, array $entry): string {
       $tool = 'VS';
-      if (strpos($key, 'vs17') !== false) {
+      if (strpos($key, 'vs18') !== false) {
+        $tool .= '18';
+      } elseif (strpos($key, 'vs17') !== false) {
         $tool .= '17';
       } elseif (strpos($key, 'vs16') !== false) {
         $tool .= '16';


### PR DESCRIPTION
PHP 8.6 builds will use Visual Studio 2026 (vs18).

Refs:
 - https://downloads.php.net/~windows/qa/releases.json 
 - https://github.com/php/php-src/pull/22094