### PR TITLE
Announce State of PHP survey

### DIFF
--- a/public/archive/archive.xml
+++ b/public/archive/archive.xml
@@ -9,6 +9,7 @@
     <uri>http://php.net/contact</uri>
     <email>php-webmaster@lists.php.net</email>
   </author>
+  <xi:include href="entries/2026-08-25-1.xml"/>
   <xi:include href="entries/2026-08-18-1.xml"/>
   <xi:include href="entries/2026-08-13-1.xml"/>
   <xi:include href="entries/2026-07-30-5.xml"/>

--- a/public/archive/entries/2026-08-25-1.xml
+++ b/public/archive/entries/2026-08-25-1.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<entry xmlns="http://www.w3.org/2005/Atom">
+  <title>Last Call for the State of PHP Survey</title>
+  <id>https://www.php.net/archive/2026.php#2026-08-25-1</id>
+  <published>2026-08-25T08:38:33+00:00</published>
+  <updated>2026-08-25T08:38:33+00:00</updated>
+  <link href="https://www.php.net/index.php#2026-08-25-1" rel="alternate" type="text/html"/>
+  <link href="https://www.php.net/archive/2026.php#2026-08-25-1" rel="via" type="text/html"/>
+  <category term="frontpage" label="PHP.net frontpage news"/>
+  <content type="xhtml">
+    <div xmlns="http://www.w3.org/1999/xhtml"><p>
+ The <a href="https://surveys.jetbrains.com/s3/phpnet-state-of-php-2026">State of PHP survey</a> is still open, but not for much longer. It asks how PHP is working for you: what you build with, what is painful, and what you think PHP should focus on next. It takes around 15 minutes.
+</p>
+<p>
+ The survey is run by <a href="https://thephp.foundation/">The PHP Foundation</a> in partnership with <a href="https://www.jetbrains.com/phpstorm/">PhpStorm</a> by JetBrains.
+</p>
+<p>
+ The aggregated results will be published later this year as the State of PHP 2026 report. The anonymized raw dataset will be released along with it, so anyone in the community can check the numbers or run their own analysis.
+</p>
+<p>
+ More responses mean a better picture of what matters to PHP users. If you have not filled it in yet, please do, and share it with your colleagues and user groups.
+</p>
+    </div>
+  </content>
+</entry>


### PR DESCRIPTION
The first State of PHP survey is still open but closes soon, and php.net is about the only place it hasn't been announced. Adding it as frontpage news.

It's run by The PHP Foundation together with JetBrains PhpStorm. Aggregated results come out later this year as the State of PHP 2026 report, and the anonymized raw dataset gets published alongside it, so anyone can check the numbers or do their own analysis.

Some precedent, since there's nothing written down about what goes on the frontpage:
- php.net has carried a survey before — the [PHP Usage Survey](https://www.php.net/archive/2003.php) in 2003, run and hosted by Zend, with their logo and a giveaway of 50 t-shirts. The results got a second frontpage post. This one has neither a logo nor a prize.
- Frontpage news that isn't a release or a conference is rare but not new, inclusing two of them Foundation-related: the Foundation announcement (2021) and the core security audit (#1254).
- Other ecosystems announce theirs on the official site: [Rust](https://blog.rust-lang.org/2025/11/17/launching-the-2025-state-of-rust-survey) yearly since 2016, [Go](https://go.dev/blog/survey2025) on the Go blog.
- Python does exactly this. The [Python Developers Survey](https://discuss.python.org/t/your-python-your-voice-join-the-python-developers-survey-2026/105883) is run by the PSF together with JetBrains, every year since 2017, and they publish the anonymized raw data. Their methodology says responses were collected via "python.org and the PSF blog, official Python mailing lists" and that "no product, service, or vendor-related channels were used to collect responses", which is also the argument for announcing it here. It got 30k+ responses that way.

/cc @thephpf @ElizabethN
