### PR TITLE
Remove unused intro variable from docs

### DIFF
--- a/docs.php
+++ b/docs.php
@@ -9,7 +9,6 @@ site_header(
     "Documentation",
     [
         "current" => "docs",
-        'intro' => $intro,
         'cache_control' => 5 * 60, // 5 minutes
     ]
 );


### PR DESCRIPTION
This fixes a regression caused by https://github.com/php/web-php/commit/94d879de808650ce4fbf8c1ec0b9fb383b84541c. A warning is triggered because `$intro` doesn't exist.

> Warning: Undefined variable $intro in /php-core/doc-php/web-php/docs.php on line 12