### PR TITLE
Fix include paths in supported versions visualization

### DIFF
--- a/public/images/supported-versions.php
+++ b/public/images/supported-versions.php
@@ -1,6 +1,6 @@
 <?php
-require_once __DIR__ . '/../include/prepend.inc';
-require_once __DIR__ . '/../include/branches.inc';
+require_once __DIR__ . '/../../include/prepend.inc';
+require_once __DIR__ . '/../../include/branches.inc';
 
 // Sizing constants.
 $margin_left = 80;


### PR DESCRIPTION
Currently, https://www.php.net/supported-versions.php is broken: the versions table exists but the calendar and everything below it is missing.  Running locally, we can see it is the result of a fatal error:

<img width="1200" height="1200" alt="Screenshot of broken page showing error text" src="https://github.com/user-attachments/assets/27dcffbc-aa8a-489f-883f-3c58afb08f51" />


With this patch, we can see the vizualization, body text, and footer render correctly:

<img width="1200" height="1292" alt="Screenshot of working page with no errors" src="https://github.com/user-attachments/assets/2374d82a-7bb2-4f7f-b1b3-3e6453179815" />


This was likely broken in b24d3106d45cc39e34ae0055386a1ae387019a20