### PR TITLE
Update GitHub Actions permissions for pull request handling

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -5,12 +5,18 @@ on:
     types:
       - completed
 
+# pull_request_target needs explicit perms; fork PRs default to read-only.
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   deploy:
     runs-on: "ubuntu-22.04"
     if: >
       github.repository_owner == 'php' &&
-      github.event.workflow_run.event == 'pull_request'
+      github.event.workflow_run.event == 'pull_request_target'
 
     steps:
       - name: Download PR number


### PR DESCRIPTION
Posting comments on PRs in a fork currently fails. https://github.com/php/web-php/actions/runs/28970317686/job/85964041447

see https://github.com/peter-evans/create-or-update-comment/issues/395