### PR TITLE
Update path constants to public folder

### DIFF
--- a/src/News/Entry.php
+++ b/src/News/Entry.php
@@ -15,7 +15,7 @@ class Entry
 
     public const PHPWEB = __DIR__ . '/../../';
 
-    public const ARCHIVE_FILE_REL = 'archive/archive.xml';
+    public const ARCHIVE_FILE_REL = 'public/archive/archive.xml';
 
     public const ARCHIVE_FILE_ABS = self::PHPWEB . self::ARCHIVE_FILE_REL;
 

--- a/src/News/Entry.php
+++ b/src/News/Entry.php
@@ -19,7 +19,7 @@ class Entry
 
     public const ARCHIVE_FILE_ABS = self::PHPWEB . self::ARCHIVE_FILE_REL;
 
-    public const ARCHIVE_ENTRIES_REL = 'archive/entries/';
+    public const ARCHIVE_ENTRIES_REL = 'public/archive/entries/';
 
     public const ARCHIVE_ENTRIES_ABS = self::PHPWEB . self::ARCHIVE_ENTRIES_REL;
 

--- a/src/News/Entry.php
+++ b/src/News/Entry.php
@@ -23,7 +23,7 @@ class Entry
 
     public const ARCHIVE_ENTRIES_ABS = self::PHPWEB . self::ARCHIVE_ENTRIES_REL;
 
-    public const IMAGE_PATH_REL = 'images/news/';
+    public const IMAGE_PATH_REL = 'public/images/news/';
 
     public const IMAGE_PATH_ABS = self::PHPWEB . self::IMAGE_PATH_REL;
 


### PR DESCRIPTION
Ran into this issue this morning trying to create an announcement.

```shell
┌─(~/Code/php/web-php)(master M:1 S:8)
└─(141)─ ./bin/createNewsEntry
Can't find archive/archive.xml, are you sure you are in phpweb/?

┌─(~/Code/php/web-php)(master M:1 S:8)
└─(1)─ ll
total 584
drwxr-xr-x@  7 halo  staff     224 Aug 10 07:45 bin/
-rw-r--r--@  1 halo  staff     936 Aug 10 07:45 composer.json
-rw-r--r--@  1 halo  staff  168217 Aug 10 07:45 composer.lock
drwxr-xr-x@ 33 halo  staff    1056 Aug 13 09:15 include/
-rw-r--r--@  1 halo  staff    1516 Jul 30 09:05 Makefile
-rw-r--r--@  1 halo  staff    8208 Apr 16 10:58 openapi.yml
-rw-r--r--@  1 halo  staff     135 Apr 16 10:58 package.json
-rw-r--r--@  1 halo  staff   83745 Aug 10 07:45 phpstan-baseline.neon
-rw-r--r--@  1 halo  staff     306 Aug 10 07:45 phpstan.neon.dist
-rw-r--r--@  1 halo  staff    1256 Jul  7 15:56 playwright.config.ts
drwxr-xr-x@ 75 halo  staff    2400 Aug 10 07:45 public/
-rw-r--r--@  1 halo  staff    1085 Aug 10 07:45 README.md
drwxr-xr-x@ 11 halo  staff     352 Aug 10 07:45 src/
drwxr-xr-x@  7 halo  staff     224 Aug 10 07:45 tests/
drwxr-xr-x@ 21 halo  staff     672 Jul 23 21:06 vendor/
-rw-r--r--@  1 halo  staff    1875 Apr 16 10:58 yarn.lock

┌─(~/Code/php/web-php)(master M:1 S:8)
└─(130)─ find . -name archive
./public/archive
```

Also ran into this:

```shell
┌─(~/Code/php/web-php)(master M:1 S:8)
└─(1)─ ./bin/createNewsEntry
Please type in the title: PHP 8.6.0beta1 is available for testing
Categories:
	0: PHP.net frontpage news	 [frontpage]
	1: New PHP release	 [releases]
	2: Conference announcement	 [conferences]
	3: Call for Papers	 [cfp]
Please select appropriate categories, seperated with space: 0
Will a picture be accompanying this entry?(y/N) N
PHP Fatal error:  Uncaught Exception: Image not found at web-php/images/news/ in /Users/halo/Code/php/web-php/src/News/Entry.php:81
Stack trace:
#0 /Users/halo/Code/php/web-php/bin/createNewsEntry(44): phpweb\News\Entry->setImage('', '', '')
#1 /Users/halo/Code/php/web-php/bin/createNewsEntry(25): getEntry()
#2 {main}
  thrown in /Users/halo/Code/php/web-php/src/News/Entry.php on line 81

Fatal error: Uncaught Exception: Image not found at web-php/images/news/ in /Users/halo/Code/php/web-php/src/News/Entry.php:81
Stack trace:
#0 /Users/halo/Code/php/web-php/bin/createNewsEntry(44): phpweb\News\Entry->setImage('', '', '')
#1 /Users/halo/Code/php/web-php/bin/createNewsEntry(25): getEntry()
#2 {main}
  thrown in /Users/halo/Code/php/web-php/src/News/Entry.php on line 81
./bin/createNewsEntry: 00:45
```