### PR TITLE
Table caption fix/update

### DIFF
--- a/public/styles/theme-base.css
+++ b/public/styles/theme-base.css
@@ -1003,7 +1003,6 @@ div.tip p:first-child {
 .docs .qandaentry dt .phpcode * {
     font-weight: normal;
 }
-
 /* }}} */
 
 
@@ -1022,10 +1021,12 @@ div.tip p:first-child {
     width: 100%;
     margin:0 0 1.5rem;
 }
+
 .doctable thead tr,
 .segmentedlist thead tr {
     border:1px solid;
 }
+
 .doctable tr,
 .segmentedlist tr {
     border:1px solid;
@@ -1552,6 +1553,7 @@ td {
     border-bottom: 1px solid #eee;
     position: relative;
   }
+
   td:before {
     left: -.50rem;
     top: -0.3rem;

--- a/public/styles/theme-base.css
+++ b/public/styles/theme-base.css
@@ -1003,6 +1003,7 @@ div.tip p:first-child {
 .docs .qandaentry dt .phpcode * {
     font-weight: normal;
 }
+
 /* }}} */
 
 
@@ -1021,12 +1022,10 @@ div.tip p:first-child {
     width: 100%;
     margin:0 0 1.5rem;
 }
-
 .doctable thead tr,
 .segmentedlist thead tr {
     border:1px solid;
 }
-
 .doctable tr,
 .segmentedlist tr {
     border:1px solid;
@@ -1553,7 +1552,6 @@ td {
     border-bottom: 1px solid #eee;
     position: relative;
   }
-  
   td:before {
     left: -.50rem;
     top: -0.3rem;

--- a/public/styles/theme-base.css
+++ b/public/styles/theme-base.css
@@ -1003,7 +1003,6 @@ div.tip p:first-child {
 .docs .qandaentry dt .phpcode * {
     font-weight: normal;
 }
-
 /* }}} */
 
 
@@ -1022,15 +1021,20 @@ div.tip p:first-child {
     width: 100%;
     margin:0 0 1.5rem;
 }
+
 .doctable thead tr,
 .segmentedlist thead tr {
     border:1px solid;
 }
+
 .doctable tr,
 .segmentedlist tr {
     border:1px solid;
 }
 
+.doctable caption {
+  line-height: 2rem;
+}
 /* }}} */
 
 /* {{{ lists */
@@ -1528,6 +1532,11 @@ td {
     display: block;
   }
 
+  /* Prevent table titles from breaking into multiple lines */
+  table caption {
+    display: inline;
+  }
+
   /* Hide the table headers */
   thead tr {
     position: absolute;
@@ -1544,6 +1553,7 @@ td {
     border-bottom: 1px solid #eee;
     position: relative;
   }
+  
   td:before {
     left: -.50rem;
     top: -0.3rem;


### PR DESCRIPTION
Change to table caption (table titles) behavior in mobile to fix table captions squishing and splitting to 3 lines. Also, increased .doctable caption line-height to 2rem for better readability. 