### PR TITLE
Fix blank pages from cached CORS rejection

### DIFF
--- a/include/prepend.inc
+++ b/include/prepend.inc
@@ -26,9 +26,12 @@ header("Permissions-Policy: interest-cohort=()");
     }
 
     $host = parse_url($_SERVER["HTTP_ORIGIN"]);
-    if (!preg_match('/^(.+\.)?php\.net$/', $host["host"])) {
-        if ($host["host"] != $_SERVER["SERVER_NAME"]) {
-            exit(10);
+    if (!preg_match('/^(.+\.)?php\.net$/', $host["host"] ?? '')) {
+        if (($host["host"] ?? '') != $_SERVER["SERVER_NAME"]) {
+            // Unknown origin: just skip the CORS headers. Don't exit,
+            // or we send a blank 200 with no Cache-Control that the CDN
+            // happily caches as an empty homepage (see issue #1955).
+            return;
         }
     }
     if (isset($host["port"])) {


### PR DESCRIPTION
Addresses issue #1955

Requests with an unrecognized Origin header hit exit(10), which returned an empty 200 with no Cache-Control. The CDN cached that blank page and served it from the affected nodes for 30 days (required manual purge to fix), even to requests sending no Origin at all. Now we skip the CORS headers and serve the page normally.