### PR TITLE
Remove links to heap.space

### DIFF
--- a/get-involved.php
+++ b/get-involved.php
@@ -54,8 +54,6 @@ site_header("Get Involved", ["current" => "community"]);
 
 <h3 class="content-title" id="references">Useful links for developers</h3>
 <ul class="content-box listed">
-    <li><a href="https://heap.space">lxr</a> - an online interface to the
-       PHP source, providing search facilities useful for programmers and researchers</li>
     <li><a href="https://wiki.php.net/rfc/howto">The RFC process</a> - the process
         by which developers can suggest and discuss new ideas with the community</li>
     <li><a href="/build-setup.php">Developer Setup Help</a> - some helpful information

--- a/sites.php
+++ b/sites.php
@@ -128,10 +128,6 @@ site_header("A Tourist's Guide", ["current" => "help"]);
  the repository for the source code to the latest version of PHP itself.
  Checking out the source code can be done <a href="git.php">anonymously</a>.
 </p>
-<p>
- Using <a href="https://heap.space/">OpenGrok</a> is another option to view the
- source code, and it offers additional features like search and cross referencing.
-</p>
 </div>
 
 <h2 id="wiki" class="content-header"><a href="https://wiki.php.net/">wiki.php.net</a>: The PHP Wiki</h2>


### PR DESCRIPTION
Fixes #1948

Heap.space now links to a Chinese ad/spam site.