### PR TITLE
Fix missing “Copy” button on the Windows download page

### DIFF
--- a/include/download-instructions/windows-downloads.php
+++ b/include/download-instructions/windows-downloads.php
@@ -125,7 +125,9 @@ foreach (['nts-x64', 'ts-x64', 'nts-x86', 'ts-x86'] as $bk) {
 			if (!empty($entry[$type]['path'])) {
 				$p = $entry[$type]['path'];
 				echo "\t", '<p><strong><a href="' . $baseDownloads . $p . '">' . $package_names[$type] . '</a></strong> <span class="size">' . $entry[$type]['size'] . '</span><br>', PHP_EOL;
-				echo "\t", '<span class="sha256">' . ($entry[$type]['sha256'] ?? '') . '</span>', PHP_EOL;
+				if (!empty($entry[$type]['sha256'])) {
+					echo "\t", sha256_html($entry[$type]['sha256']), PHP_EOL;
+				}
 				if ($type === 'zip' && $hasSbom) {
 					echo "\t", '<span class="sbom"><a href="' . $baseDownloads . $p . '.spdx.json">SPDX</a>|<a href="' . $baseDownloads . $p . '.cdx.json">CDX</a></span>', PHP_EOL;
 				}

--- a/releases/index.php
+++ b/releases/index.php
@@ -233,20 +233,12 @@ function mk_rel(int $major,
             if (!isset($src["filename"])) {
                 continue;
             }
-            printf('<li><a href="https://museum.php.net/php%d/%s">%s</a>',
+            printf('<li><a href="https://museum.php.net/php%d/%s">%s</a></li>',
                    $major, $src["filename"], $src["name"]);
-            if (isset($src['sha256'])) {
-                echo "<br>\n", sha256_html($src['sha256']);
-            }
-            echo "</li>\n";
         }
         foreach ($windows as $src) {
-            printf('<li><a href="https://museum.php.net/%s/%s">%s</a>',
+            printf('<li><a href="https://museum.php.net/%s/%s">%s</a></li>',
                    ($major == 5 ? "php5" : "win32"), $src["filename"], $src["name"]);
-            if (isset($src['sha256'])) {
-                echo "<br>\n", sha256_html($src['sha256']);
-            }
-            echo "</li>\n";
         }
     }
 

--- a/releases/index.php
+++ b/releases/index.php
@@ -233,12 +233,20 @@ function mk_rel(int $major,
             if (!isset($src["filename"])) {
                 continue;
             }
-            printf('<li><a href="https://museum.php.net/php%d/%s">%s</a></li>',
+            printf('<li><a href="https://museum.php.net/php%d/%s">%s</a>',
                    $major, $src["filename"], $src["name"]);
+            if (isset($src['sha256'])) {
+                echo "<br>\n", sha256_html($src['sha256']);
+            }
+            echo "</li>\n";
         }
         foreach ($windows as $src) {
-            printf('<li><a href="https://museum.php.net/%s/%s">%s</a></li>',
+            printf('<li><a href="https://museum.php.net/%s/%s">%s</a>',
                    ($major == 5 ? "php5" : "win32"), $src["filename"], $src["name"]);
+            if (isset($src['sha256'])) {
+                echo "<br>\n", sha256_html($src['sha256']);
+            }
+            echo "</li>\n";
         }
     }
 


### PR DESCRIPTION
Add Copy buttons next to SHA256 checksums on download-related pages. Follow-up #1957. Now not only in the pre-realese page do we have this button after sha1 hash.

cc @sy-records 