### PR TITLE
Fix uncaught PDOException in manual lookup when sqlite is unavailable

### DIFF
--- a/include/manual-lookup.inc
+++ b/include/manual-lookup.inc
@@ -110,7 +110,13 @@ function find_manual_page($lang, $keyword)
         if (in_array('sqlite', PDO::getAvailableDrivers(), true)) {
             if (file_exists($_SERVER['DOCUMENT_ROOT'] . '/backend/manual-lookup.sqlite')) {
                 try {
-                    $dbh = new PDO( 'sqlite:' . $_SERVER['DOCUMENT_ROOT'] . '/backend/manual-lookup.sqlite', '', '', [PDO::ATTR_PERSISTENT => true, PDO::ATTR_EMULATE_PREPARES => true] );
+                    // ERRMODE_SILENT (the default before PHP 8.0) is required: the query
+                    // handling below relies on prepare()/execute() returning false on
+                    // failure so it can fall back to find_manual_page_slow(). Under PHP 8's
+                    // default ERRMODE_EXCEPTION those failures throw instead, which escaped
+                    // uncaught (e.g. "attempt to write a readonly database" on a locked or
+                    // read-only sqlite file) and produced fatals.
+                    $dbh = new PDO( 'sqlite:' . $_SERVER['DOCUMENT_ROOT'] . '/backend/manual-lookup.sqlite', '', '', [PDO::ATTR_PERSISTENT => true, PDO::ATTR_EMULATE_PREPARES => true, PDO::ATTR_ERRMODE => PDO::ERRMODE_SILENT] );
                 } catch (PDOException $e) {
                     return find_manual_page_slow($lang, $keyword);
                 }
@@ -209,7 +215,11 @@ function find_manual_page($lang, $keyword)
                 }
             }
         } else {
-            error_noservice();
+            // The sqlite fast-path failed for this query (e.g. prepare() returned false
+            // on a broken/locked database). Fall back to the filesystem search like the
+            // other failure paths above, rather than showing a hard "service not working"
+            // page for what is only a best-effort lookup optimisation.
+            return find_manual_page_slow($langs[0], $kw);
         }
     }
 

--- a/include/manual-lookup.inc
+++ b/include/manual-lookup.inc
@@ -112,7 +112,8 @@ function find_manual_page($lang, $keyword)
         if (in_array('sqlite', PDO::getAvailableDrivers(), true)) {
             if (file_exists(ProjectGlobals::getBackendRoot() . '/manual-lookup.sqlite')) {
                 try {
-                    $dbh = new PDO( 'sqlite:' . ProjectGlobals::getBackendRoot() . '/manual-lookup.sqlite', '', '', [PDO::ATTR_PERSISTENT => true, PDO::ATTR_EMULATE_PREPARES => true] );
+                    // Check prepare()/execute() for false to fall back to the slow search
+                    $dbh = new PDO( 'sqlite:' . ProjectGlobals::getBackendRoot() . '/manual-lookup.sqlite', '', '', [PDO::ATTR_PERSISTENT => true, PDO::ATTR_EMULATE_PREPARES => true, PDO::ATTR_ERRMODE => PDO::ERRMODE_SILENT] );
                 } catch (PDOException $e) {
                     return find_manual_page_slow($lang, $keyword);
                 }
@@ -211,7 +212,8 @@ function find_manual_page($lang, $keyword)
                 }
             }
         } else {
-            error_noservice();
+            // prepare() failed, fall back to the slow search
+            return find_manual_page_slow($langs[0], $kw);
         }
     }
 

--- a/tests/Unit/ManualLookup/FindManualPageTest.php
+++ b/tests/Unit/ManualLookup/FindManualPageTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace {
+    // include/manual-lookup.inc defines global functions and depends on the global
+    // get_manual_search_sections() (normally from include/site.inc). Provide the same
+    // section list here so the file can be exercised without pulling in all of site.inc.
+    if (!function_exists('get_manual_search_sections')) {
+        function get_manual_search_sections(): array
+        {
+            return ['', 'book.', 'ref.', 'function.', 'class.', 'enum.', 'features.', 'control-structures.', 'language.', 'about.', 'faq.'];
+        }
+    }
+
+    require_once __DIR__ . '/../../../include/manual-lookup.inc';
+}
+
+namespace phpweb\Test\Unit\ManualLookup {
+
+    use PHPUnit\Framework;
+
+    #[Framework\Attributes\CoversFunction('find_manual_page')]
+    #[Framework\Attributes\CoversFunction('find_manual_page_slow')]
+    final class FindManualPageTest extends Framework\TestCase
+    {
+        private string $root;
+
+        private ?string $originalDocumentRoot;
+
+        protected function setUp(): void
+        {
+            $this->root = sys_get_temp_dir() . '/phpweb-ml-' . uniqid('', true);
+            mkdir($this->root . '/backend', 0777, true);
+            mkdir($this->root . '/manual/en', 0777, true);
+            // Filesystem (slow-path) target for the keyword "echo".
+            file_put_contents($this->root . '/manual/en/function.echo.php', '<?php');
+
+            $this->originalDocumentRoot = $_SERVER['DOCUMENT_ROOT'] ?? null;
+            $_SERVER['DOCUMENT_ROOT'] = $this->root;
+        }
+
+        protected function tearDown(): void
+        {
+            if ($this->originalDocumentRoot === null) {
+                unset($_SERVER['DOCUMENT_ROOT']);
+            } else {
+                $_SERVER['DOCUMENT_ROOT'] = $this->originalDocumentRoot;
+            }
+
+            array_map('unlink', glob($this->root . '/backend/*') ?: []);
+            array_map('unlink', glob($this->root . '/manual/en/*') ?: []);
+            @rmdir($this->root . '/backend');
+            @rmdir($this->root . '/manual/en');
+            @rmdir($this->root . '/manual');
+            @rmdir($this->root);
+        }
+
+        /**
+         * Regression test for the production fatal:
+         *   Uncaught PDOException: SQLSTATE[HY000]: General error: 8
+         *   attempt to write a readonly database in include/manual-lookup.inc
+         *
+         * When the sqlite fast-path fails for ANY reason (a read-only/locked database,
+         * or a corrupt/truncated one from an interrupted rsync), find_manual_page() must
+         * fall back to the filesystem search instead of throwing an uncaught exception.
+         */
+        public function testFallsBackToSlowSearchWhenSqliteQueryFails(): void
+        {
+            file_put_contents($this->root . '/backend/manual-lookup.sqlite', 'this is not a sqlite database');
+
+            $result = find_manual_page('en', 'echo');
+
+            self::assertSame('/manual/en/function.echo.php', $result);
+        }
+
+        public function testFallsBackToSlowSearchForDottedKeywordWhenSqliteQueryFails(): void
+        {
+            // A dotted keyword takes the other SQL branch in find_manual_page(); it must
+            // fall back to the filesystem search on a broken database too.
+            file_put_contents($this->root . '/backend/manual-lookup.sqlite', 'this is not a sqlite database');
+
+            $result = find_manual_page('en', 'function.echo');
+
+            self::assertSame('/manual/en/function.echo.php', $result);
+        }
+
+        #[Framework\Attributes\RequiresPhpExtension('pdo_sqlite')]
+        public function testUsesSqliteFastPathWhenDatabaseIsValid(): void
+        {
+            $this->buildValidDatabase();
+
+            $result = find_manual_page('en', 'function.echo');
+
+            self::assertSame('/manual/en/function.echo.php', $result);
+        }
+
+        public function testFallsBackToSlowSearchWhenNoDatabasePresent(): void
+        {
+            // No backend/manual-lookup.sqlite at all -> slow (filesystem) search only.
+            $result = find_manual_page('en', 'echo');
+
+            self::assertSame('/manual/en/function.echo.php', $result);
+        }
+
+        private function buildValidDatabase(): void
+        {
+            $dbh = new \PDO('sqlite:' . $this->root . '/backend/manual-lookup.sqlite');
+            $dbh->exec('CREATE TABLE fs (lang TEXT, prefix TEXT, keyword TEXT, name TEXT, prio INT)');
+            $dbh->exec("INSERT INTO fs (lang, prefix, keyword, name, prio) VALUES ('en', 'function.', 'echo', '/manual/en/function.echo.php', 3)");
+            $dbh = null;
+        }
+    }
+}

--- a/tests/Unit/ManualLookup/FindManualPageTest.php
+++ b/tests/Unit/ManualLookup/FindManualPageTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace {
+    // include/manual-lookup.inc defines global functions and depends on the global
+    // get_manual_search_sections(). That lives in include/site.inc, which cannot be
+    // required in isolation, so repeat the list from site.inc here.
+    if (!function_exists('get_manual_search_sections')) {
+        /** @return list<string> */
+        function get_manual_search_sections(): array
+        {
+            return [
+                "", "book.", "ref.", "function.", "class.", "enum.",
+                "features.", "control-structures.", "language.",
+                "about.", "faq.",
+            ];
+        }
+    }
+
+    require_once phpweb\ProjectGlobals::getProjectRoot() . '/include/manual-lookup.inc';
+}
+
+namespace phpweb\Test\Unit\ManualLookup {
+
+    use phpweb\ProjectGlobals;
+    use PHPUnit\Framework;
+
+    #[Framework\Attributes\CoversFunction('find_manual_page')]
+    #[Framework\Attributes\CoversFunction('find_manual_page_slow')]
+    #[Framework\Attributes\RunTestsInSeparateProcesses]
+    #[Framework\Attributes\PreserveGlobalState(false)]
+    final class FindManualPageTest extends Framework\TestCase
+    {
+        // Manual pages checked into public/manual/en/ that the searches below resolve to.
+        private const SLOW_PATH_PAGE = '/manual/en/function.strpos.php';
+
+        private const FAST_PATH_PAGE = '/manual/en/function.rtrim.php';
+
+        private string $database;
+
+        protected function setUp(): void
+        {
+            $this->database = ProjectGlobals::getBackendRoot() . '/manual-lookup.sqlite';
+
+            // A database here means a live checkout with an rsynced manual, not a test one
+            if (file_exists($this->database)) {
+                self::markTestSkipped('manual-lookup.sqlite is present, refusing to overwrite it');
+            }
+        }
+
+        protected function tearDown(): void
+        {
+            @unlink($this->database);
+        }
+
+        /**
+         * Regression test for the production fatal:
+         *   Uncaught PDOException: SQLSTATE[HY000]: General error: 8
+         *   attempt to write a readonly database in include/manual-lookup.inc
+         *
+         * A read-only, locked or truncated database must fall back to the slow
+         * search rather than throwing.
+         */
+        public function testFallsBackToSlowSearchWhenSqliteQueryFails(): void
+        {
+            file_put_contents($this->database, 'this is not a sqlite database');
+
+            self::assertSame(self::SLOW_PATH_PAGE, find_manual_page('en', 'strpos'));
+        }
+
+        public function testFallsBackToSlowSearchForDottedKeywordWhenSqliteQueryFails(): void
+        {
+            // A dotted keyword takes the other SQL branch, which must fall back too
+            file_put_contents($this->database, 'this is not a sqlite database');
+
+            self::assertSame(self::SLOW_PATH_PAGE, find_manual_page('en', 'function.strpos'));
+        }
+
+        public function testFallsBackToSlowSearchWhenNoDatabasePresent(): void
+        {
+            self::assertSame(self::SLOW_PATH_PAGE, find_manual_page('en', 'strpos'));
+        }
+
+        /**
+         * The fast path maps the keyword to a different page than the slow search
+         * would find, so a match on it proves the database was really used.
+         */
+        #[Framework\Attributes\RequiresPhpExtension('pdo_sqlite')]
+        public function testUsesSqliteFastPathWhenDatabaseIsValid(): void
+        {
+            $dbh = new \PDO('sqlite:' . $this->database);
+            $dbh->exec('CREATE TABLE fs (lang TEXT, prefix TEXT, keyword TEXT, name TEXT, prio INT)');
+            $dbh->exec(sprintf(
+                "INSERT INTO fs (lang, prefix, keyword, name, prio) VALUES ('en', 'function.', 'strpos', '%s', 3)",
+                self::FAST_PATH_PAGE,
+            ));
+            $dbh = null;
+
+            self::assertSame(self::FAST_PATH_PAGE, find_manual_page('en', 'strpos'));
+        }
+    }
+}


### PR DESCRIPTION
# Fix uncaught `PDOException` in manual lookup when SQLite is unavailable

## Summary

`find_manual_page()` (in `include/manual-lookup.inc`) throws an uncaught
`PDOException` whenever the manual-lookup SQLite database can't be queried: a
read-only/locked file, or a corrupt/truncated one. It was written for PDO's
**pre-8.0 `ERRMODE_SILENT`** behaviour, where a failed `prepare()`/`execute()`
returns `false` and the code falls back to the filesystem search
(`find_manual_page_slow()`). PHP 8 changed PDO's default to
**`ERRMODE_EXCEPTION`**, so those failures now *throw*, and the only `try/catch`
wraps the connection, not the queries.

This is the second-largest source of PHP fatals on www.php.net:
**19,892 fatal errors** in a recent 15-day window, almost all reached through the
404 handler (`error.php` → `find_manual_page()`), which runs a manual lookup for
every not-found URL.

## The bug

The SQLite fast-path relies on the old silent-mode contract:

```php
$dbh = new PDO('sqlite:' . ... , '', '', [PDO::ATTR_PERSISTENT => true, PDO::ATTR_EMULATE_PREPARES => true]);
// ...
$stm = $dbh->prepare($SQL);
if (!$stm) {                                 // <-- assumes prepare() returns false on error
    return find_manual_page_slow($lang, $keyword);
}
$stm->execute([...]);                        // <-- under PHP 8 this THROWS on error
```

Under PHP 8's default `ERRMODE_EXCEPTION`, `prepare()`/`execute()` throw instead
of returning `false`, so the `if (!$stm)` guards are dead and the exception
propagates uncaught.

A second, related defect sits in the same function: when `prepare()` fails in the
bare-keyword branch, the code calls `error_noservice()` instead of falling back to the slow search like
every other failure path. `error_noservice()` renders a hard "service not working"
page and then calls `exit`.

## Evidence from production logs

**The fatal (`error.log`, client IP redacted):**

```
[Sat Jul 04 18:30:07.387384 2026] [php:error] [pid 453880:tid 453880] [client REDACTED] PHP Fatal error:  Uncaught PDOException: SQLSTATE[HY000]: General error: 8 attempt to write a readonly database in /var/www/sites/www.php.net/include/manual-lookup.inc:173
Stack trace:
#0 /var/www/sites/www.php.net/include/manual-lookup.inc(173): PDOStatement->execute()
#1 /var/www/sites/www.php.net/error.php(745): find_manual_page()
#2 {main}
  thrown in /var/www/sites/www.php.net/include/manual-lookup.inc on line 173
```

**Volume:** 19,892 fatals (30 Jun – 14 Jul 2026), every one
`General error: 8 attempt to write a read-only database`.

**It hits every query path**, both SQL branches, at both `prepare()` and
`execute()`:

| Throwing call | Line | Count |
|---|---|---:|
| `prepare()` (dotted-keyword branch) | `manual-lookup.inc:169` | 9,951 |
| `execute()` (dotted-keyword branch) | `manual-lookup.inc:173` | 8,366 |
| `prepare()` (bare-keyword branch)   | `manual-lookup.inc:186` |   820 |
| `execute()` (bare-keyword branch)   | `manual-lookup.inc:188` |   755 |

The 820 hits at line 186 are the `prepare()`-in-the-bare-branch case that reaches
`error_noservice()`: 820 users were shown a hard "service not working" page
for what should have been a transparent fallback.

**How it's reached**, almost entirely via the 404 handler running a manual
lookup for missing URLs:

| Caller | Count |
|---|---:|
| `error.php` → `find_manual_page()` | 17,898 |
| `manual-lookup.php` → `find_manual_page()` | 1,994 |

## Root cause

PHP 8 changed PDO's default error mode from `ERRMODE_SILENT` to
`ERRMODE_EXCEPTION`. The code's "sqlite is a best-effort optimization; fall back
to the filesystem search on any problem" design depended on the silent behavior,
so every sqlite failure that used to degrade gracefully now throws an uncaught.

*(Why the database is unwritable in the first place is a separate,
infrastructure-side issue; see below.)*

## The fix

Two changes, both restoring the function's clear original intent (any sqlite
failure → fall back to `find_manual_page_slow()`):

1. Set `PDO::ATTR_ERRMODE => PDO::ERRMODE_SILENT` on the connection, so
   `prepare()`/`execute()` return `false` on failure and the existing fallback
   guards work again.
2. Replace the `error_noservice()` call with a fall-back to the slow search, so a
   `prepare()` failure in the bare-keyword branch degrades gracefully like the
   other paths instead of showing a hard error page.

## Testing

- **New:** `tests/Unit/ManualLookup/FindManualPageTest.php`, integration tests
  that drive the real `find_manual_page()`:
  - broken/corrupt database → falls back to the filesystem result (both SQL
    branches),
  - no database present → filesystem search,
  - healthy database → sqlite fast path.
- Written test-first: the broken-database test was confirmed to reproduce the
  uncaught `PDOException` against the original code before the fix.
- Full unit suite green (**109 tests**), **PHPStan** clean, **php-cs-fixer**
  clean.